### PR TITLE
Add cconsole.h to koka.cabal

### DIFF
--- a/koka.cabal
+++ b/koka.cabal
@@ -134,6 +134,7 @@ executable koka
       src/Platform/cpp/Platform
   c-sources:
       src/Platform/cpp/Platform/cconsole.c
+      src/Platform/cpp/Platform/cconsole.h
   build-tools:
       alex
   build-depends:


### PR DESCRIPTION
Without it, `cabal install` fails (while `cabal build` succeeds either way).