### PR TITLE
Fix JS backend

### DIFF
--- a/lib/std/core/core-integer-inline.js
+++ b/lib/std/core/core-integer-inline.js
@@ -118,9 +118,9 @@ export function _int64_from_int32(x) {
   return BigInt(x);
 }
 
-const _max_uint32 =  0xFFFFFFFFn;
-const _max_int32  =  0x7FFFFFFFn;
-const _min_int32  = -0x80000000n;
+const _max_uint32n =  0xFFFFFFFFn;
+const _max_int32n  =  0x7FFFFFFFn;
+const _min_int32n  = -0x80000000n;
 
 export function _int64_clamp_int32(x) {
   return (x > _max_int32n ? _max_int32n : (x < _min_int32n ? _min_int32n : Number(x))); 


### PR DESCRIPTION
There is probably a typo in _max_uint32 (and a couple of other) variable names as this module references `_max_uint32n` but doesn't declare `_max_uint32`. Also, the JS code isn't valid since declaring two consts with the same name isn't allowed in js.

<img width="553" alt="Screenshot 2022-05-15 at 23 04 53" src="https://user-images.githubusercontent.com/4306737/168493746-314deba3-a792-4604-9580-52449a52855e.png">

