### PR TITLE
fix 'grammar is in an endless loop' on vscode

### DIFF
--- a/support/sublime-text/Koka/koka.JSON-tmLanguage
+++ b/support/sublime-text/Koka/koka.JSON-tmLanguage
@@ -202,7 +202,7 @@
       },
 
     "number" :
-      { "match": "0[xX][\\da-fA-F]+|\\d+(\\.\\d+([eE][\\-+]?\\d+)?)?|"
+      { "match": "0[xX][\\da-fA-F]+|\\d+(\\.\\d+([eE][\\-+]?\\d+)?)?"
       , "name": "constant.numeric.koka"
       },
 


### PR DESCRIPTION
Using the json file with vscode, the following error appears:

    [4] - Grammar is in an endless loop - Grammar is not advancing,
    nor is it pushing/popping

The 'why' for this error is documented here in [1]. I found out it was
because of the 'number' pattern thanks to the repo grammar-debug [2];
I basically did a 'bisect', removing one by one each include in the
koka.JSON-tmLanguage file.

[1]: https://github.com/Microsoft/vscode-textmate/issues/9
[2]: https://github.com/alexandrudima/grammar-debug