### PR TITLE
Make std/core/int32 private to avoid conflict

### DIFF
--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -1604,7 +1604,7 @@ fun maybe( i : int ) : maybe<int> {
 
 // Type of a 32-bit signed integer.
 // See the [``std/int32``](std_int32.html) module for operations on 32-bit integers.
-type int32
+private type int32
 
 // Convert an `:int32` to an `:int`.
 extern inline int( i : int32 ) : int {


### PR DESCRIPTION
It currently conflicts with sys/dom/types/int32.
For example, trying to load the conway example - leads to this error -

    > :l demo/dom/conway
    koka\lib\sys\dom\html\window.kk(575,52): error: Type int32 is ambiguous.
      hint: It can refer to either sys/dom/types/int32, or std/core/int32
