### PR TITLE
A variation of map for maybe types that avoids nesting

### DIFF
--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -189,6 +189,14 @@ fun map( m : maybe<a>, f : a -> e b ) : e maybe<b> {
   }
 }
 
+fun map-maybe( m : maybe<a>, f: a -> e maybe<b> ) : e maybe<b>
+{
+  match(m) {
+    Nothing -> Nothing
+    Just(x) -> f(x)
+  }
+}
+
 fun (||)( m1 : maybe<a>, m2: maybe<a> ) : maybe<a> {
   match(m1) {
     Nothing -> m2


### PR DESCRIPTION
It seems that something like this would be desirable in the long term. I can't see a way to implement this as a variation of *map* without sacrificing generality.