### PR TITLE
Changing jake and madoko to be local dependencies rather than global

### DIFF
--- a/doc/spec/getstarted.kk.md
+++ b/doc/spec/getstarted.kk.md
@@ -49,19 +49,16 @@ Now we can build Koka itself:
 
        > npm install
 
-   If you are running on MacOSX or Unix, you may have to run this as
-   ``sudo npm install`` so that the ``npm`` package manager has enough
-  permissions to install the ``jake`` and ``madoko`` tools.
-
 4. Finally, build the compiler and run the Koka interactive environment:
-       > jake
 
-   You can type ``jake help`` to see an overview of all make targets.
+       > npm run repl
+
+   You can type ``npm run help`` to see an overview of all make targets.
 
 The excellent [Sublime](http://www.sublimetext.com) text editor is recommended
 to edit Koka programs. You can install support for Koka programs using
 
-    > jake sublime
+    > npm run sublime
 
 After this ``.kk`` files will be properly highlighted. It is also
 recommended to use the newly installed ``snow`` color theme which is
@@ -70,7 +67,7 @@ designed to work well with Koka files.
 
 ## Running the interactive compiler
 
-After running a plain ``jake`` command, the Koka interactive environment will start:
+After running a plain ``npm run repl`` command, the Koka interactive environment will start:
 ````
 __          _
 | |        | |

--- a/doc/spec/getstarted.kk.md
+++ b/doc/spec/getstarted.kk.md
@@ -1,7 +1,7 @@
 # Getting started
 
 Welcome to the Koka book. This provides an overview and
-formal specification of the language. 
+formal specification of the language.
 For more background information, see:
 
 * The [library documentation][libraries].
@@ -14,7 +14,7 @@ For more background information, see:
 [langspec]: https://koka-lang.github.io/koka/doc/kokaspec.html  {target='_top'}
 [libraries]: https://koka-lang.github.io/koka/doc/toc.html {target='_top'}
 [slides]: http://research.microsoft.com/en-us/projects/koka/2012-overviewkoka.pdf {target='_top'}
-[kokarepo]: https://github.com/koka-lang/koka {target='_top'} 
+[kokarepo]: https://github.com/koka-lang/koka {target='_top'}
 [kokaproject]: http://research.microsoft.com/en-us/projects/koka {target='_top'}
 [rise4fun]: http://rise4fun.com/koka/tutorial
 
@@ -33,11 +33,11 @@ The following programs are required to build Koka:
 * Some version of [Git](https://help.github.com/articles/set-up-git/) for version control.
 
 All these programs are very easy to install on most platforms.
-Now we can build Koka itself: 
+Now we can build Koka itself:
 
 1. First clone the Koka sources with algebraic effects support:
 
-       > git clone https://github.com/koka-lang/koka.git 
+       > git clone https://github.com/koka-lang/koka.git
 
    You can also use the flag ``-b dev`` to get the latest development version.
 
@@ -45,13 +45,13 @@ Now we can build Koka itself:
 
        > cd koka
 
-3. Install any needed Node libraries using the Node package manager: 
+3. Install any needed Node libraries using the Node package manager:
 
        > npm install
 
 4. Finally, build the compiler and run the Koka interactive environment:
 
-       > npm run repl
+       > npm run interactive
 
    You can type ``npm run help`` to see an overview of all make targets.
 
@@ -67,7 +67,7 @@ designed to work well with Koka files.
 
 ## Running the interactive compiler
 
-After running a plain ``npm run repl`` command, the Koka interactive environment will start:
+After running a plain ``npm run interactive`` command, the Koka interactive environment will start:
 ````
 __          _
 | |        | |
@@ -116,9 +116,9 @@ Some browser specific demo to try is for example ``demo/dom/conway.kk``.
 
 ## Algebraic effect handlers
 
-A novel feature of Koka is a compiled and typed implementation of algebraic 
+A novel feature of Koka is a compiled and typed implementation of algebraic
 effect handlers (described in detail in [@Leijen:algeff]).
-In the interactive environment, you can load various demo files with algebraic 
+In the interactive environment, you can load various demo files with algebraic
 effects which are located in the ``test/algeff`` directory. This is by default
 included in the search path, so we can load them directly using
 the _load_ (``:l``) command:
@@ -127,13 +127,13 @@ the _load_ (``:l``) command:
 
 Use the ``:?`` command to get an overview of all commands. After
 loading the ``scoped`` demo, we can run it directly from the interpreter:
-    
+
     > :l scoped
     compile: test/algeff/scoped.kk
     check  : scoped
     modules:
       scoped
-    
+
     > main()
     [[3],[2,1],[1,2],[1,1,1]]
     (state=12, [[3],[2,1],[1,2],[1,1,1]])
@@ -168,7 +168,7 @@ and state effect:
     check  : effs2
     modules:
       effs1
-    
+
     > main()
     \(`[False,True,True,False]`\)
     \(`[False,False,True,True,False]`\)
@@ -209,7 +209,7 @@ removes the `amb` effect from its argument, and return a list of results:
     > :t amb
     \(|`:forall<a,e> (action : () -> <amb|e> a) -> e list<a>`\)
 
-We can now run the `xor` function using the `amb` handler to 
+We can now run the `xor` function using the `amb` handler to
 handle the `flip` operations:
 
 ```
@@ -237,14 +237,14 @@ Next we define a function that uses both ambiguity and the state
 effect:
 ```
 fun foo() : <amb,state<int>> bool {
-  val p = flip() 
+  val p = flip()
   val i = get()
   set(i+1)
   if (i>0 && p) then xor() else False
 }
 ```
 The handler for the `:state` effect takes a local parameter that
-is propagated through the `resume` function. 
+is propagated through the `resume` function.
 ```
 val state = handler(i) {
   return x -> x
@@ -275,6 +275,6 @@ predict the outcomes of running the tests?
 
     > test2()
     \(`[False,False,True,True,False]`\)
-    
+
     > test3()
     \(`[False,False]`\)

--- a/package.json
+++ b/package.json
@@ -6,22 +6,22 @@
   "description" : "Koka is an effectful function-oriented language.",
   "license"     : "Apache-2.0",
   "licenses": [{
-    "type"      : "Apache License 2.0", 
+    "type"      : "Apache License 2.0",
     "url"       : "http://www.apache.org/licenses/LICENSE-2.0.html"
   }],
   "keywords": [
-      "Koka", 
-      "Microsoft", 
-      "compiler", 
-      "language", 
+      "Koka",
+      "Microsoft",
+      "compiler",
+      "language",
       "effect",
       "type inference"
   ],
-  "engines" : { 
-    "node": ">=0.10.0" 
+  "engines" : {
+    "node": ">=0.10.0"
   },
   "dependencies": {
-    "amdefine"   : ">=0.0.4",    
+    "amdefine"   : ">=0.0.4",
     "requirejs"  : ">=2.1",
     "node-static": ">=0.6",
     "ws"         : ">=0.4",
@@ -34,14 +34,21 @@
     "madoko": "^1.1.0"
   },
   "scripts": {
-    "build": "jake compiler",
-    "repl": "jake interactive",
-    "sublime": "jake sublime",
+    "interactive": "jake interactive",
+    "compiler": "jake compiler",
+    "ghci": "jake ghci",
+    "config": "jake config",
+    "clean": "jake clean",
+    "iclean": "jake iclean",
     "test": "jake test",
+    "grammar": "jake grammar",
+    "spec": "jake spec",
+    "guide": "jake guide",
+    "sublime": "jake sublime",
     "help": "jake help"
   },
   "repository": {
-    "type": "git", 
+    "type": "git",
     "url" : "https://github.com/koka-lang/koka.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "madoko": "^1.1.0"
   },
   "scripts": {
-    "prepublish": "jake compiler",
+    "prepublish": "env variant=release jake compiler",
     "interactive": "jake interactive",
     "compiler": "jake compiler",
     "ghci": "jake ghci",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,16 @@
     "colors"     : ">=1.0",
     "diff"       : ">=1.0"
   },
+  "devDependencies": {
+    "jake"  : "^8.0.15",
+    "madoko": "^1.1.0"
+  },
   "scripts": {
-    "preinstall": "npm install -g jake madoko"
+    "build": "jake compiler",
+    "repl": "jake interactive",
+    "sublime": "jake sublime",
+    "test": "jake test",
+    "help": "jake help"
   },
   "repository": {
     "type": "git", 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "madoko": "^1.1.0"
   },
   "scripts": {
+    "prepublish": "jake compiler",
     "interactive": "jake interactive",
     "compiler": "jake compiler",
     "ghci": "jake ghci",

--- a/readme.md
+++ b/readme.md
@@ -45,20 +45,16 @@ Now we can build Koka itself:
 
    `> npm install`
 
-   If you are running on MacOSX or Unix, you may have to run this as
-   ``sudo npm install`` so that the ``npm`` package manager has enough
-  permissions to install the ``jake`` and ``madoko`` tools.
-
 4. Finally, build the compiler and run the Koka interactive environment:
 
-   `> jake`
+   `> npm run repl`
 
-   You can type ``jake help`` to see an overview of all make targets.
+   You can type ``npm run help`` to see an overview of all make targets.
 
 The excellent [Sublime](http://www.sublimetext.com) text editor is recommended
 to edit Koka programs. You can install support for Koka programs using
 
-`> jake sublime`
+`> npm run sublime`
 
 After this ``.kk`` files will be properly highlighted. It is also
 recommended to use the newly installed ``snow`` color theme which is
@@ -67,7 +63,7 @@ designed to work well with Koka files.
 
 ## Running the interactive compiler
 
-After running a plain ``jake`` command, the Koka interactive environment will start:
+After running a plain ``npm run repl`` command, the Koka interactive environment will start:
 ````
 __          _
 | |        | |

--- a/readme.md
+++ b/readme.md
@@ -8,9 +8,9 @@ For more background information, see:
 * The article _Algebraic Effects for Functional Programming_ [[3]](#references) about the algebraic effects in Koka.
 
 [kokabook]: https://koka-lang.github.io/koka/doc/kokaspec.html  
-[libraries]: https://koka-lang.github.io/koka/doc/toc.html 
+[libraries]: https://koka-lang.github.io/koka/doc/toc.html
 [slides]: http://research.microsoft.com/en-us/projects/koka/2012-overviewkoka.pdf
-[kokarepo]: https://github.com/koka-lang/koka 
+[kokarepo]: https://github.com/koka-lang/koka
 [kokaproject]: http://research.microsoft.com/en-us/projects/koka
 [rise4fun]: http://rise4fun.com/koka/tutorial
 
@@ -29,7 +29,7 @@ The following programs are required to build Koka:
 * Some version of [Git](https://help.github.com/articles/set-up-git/) for version control.
 
 All these programs are very easy to install on most platforms.
-Now we can build Koka itself: 
+Now we can build Koka itself:
 
 1. First clone the Koka sources with algebraic effects support:
 
@@ -41,13 +41,13 @@ Now we can build Koka itself:
 
    `> cd koka`
 
-3. Install any needed Node libraries using the Node package manager: 
+3. Install any needed Node libraries using the Node package manager:
 
    `> npm install`
 
 4. Finally, build the compiler and run the Koka interactive environment:
 
-   `> npm run repl`
+   `> npm run interactive`
 
    You can type ``npm run help`` to see an overview of all make targets.
 
@@ -63,7 +63,7 @@ designed to work well with Koka files.
 
 ## Running the interactive compiler
 
-After running a plain ``npm run repl`` command, the Koka interactive environment will start:
+After running a plain ``npm run interactive`` command, the Koka interactive environment will start:
 ````
 __          _
 | |        | |
@@ -112,9 +112,9 @@ Some browser specific demo to try is for example ``demo/dom/conway.kk``.
 
 ## Algebraic effect handlers
 
-A novel feature of Koka is a compiled and typed implementation of algebraic 
+A novel feature of Koka is a compiled and typed implementation of algebraic
 effect handlers (described in detail in [[3]](#references)).
-In the interactive environment, you can load various demo files with algebraic 
+In the interactive environment, you can load various demo files with algebraic
 effects which are located in the ``test/algeff`` directory. This is by default
 included in the search path, so we can load them directly using
 the _load_ (``:l``) command:
@@ -123,13 +123,13 @@ the _load_ (``:l``) command:
 
 Use the ``:?`` command to get an overview of all commands. After
 loading the ``scoped`` demo, we can run it directly from the interpreter:
-    
+
     > :l scoped
     compile: test/algeff/scoped.kk
     check  : scoped
     modules:
       scoped
-    
+
     > main()
     [[[3]],[2,1],[1,2],[1,1,1]]
     (state=12, [[[3]],[2,1],[1,2],[1,1,1]])

--- a/support/sublime-text/readme.md
+++ b/support/sublime-text/readme.md
@@ -13,7 +13,7 @@ Support packages for the Sublime Text 2 editor.
 Installation
 ------------
 
-- You can install these files by running `jake sublime`
+- You can install these files by running `npm run sublime`
 
 - Or, manually copy both directories to the Packages directory of Sublime,
   and put the Jake-Haskell build file in the Packages/User directory.


### PR DESCRIPTION
This pull request changes `jake` and `madoko` to be local dependencies rather than global.

You can use `npm run` commands instead of `jake` commands.

----

Using global dependencies is bad because:

* It requires `sudo` permissions

* It prevents reproducible builds

* If the user already has `jake` or `madoko` installed with a different version, it will cause conflicts

* It pollutes the user's computer (deleting the `koka` folder isn't enough to uninstall Koka)

----

In addition to avoiding the above downsides, it also has some benefits:

* The user does not need to learn a separate build tool, they can just use `npm run`, which is the idiomatic way to use npm.

* It allows for swapping to a different build system in a backwards-compatible way, because the new build system can continue to use the exact same `npm run` commands.

* It improves integration with existing systems (such as continuous integration), because they automatically run the `npm test` command.