### PR TITLE
Document map type as generic over effect

### DIFF
--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -1887,7 +1887,7 @@ pub fun foreach-while( v : vector<a>, f : a -> e maybe<b> ) : e maybe<b>
   for-whilez( 0.ssize_t, v.lengthz.decr ) fn(i)
     f(v.unsafe-idx(i))
 
-// Apply a total function `f` to each element in a vector `v`
+// Apply a function `f` to each element in a vector `v`
 pub fun map( v : vector<a>, f : a -> e b ) : e vector<b>
   val w = unsafe-vector(v.length.ssize_t)
   v.foreach-indexedz fn(i,x)


### PR DESCRIPTION
Sorry for making such a short PR, but I  got confused by the doc string of map. It says map can only be used with total functions, but the type signature seems to indicate otherwise. 

The guide seems to also contradict the doc string: https://koka-lang.github.io/koka/doc/book.html#why-effects