### PR TITLE
Resolve VS Code extension not starting

### DIFF
--- a/support/vscode/koka.language-koka/package.json
+++ b/support/vscode/koka.language-koka/package.json
@@ -39,10 +39,6 @@
 		"Koka",
 		"Effects"
 	],
-	"activationEvents": [
-		"onLanguage:koka"
-	],
-	"main": "./out/src/extension",
 	"contributes": {
 		"configuration": {
 			"type": "object",


### PR DESCRIPTION
Removed some line items in the extension configuration that were preventing extension startup on a recent version of VS Code (1.52.1).

- reference to non-existent main file
- `onLanguage:koka` depends on the contributed language config, but that doesn't seem to load unless the extension is activated? I'm not sure whether this chicken-and-egg behaviour is intentional on VS Code's part, but removing the activation event breaks the cycle.