### PR TITLE
Allow constructors to be first-class values

### DIFF
--- a/src/Type/Type.hs
+++ b/src/Type/Type.hs
@@ -64,7 +64,7 @@ module Type.Type (-- * Types
                   -- ** Trivial conversion
                   , IsType( toType)
                   -- ** Primitive
-                  , isFun, splitFunType, splitFunScheme
+                  , isFun, splitFunType, splitFunTypeThroughForall, splitFunScheme
                   , getTypeArities
                   , module Common.Name
                   ) where
@@ -457,6 +457,20 @@ splitFunType tp
       TSyn _ _ t
         -> splitFunType t
       _ -> Nothing
+
+-- | split a function type that may be wrapped by a forall into the forall
+-- | (if it's there) and the function's arguments, effect, and result type
+splitFunTypeThroughForall :: Type -> Maybe ( Maybe ([TypeVar], [Pred])
+                                           , [(Name,Type)], Type, Type)
+splitFunTypeThroughForall tp
+  = case tp of
+      TForall vars preds inner
+        -> do
+             (params, effect, result) <- splitFunType inner
+             return (Just (vars, preds), params, effect, result)
+      _ -> do
+             (params, effect, result) <- splitFunType tp
+             return (Nothing, params, effect, result)
 
 
 {--------------------------------------------------------------------------

--- a/test/cgen/first-class-constructors.kk
+++ b/test/cgen/first-class-constructors.kk
@@ -1,0 +1,14 @@
+// Tests C code generation of constructors treated as first-class values.
+
+fun cons-alias() : ((a, list<a>) -> list<a>) {
+    return Cons
+}
+
+fun main() {
+    val list_of_maybes = map(cons-alias()(1, [2, 3]), Just)
+    val list_of_ints = map(
+        list_of_maybes,
+        fn(maybe_el) { match(maybe_el) { Just(el) -> el } }
+    )
+    println(show(list_of_ints))
+}

--- a/test/cgen/first-class-constructors.kk.out
+++ b/test/cgen/first-class-constructors.kk.out
@@ -1,0 +1,2 @@
+[1,2,3]
+add default effect for std/core/exn


### PR DESCRIPTION
Before this change, using a constructor as a first-class value would
trigger a C compiler error. For example, `val x = Just` would cause the
C compiler to return a "not enough arguments" error.

After this change, constructors are correctly treated as first-class
values. This is accomplished by creating a lambda "on the fly" in the
C backend that looks like `fn(x, xs) { Cons(x, xs) }`.

Here is a longer example of code that used to not work, but does now:

    fun main() {
        val list_of_maybes = map([1, 2, 3], Just)
        val list_of_ints = map(
            list_of_maybes,
            fn(maybe_el) { match(maybe_el) { Just(el) -> el } }
        )
        println(show(list_of_ints)) // prints [1,2,3]
    }
