### PR TITLE
Improve precision of resume analysis on let binders

### DIFF
--- a/src/Core/AnalysisResume.hs
+++ b/src/Core/AnalysisResume.hs
@@ -96,11 +96,20 @@ arExpr' appResume expr
       Let [DefNonRec def] expr
         | defName def == getName resumeName  -- TODO: too weak a check!! improve it!! we just need to skip the first definition..
         -> arExpr' appResume expr
-      Let defGroups body -- TODO: be more sophisticated here?
-        -> if (isResumingElem (bv defGroups `S.union` fv defGroups))
-            then ResumeNormal else arExpr' appResume body
+      Let defs body
+        -> rand (arDefs defs) $ arExpr' appResume body
       Case exprs branches
         -> arExprsAnd exprs `rand` arBranches appResume branches
+
+arDefs :: [DefGroup] -> ResumeKind
+arDefs defs
+  = rands (map arDef defs)
+
+arDef :: DefGroup -> ResumeKind
+arDef (DefRec defs)
+  = arExprsAnd (map defExpr defs)
+arDef (DefNonRec def)
+  = arExpr (defExpr def)
 
 arBranches :: ResumeKind -> [Branch] -> ResumeKind
 arBranches appResume branches


### PR DESCRIPTION
In this PR I try to improve the precision of the resume analysis. In particular we want to have for

```
effect writer {
  fun write(n : int): ()
}
```

## Scoped
```
val ignore = handler {
  fun write(n) {
    val x = resume(())
    val y = ()
    println(n);
    resume(())
  }
}
```
and

```
val ignore = handler {
  fun write(n) {
    val x = resume(())
    val y = resume(())
    println(n);
  }
}
```

## Scoped Once
```
val ignore = handler {
  fun write(n) {
    val x = resume(())
    val y = ()
    println(n);
  }
}
```

## Tail
```
val ignore = handler {
  fun write(n) {
    val y = ()
    println(n);
    resume(())
  }
}
```

@daanx I am not sure whether I am missing something for recursive `defs`