### PR TITLE
Add config as dependency to compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
 - nvm install node
 - nvm use node
 install:
-- cabal install --only-dependencies
 - cabal install alex
 - npm install
 script:

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -81,7 +81,7 @@ else if (variant === "trace") {
 task("default",["interactive"]);
 
 desc("build and run the compiler (default)");
-task("interactive", ["config","compiler"], function(rebuild) {
+task("interactive", ["compiler"], function(rebuild) {
   var libDir = path.join(outputDir,libraryDir);
   jake.mkdirP(libDir);
   var cmd = mainExe + " " + hsRunFlags + " --outdir=" + libDir + " " + kokaFlags;
@@ -92,7 +92,7 @@ task("interactive", ["config","compiler"], function(rebuild) {
 
 desc(["build the compiler (" + mainExe + ")",
       "     compiler[rebuild]  # force a rebuild (where dependencies are ignored)"].join("\n"));
-task("compiler", [], function(rebuild) {
+task("compiler", ["config"], function(rebuild) {
   rebuild = rebuild || false;
   initializeDeps(allItems,false,function(items) {
     build("koka " + version + " (" + variant + " version)",rebuild,items);
@@ -122,7 +122,7 @@ task("config", [], function () {
       complete();
     }
     else {
-      var cmd = "cabal install text random parsec"
+      var cmd = "cabal install text random parsec alex"
       jake.logger.log("> " + cmd)
       jake.exec(cmd + " 2>&1", {interactive: true}, function() { complete(); });
     }

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,14 @@ Now we can build Koka itself:
    ``sudo npm install`` so that the ``npm`` package manager has enough
    permissions to install the ``jake`` and ``madoko`` tools.
 
-4. Finally, build the compiler and run the Koka interactive environment:
+4. Install `alex`, a lexer generator used by the Koka compiler:
+
+   ```
+   > cabal update
+   > cabal install alex
+   ```
+
+5. Finally, build the compiler and run the Koka interactive environment:
 
    `> jake`
 


### PR DESCRIPTION
Just running `test` in CI does not install the dependencies. `config` really should be a dependency of `compiler`.  This was also noticed in #5 by @rauchg.