### PR TITLE
Use an IIFE for js unsafe-assert-fail

### DIFF
--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -2427,7 +2427,7 @@ noinline fun notrace() : st<global> () {
 
 private extern unsafe-assert-fail( msg : string ) : () {
   c "kk_assert_fail"
-  js inline "throw new Error(\"assertion failed: \" ++ #1)"
+  js inline "function() { throw new Error(\"assertion failed: \" + #1) }()"
 }
 
 fun assert( message : string, condition : bool ) : () {  // Compiler removes assert calls in optimized builds


### PR DESCRIPTION
In both v2.0.16 release and the current dev branches, building a simple Hello World program with JS target and node host fails with a syntax error in the `unsafe-assert-fail` function. The generated js is 

```js
function unsafe_assert_fail(msg) /* (msg : string) -> () */  {
  return throw new Error("assertion failed: " + msg);
}
```

A throw keyword cannot come after return in JS. The only way I could think of throwing an error under the current semantics of generating `return + contents of js inline` is by using an immediately invoked function expression. That is what the PR does.

I'm open to any suggestions or any further changes.