### PR TITLE
Fix incorrect reference count when applying a bigint modulo to a negative smallint

### DIFF
--- a/kklib/src/integer.c
+++ b/kklib/src/integer.c
@@ -1401,7 +1401,7 @@ kk_integer_t kk_integer_cmod_generic(kk_integer_t x, kk_integer_t y, kk_context_
 // - x `mod` 2^n == and(x,2^(n-1))  for any x, n
 // - Euclidean division behaves identical to truncated division for positive dividends.
 kk_integer_t kk_integer_div_mod_generic(kk_integer_t x, kk_integer_t y, kk_integer_t* mod, kk_context_t* ctx) {
-if (kk_integer_is_zero_borrow(y)) {
+  if (kk_integer_is_zero_borrow(y)) {
     // div by zero
     if (mod!=NULL) {
       *mod = x;
@@ -1423,14 +1423,14 @@ if (kk_integer_is_zero_borrow(y)) {
     if (kk_integer_is_neg_borrow(m)) {
       if (kk_integer_is_neg_borrow(y)) {
         d = kk_integer_inc(d, ctx);
-        if (mod!=NULL) { m = kk_integer_sub(m, y, ctx); }      
+        if (mod!=NULL) { m = kk_integer_sub(m, kk_integer_dup(y), ctx); }
       }
       else {
         d = kk_integer_dec(d, ctx);
-        if (mod!=NULL) { m = kk_integer_add(m, y, ctx); } 
+        if (mod!=NULL) { m = kk_integer_add(m, kk_integer_dup(y), ctx); }
       }
     }
-    kk_integer_drop(y,ctx);
+    kk_integer_drop(y, ctx);
     if (mod==NULL) {
       kk_integer_drop(m, ctx);
     }

--- a/readme.md
+++ b/readme.md
@@ -486,4 +486,4 @@ Also as MSR-TR-2021-5, Mar, 2021.
 [pdf](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
 
 10. Anton Lorenzen and Daan Leijen. &ldquo; Reference Counting with Frame-Limited Reuse&rdquo; Microsoft Research
-technical report MSR-2021-30, Nov 2021. [pdf][https://www.microsoft.com/en-us/research/publication/reference-counting-with-frame-limited-reuse-extended-version/]
+technical report MSR-2021-30, Nov 2021. [pdf](https://www.microsoft.com/en-us/research/publication/reference-counting-with-frame-limited-reuse-extended-version/)

--- a/readme.md
+++ b/readme.md
@@ -486,4 +486,4 @@ Also as MSR-TR-2021-5, Mar, 2021.
 [pdf](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
 
 10. Anton Lorenzen and Daan Leijen. &ldquo; Reference Counting with Frame-Limited Reuse&rdquo; Microsoft Research
-technical report MSR-2021-30, Nov 2021. [pdf](https://www.microsoft.com/en-us/research/publication/reference-counting-with-frame-limited-reuse-extended-version/)
+technical report MSR-TR-2021-30, Nov 2021. [pdf](https://www.microsoft.com/en-us/research/publication/reference-counting-with-frame-limited-reuse-extended-version/)


### PR DESCRIPTION
Right now this code replicates the crash:
```koka
struct testing
  p: int

fun main(){
  val a = Testing(1000000000000000000)
  println(a.p) // 1000000000000000000
  val b = -1 % a.p
  println(b) // 999999999999999999
  println(a.p) // empty line
  val crash = 1 % a.p // Segfault
  println("bye") // Is never run because crash
}
```

a.p is incorrectly freed by the modulo operation, this means you can now still use the freed value after the modulo. This ofcourse produces incorrect results and causes a crash.

After some debugging I've managed to locate the problem to the `kk_interger_sub` and `kk_integer_add` functions. These decrement the rc of their parameters, so when these are not incremented beforehand they will get freed. This is what happens to the right paramter of the modulo in this case.

So I have fixed the bug by incrementing the rc before calling these functions. I'm not exactly sure if this is the right place in the code to increment them though, so feel free to modify if necessary.