### PR TITLE
improve freebsd support

### DIFF
--- a/kklib/src/os.c
+++ b/kklib/src/os.c
@@ -778,12 +778,14 @@ kk_string_t kk_os_app_path(kk_context_t* ctx) {
   }
 }
 
-#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(__DragonFly__) || defined(__NetBSD__)
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
 #if defined(__sun)
 #define KK_PROC_SELF "/proc/self/path/a.out"
 #elif defined(__NetBSD__)
 #define KK_PROC_SELF "/proc/curproc/exe"
-#elif defined(__DragonFly__)
+#elif defined(__DragonFly__) || defined(__FreeBSD__)
+// In FreeBSD, this path can be possibly not mounted
+// but it is okay to fall back to generic way. 
 #define KK_PROC_SELF "/proc/curproc/file"
 #else
 #define KK_PROC_SELF "/proc/self/exe"

--- a/kklib/src/os.c
+++ b/kklib/src/os.c
@@ -109,12 +109,12 @@ kk_decl_export int kk_os_ensure_dir(kk_string_t path, int mode, kk_context_t* ct
       if (c == 0 || c == '/' || c == '\\') {
         *p = 0;
         if (cpath[0]!=0) {
-	  if (!kk_os_is_directory_cstr(cpath)) {
+    if (!kk_os_is_directory_cstr(cpath)) {
             int res = os_mkdir(cpath, mode);
             if (res != 0 && errno != EEXIST) {
               err = errno;
-	    }
-	  }
+      }
+    }
         }
         *p = c;
       }
@@ -171,21 +171,21 @@ static int os_copy_file(const char* from, const char* to, bool preserve_mtime) {
 static int
 copy_fallback(int from_fd, int to_fd, char *buf, size_t bufsize)
 {
-	int rcount;
-	ssize_t wresid, wcount = 0;
-	char *bufp;
+  int rcount;
+  ssize_t wresid, wcount = 0;
+  char *bufp;
 
-	rcount = read(from_fd, buf, bufsize);
-	if (rcount <= 0)
-		return (rcount);
-	for (bufp = buf, wresid = rcount; ; bufp += wcount, wresid -= wcount) {
-		wcount = write(to_fd, bufp, wresid);
-		if (wcount <= 0)
-			break;
-		if (wcount >= (ssize_t)wresid)
-			break;
-	}
-	return (wcount < 0 ? wcount : rcount);
+  rcount = read(from_fd, buf, bufsize);
+  if (rcount <= 0)
+    return (rcount);
+  for (bufp = buf, wresid = rcount; ; bufp += wcount, wresid -= wcount) {
+    wcount = write(to_fd, bufp, wresid);
+    if (wcount <= 0)
+      break;
+    if (wcount >= (ssize_t)wresid)
+      break;
+  }
+  return (wcount < 0 ? wcount : rcount);
 }
 #endif
 
@@ -233,61 +233,61 @@ static int os_copy_file(const char* from, const char* to, bool preserve_mtime) {
   char *bufp, *p, *buf = NULL;
   size_t bufsize = 0;
   ssize_t wcount;
-	size_t wresid;
-	off_t wtotal;
+  size_t wresid;
+  off_t wtotal;
   int use_copy_file_range = 1, rcount = 0;
   // first try MMAP
   if (S_ISREG(finfo.st_mode) && finfo.st_size > 0 &&
-		  finfo.st_size <= 8 * 1024 * 1024 &&
-		  (p = mmap(NULL, (size_t)finfo.st_size, PROT_READ,
-		   MAP_SHARED, inp, (off_t)0)) != MAP_FAILED) 
+      finfo.st_size <= 8 * 1024 * 1024 &&
+      (p = mmap(NULL, (size_t)finfo.st_size, PROT_READ,
+       MAP_SHARED, inp, (off_t)0)) != MAP_FAILED) 
   {
-		wtotal = 0;
-		for (bufp = p, wresid = finfo.st_size; ;
-			bufp += wcount, wresid -= (size_t)wcount) {
-			wcount = write(out, bufp, wresid);
-			if (wcount <= 0)
-				break;
-			wtotal += wcount;
-			if (wcount >= (ssize_t)wresid)
-					break;
-			}
-			if (wcount != (ssize_t)wresid) {
-				err = EBADF;
-			}
-			/* Some systems don't unmap on close(2). */
-			if (munmap(p, finfo.st_size) < 0) {
-				err = errno;
-			}
-	}
+    wtotal = 0;
+    for (bufp = p, wresid = finfo.st_size; ;
+      bufp += wcount, wresid -= (size_t)wcount) {
+      wcount = write(out, bufp, wresid);
+      if (wcount <= 0)
+        break;
+      wtotal += wcount;
+      if (wcount >= (ssize_t)wresid)
+          break;
+      }
+      if (wcount != (ssize_t)wresid) {
+        err = EBADF;
+      }
+      /* Some systems don't unmap on close(2). */
+      if (munmap(p, finfo.st_size) < 0) {
+        err = errno;
+      }
+  }
   else {
     // create buffer
     if (sysconf(_SC_PHYS_PAGES) > PHYSPAGES_THRESHOLD)
-			bufsize = BUFSIZE_MAX < MAXPHYS * 8 ? BUFSIZE_MAX : MAXPHYS;
-		else
-			bufsize = BUFSIZE_SMALL;
-		buf = malloc(bufsize);
-		if (buf == NULL) {
+      bufsize = BUFSIZE_MAX < MAXPHYS * 8 ? BUFSIZE_MAX : MAXPHYS;
+    else
+      bufsize = BUFSIZE_SMALL;
+    buf = malloc(bufsize);
+    if (buf == NULL) {
       err = ENOMEM;
     }
 
     do {
-			if (use_copy_file_range) {
-				rcount = copy_file_range(inp, NULL, out, NULL, bufsize, 0);
-				if (rcount < 0 && errno == EINVAL) {
-					// Prob a non-seekable FD
-					use_copy_file_range = 0;
-				}
-			}
-			if (!use_copy_file_range) {
-				rcount = copy_fallback(inp, out, buf, bufsize);
-			}
-			wtotal += rcount;
-		} while (rcount > 0);
+      if (use_copy_file_range) {
+        rcount = copy_file_range(inp, NULL, out, NULL, bufsize, 0);
+        if (rcount < 0 && errno == EINVAL) {
+          // Prob a non-seekable FD
+          use_copy_file_range = 0;
+        }
+      }
+      if (!use_copy_file_range) {
+        rcount = copy_fallback(inp, out, buf, bufsize);
+      }
+      wtotal += rcount;
+    } while (rcount > 0);
 
-		if (rcount < 0) {
-			err = EBADF;
-		}
+    if (rcount < 0) {
+      err = EBADF;
+    }
   }
   // maintain access/mod time
   if (err == 0 && preserve_mtime) {


### PR DESCRIPTION
- fix FreeBSD copyfile:
  it has no fcopyfile syscall so we need to mimic one from freebsd's cp
  - use `mmap` if filesize is less than `8MiB`
  - otherwise
    - create buffer (via `mi_malloc`)
    - try `copy_file_range` 
    - if `copy_file_range` failed, fallback to `read/write`
  
- detect self process via `KK_PROC_SELF "/proc/curproc/file"`
  In FreeBSD, this path can be possibly not mounted, but it is okay to fall back to generic way. 