### PR TITLE
Generate (==) & show

### DIFF
--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -2056,6 +2056,15 @@ pub fun show( s : sslice ) : string
 pub fun show-list( xs : list<a>, show-elem : (a) -> e string ) : e string
   "[" ++ xs.map(show-elem).join(",") ++ "]"
 
+pub fun show( xs : list<a>, show-elem : (a) -> e string ) : e string
+  "[" ++ xs.map(show-elem).join(",") ++ "]"
+
+pub fun (==)(l: list<a>, l2: list<a>, eqA: (a, a) -> e bool): e bool
+  match (l, l2)
+    (Cons(a, l'), Cons(b, l2')) -> eqA(a, b) && (==)(l'.unsafe-decreasing, l2'.unsafe-decreasing, eqA)
+    (Nil, Nil) -> True
+    (_,_) -> False
+
 pub fun show( xs : list<string> ) : string
   show-list(xs,show)
 

--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -1422,6 +1422,11 @@ extern string-compare : ( x : string, y : string ) -> int
   cs inline "String.Compare(#1,#2)"
   js inline "(#1===#2 ? 0 : (#1 > #2 ? 1 : -1))"
 
+pub fun (==)(this: sslice, other: sslice) : bool
+  val Sslice(this-s, this-start, this-len) = this
+  val Sslice(other-s, other-start, other-len) = other
+  this-s == other-s && this-start == other-start && this-len == other-len
+
 // Compare two strings.
 // Uses the character codes directly for comparison
 pub fun compare( x : string, y : string) : order
@@ -2077,6 +2082,11 @@ pub fun show( xs : list<bool> ) : string
 pub fun show-tuple( x : (a,b), showfst : a -> string, showsnd : b -> string ) : string
   "(" ++ x.fst.showfst ++ "," ++ x.snd.showsnd ++ ")"
 
+pub fun show( x : (a,b), showfst : a -> string, showsnd : b -> string ) : string
+  "(" ++ x.fst.showfst ++ "," ++ x.snd.showsnd ++ ")"
+
+pub fun (==)( this : (a, b), other : (a, b), eqFst : (a, a) -> bool, eqSnd : (b, b) -> bool ) : bool
+  eqFst(this.fst, other.fst) && eqSnd(this.snd, other.snd)
 
 // ----------------------------------------------------------------------------
 // Print to the console
@@ -2384,6 +2394,12 @@ pub extern main-console : forall<a,e> ( main : () -> e a ) -> e a
 // ----------------------------------------------------------------------------
 // References
 // ----------------------------------------------------------------------------
+
+pub fun (==)( self : ref<h,a>, other : ref<h,a>, eqA : (a, a) -> e bool ) : e bool
+  eqA(unsafe-total{!self}, unsafe-total{!other})
+
+pub fun show( self : ref<h,a>, showA : a -> e string ) : e string
+  showA(unsafe-total{!self})
 
 pub inline extern inject-local<a,h,e>( action : () -> e a ) : total (() -> <local<h>|e> a)  
   inline "#1"

--- a/samples/basic/generated.kk
+++ b/samples/basic/generated.kk
@@ -1,3 +1,23 @@
+pub type round
+  // Round to neareast integer, round to the even number in case of a tie
+  con Half-even
+  // Round to nearest integer, round towards infinity in case of a tie
+  con Half-ceiling
+  // Round to nearest integer, round towards negative infinity in case of a tie
+  con Half-floor
+  // Round to nearest integer, round towards zero in case of a tie
+  con Half-truncate
+  // Round to nearest integer, round away from zero in case of a tie
+  con Half-away-from-zero
+  // Round to the minimum integer that is larger or equal
+  con Ceiling
+  // Round to the maximum integer that is lower or equal
+  con Floor
+  // Round to the nearest integer towards zero (i.e. _truncate_)
+  con Truncate
+  // Round to the nearest integer away from zero, i.e. toward negative infinity for negative numbers, and positive infinity for positive numbers.
+  con Away-from-zero
+
 type hello<e::E>
   Hello(f: () -> e ())
 

--- a/samples/basic/generated.kk
+++ b/samples/basic/generated.kk
@@ -1,0 +1,45 @@
+type hello<e::E>
+  Hello(f: () -> e ())
+
+type even<t>
+  Even(o1: odd<t>)
+  Zero(t: t)
+
+type odd<t>
+  Odd(o1: even<t>)
+
+type vvalue
+  IntV(i: int)
+  BoolV(b: bool)
+  CharV(c: char)
+  StringV(s: string)
+
+alias primop = (vvalue) -> <console,pure> vvalue
+
+type expr<t::V>
+  Int(i: int)
+  Bool(b: bool)
+  Char(c: char)
+  String(s: string)
+  Var(s: string)
+  Lam(x: string, y: expr<t>)
+  App(op: expr<t>, args: list<expr<t>>)
+  PrimOp(name: string, prim: primop)
+
+fun printPrim(v: vvalue): console vvalue
+  v.show.println
+  v
+
+fun main() 
+  val h = Hello(fn () println("Hi!"))
+  h.show.println
+  f(h)()
+  Even(Odd(Zero(0))).show(show).println
+  val x = Lam("x", Var("x"))
+  val y = App(x, [Char('a')])
+  val strEq = fn(x1: string, y1: string) x1 == y1
+  val strShow = fn(x1: string) x1
+  (==)(x,y,strEq).show.println
+  (==)(x,x,strEq).show.println
+  x.show(strShow).println
+  y.show(strShow).println

--- a/src/Common/Name.hs
+++ b/src/Common/Name.hs
@@ -18,7 +18,7 @@ module Common.Name
           , readQualified
           , labelNameCompare
           , toHiddenUniqueName
-          , newName, newQualified
+          , newName, newQualified, newPrefixName
           , nameNil, nameIsNil
           , nameCaseEqual, nameCaseOverlap, isSameNamespace
           , qualify, unqualify, isQualified, qualifier
@@ -175,6 +175,10 @@ newName :: String -> Name
 newName s
   = newQualified "" s
 
+
+newPrefixName :: String -> Name -> Name
+newPrefixName prefix s
+  = newQualified (nameModule s) (prefix ++ nameId s)
 
 newQualified :: String -> String -> Name
 newQualified m n

--- a/src/Common/NamePrim.hs
+++ b/src/Common/NamePrim.hs
@@ -14,7 +14,8 @@ module Common.NamePrim
           -- * Interpreter
             nameExpr, nameMain, nameType
           , nameInteractive, nameInteractiveModule
-          , nameSystemCore, nameCoreTypes
+          , nameSystemCore, nameCoreTypes, nameDecimal, nameDdouble
+          , nameDate, nameTimestamp, nameDuration, nameInstant, nameUtc, nameCalendar, nameTime
           , isSystemCoreName
           , isPrimitiveModule -- no monadic lifting
           , nameCoreHnd
@@ -468,6 +469,15 @@ nameSystemCore  = newName "std/core"
 nameCoreHnd     = newName "std/core/hnd"
 nameCoreTypes   = newName "std/core/types"
 nameDict        = newName "std/data/dict"
+nameDecimal     = newName "std/num/decimal"
+nameDdouble     = newName "std/num/ddouble"
+nameDate     = newName "std/time/date"
+nameTimestamp     = newName "std/time/timestamp"
+nameDuration     = newName "std/time/duration"
+nameInstant     = newName "std/time/instant"
+nameUtc    = newName "std/time/utc"
+nameCalendar    = newName "std/time/calendar"
+nameTime   = newName "std/time/time"
 
 isSystemCoreName name
   = let m = nameModule name

--- a/src/Compiler/Compile.hs
+++ b/src/Compiler/Compile.hs
@@ -823,6 +823,7 @@ inferCheck loaded0 flags line coreImports program
               (loadedSynonyms loaded0)
               (loadedNewtypes loaded0)
               program
+      --  trace (show defs) $ return ()
 
        let  gamma0  = gammaUnions [loadedGamma loaded0
                                   ,extractGamma (isValueFromFlags flags) True coreProgram

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -127,7 +127,7 @@ import Common.NamePrim( nameTrue, nameFalse, nameTuple, nameTpBool, nameEffectOp
 import Common.Syntax
 import Kind.Kind
 import Type.Type
-import Type.Pretty ()
+import Type.Pretty (defaultEnv)
 import Type.TypeVar
 import Type.Kind    ( getKind, getHandledEffect, HandledSort(ResumeMany), isHandledEffect, extractHandledEffect )
 
@@ -1180,7 +1180,7 @@ instance HasType Expr where
   typeOf tapp@(TypeApp expr tps)
     = let (tvs,tp1) = splitTForall (typeOf expr)
       in -- assertion "Core.Core.typeOf.TypeApp" (getKind a == getKind tp) $
-         -- trace ("typeOf:TypeApp: , tvs: " ++ show (map pretty tvs) ++ ", tp1: " ++ show (pretty tp1)) $
+         --  trace ("typeOf:TypeApp: , tvs: " ++ show (map pretty tvs) ++ ", tp1: " ++ show (pretty tp1)) $
          subNew (zip tvs tps) |-> tp1
 
   -- Literals
@@ -1255,7 +1255,8 @@ splitTForall :: Type -> ([TypeVar], Type)
 splitTForall tp
   = case expandSyn tp of
       (TForall tvs _ tp) -> (tvs, tp) -- TODO what about the rest of the variables and preds?
-      _ ->  failure ("Core.Core.splitTForall: Expected forall: " ++ show (pretty tp))
+      tp@(TFun args eff res) -> ([], tp)
+      _ ->  failure ("Core.Core.splitTForall: Expected forall: " ++ show tp)
 
 
 type Deps = S.Set Name

--- a/src/Type/Pretty.hs
+++ b/src/Type/Pretty.hs
@@ -10,7 +10,8 @@ module Type.Pretty (-- * Pretty
                    ,prettyDataInfo, prettyConInfo, prettyDefFunType
                    ,ppSchemeEffect, ppDeclType, ppPred
                    ,niceTypeInitial, niceTypeExtend, niceTypeExtendVars
-                   ,precTop, precArrow, precApp, precAtom, pparens, ppExpr, ppBinder, ppBranch, ppGuard, ppPattern, ppLit, ppPatBinder
+                   ,precTop, precArrow, precApp, precAtom, pparens
+                   ,ppDef, ppExpr, ppBinder, ppBranch, ppGuard, ppPattern, ppLit, ppPatBinder
                    ,Env(..), defaultEnv
                    ,niceList, niceTypes, niceType, niceEnv
                    ,typeColon, niceTypeVars, ppName

--- a/src/Type/Type.hs
+++ b/src/Type/Type.hs
@@ -53,7 +53,7 @@ module Type.Type (-- * Types
 
                   -- , isDelay
                   -- ** Standard tests
-                  , isTau, isRho, isTVar, isTCon
+                  , isTau, isRho, isTVar, isTCon, isNamedHandler
                   , tconTotal, tconList
                   , isTypeTotal
                   , isTypeBool, isTypeInt, isTypeString, isTypeChar
@@ -217,6 +217,16 @@ conInfoSize :: Platform -> ConInfo -> Int
 conInfoSize platform conInfo
   = valueReprSize platform (conInfoValueRepr conInfo)
 
+isNamedHandler :: DataInfo -> Bool
+isNamedHandler dataInfo = length (dataInfoConstrs dataInfo) == 1 && isNamedEffectCon (head (dataInfoConstrs dataInfo))
+
+
+isEvValueType :: Tau -> Bool
+isEvValueType (TApp (TCon tc) _) = tc == tconEv
+isEvValueType _         = False
+
+isNamedEffectCon :: ConInfo -> Bool
+isNamedEffectCon conInfo = length (conInfoParams conInfo) == 1 && isEvValueType (snd (head (conInfoParams conInfo)))
 
 -- | A type synonym is quantified by type parameters
 data SynInfo = SynInfo{ synInfoName :: Name

--- a/src/Type/Type.hs
+++ b/src/Type/Type.hs
@@ -22,7 +22,7 @@ module Type.Type (-- * Types
                   -- ** Accessors
                   , maxSynonymRank
                   , synonymRank, typeVarId, typeConName, typeSynName
-                  , isBound, isSkolem, isMeta
+                  , isBound, isSkolem, isMeta, isStarType, isStarTypeVar
                   -- ** Operations
                   , makeScheme
                   , quantifyType, qualifyType, applyType, tForall
@@ -467,6 +467,20 @@ splitFunType tp
       TSyn _ _ t
         -> splitFunType t
       _ -> Nothing
+
+
+
+isStarType_ :: Type -> Bool
+isStarType_ (TVar (TypeVar id kind _)) = hasKindStarResult kind
+isStarType_ (TApp (TCon (TypeCon _ kind)) _) = hasKindStarResult kind
+isStarType_ (TCon (TypeCon _ kind)) = hasKindStarResult kind
+isStarType_ _ = False
+
+isStarType :: Type -> Bool
+isStarType = isStarType_ . canonicalForm
+
+isStarTypeVar :: TypeVar -> Bool
+isStarTypeVar (TypeVar id kind _) = hasKindStarResult kind
 
 
 {--------------------------------------------------------------------------

--- a/test/algeff/cps4.kk
+++ b/test/algeff/cps4.kk
@@ -8,7 +8,7 @@ type expr {
   Div( e1 : expr, e2: expr )
 }
 
-fun show( e : expr ) : total string {
+fun showExpr( e : expr ) : total string {
   match(e) {
     Int(i) -> core/show(i)
     Div(e1,e2) -> "(" ++ e1.show ++ "/" ++ e2.show ++ ")"

--- a/test/algeff/cps4.kk.out
+++ b/test/algeff/cps4.kk.out
@@ -1,5 +1,6 @@
 1 (state=2)
  
+algeff/cps4/==: (expr, expr) -> div bool
 algeff/cps4/>>=: forall<a,b> (m : stexn<a>, f : (a) -> stexn<b>) -> stexn<b>
 algeff/cps4/Div: (e1 : expr, e2 : expr) -> expr
 algeff/cps4/Int: (i : int) -> expr
@@ -14,6 +15,7 @@ algeff/cps4/is-int: (expr : expr) -> bool
 algeff/cps4/main: () -> console ()
 algeff/cps4/run: forall<a,b,e> (s : a, m : (a) -> e b) -> e b
 algeff/cps4/show: (r : either<string,(int, int)>) -> total string
-algeff/cps4/show: (e : expr) -> total string
+algeff/cps4/show: forall<e> (expr) -> e string
+algeff/cps4/showExpr: (e : expr) -> total string
 algeff/cps4/tick: forall<a,e> () -> ((s : int) -> e either<a,((), int)>)
 algeff/cps4/unit: forall<a> (x : a) -> stexn<a>

--- a/test/algeff/expr.kk
+++ b/test/algeff/expr.kk
@@ -23,7 +23,7 @@ fun eval0( e : expr ) : int {
   }
 }
 
-fun show( e : expr ) : total string {
+fun showE( e : expr ) : total string {
   match(e) {
     Int(i) -> core/show(i)
     Div(e1,e2) -> "(" ++ e1.show ++ "/" ++ e2.show ++ ")"

--- a/test/algeff/expr.kk.out
+++ b/test/algeff/expr.kk.out
@@ -1,14 +1,15 @@
 2
 ticks: 2
 2
-((16/2)/3)
-(16/2)
-16
-2
-3
+Div(e1: Div(e1: Int(i: 16), e2: Int(i: 2)), e2: Int(i: 3))
+Div(e1: Int(i: 16), e2: Int(i: 2))
+Int(i: 16)
+Int(i: 2)
+Int(i: 3)
 ticks: 2
 2
  
+algeff/expr/==: (expr, expr) -> div bool
 algeff/expr/>>=: forall<a,b> (m : stexn<a>, f : (a) -> stexn<b>) -> stexn<b>
 algeff/expr/Div: (e1 : expr, e2 : expr) -> expr
 algeff/expr/Exc: forall<e,a> (.hnd-exc<e,a>) -> exc
@@ -34,9 +35,10 @@ algeff/expr/mtick: forall<a,e> () -> ((s : int) -> e either<a,((), int)>)
 algeff/expr/out: forall<a,e> (() -> <console,out|e> a) -> <console|e> a
 algeff/expr/run: forall<a,b,e> (s : a, m : (a) -> e b) -> e b
 algeff/expr/show: (r : either<string,(int, int)>) -> total string
-algeff/expr/show: (e : expr) -> total string
+algeff/expr/show: forall<e> (expr) -> e string
 algeff/expr/show1: (x : either<string,int>) -> string
 algeff/expr/show2: (x : (either<string,int>, int)) -> string
+algeff/expr/showE: (e : expr) -> total string
 algeff/expr/showErr: forall<a> (s : (a) -> string, x : either<string,a>) -> string
 algeff/expr/state: forall<a,e> (init : int, action : () -> <state|e> a) -> e (a, int)
 algeff/expr/test1: (e : expr) -> console ()

--- a/test/algeff/implicits.kk.out
+++ b/test/algeff/implicits.kk.out
@@ -6,6 +6,8 @@
 ()
 False
  
+algeff/implicits/==: (rose, rose) -> div bool
+algeff/implicits/==: forall<e> (graph, graph) -> e bool
 algeff/implicits/Abort: forall<e,a> (.hnd-abort<e,a>) -> abort
 algeff/implicits/Children: forall<e,a> (.hnd-children<e,a>) -> children
 algeff/implicits/Choice: forall<e,a> (.hnd-choice<e,a>) -> choice
@@ -45,6 +47,8 @@ algeff/implicits/pretty-emit: forall<a,e> (action : () -> <emit|e> a) -> e strin
 algeff/implicits/pretty-emit1: forall<a,e> (action : () -> <console,emit,exn|e> a) -> <console|e> error<a>
 algeff/implicits/pretty-emit2: forall<a,e> (action : () -> <console,emit,width|e> a) -> <console,width|e> a
 algeff/implicits/set: forall<a> (x : a) -> (state<a>) ()
+algeff/implicits/show: (rose) -> div string
+algeff/implicits/show: forall<e> (graph) -> e string
 algeff/implicits/state1: forall<a,e> (action : () -> <state<int>|e> a) -> e a
 algeff/implicits/state2: forall<a,b,e> (init : a, action : () -> <state<a>|e> b) -> e b
 algeff/implicits/sub: (rose : rose) -> list<rose>

--- a/test/algeff/nim.kk
+++ b/test/algeff/nim.kk
@@ -12,23 +12,8 @@ type player {
   Alice
 }
 
-fun (==)(p1, p2) {
-  match(p1,p2) {
-    (Bob,Bob) -> True
-    (Alice,Alice) -> True
-    _ -> False
-  }
-}
-
-fun show(p:player) : string {
-  match(p) {
-    Bob   -> "bob"
-    Alice -> "alice"
-  }
-}
-
 fun show(ps : list<player> ) : string {
-  ps.show-list(show)
+  ps.show(show)
 }
 
 
@@ -92,14 +77,10 @@ val gametree = handler {
   }
 }
 
-fun show(gt :gtree) : div string {
-  showGt(gt,2)
-}
-
-fun showGt(gt :gtree, indent:int) : _ string {
+fun showGt(gt :gtree, indent:int=2) : _ string {
   val showi = (show : (int) -> string)
   match(gt) {
-    Take(p,moves) -> p.show ++ moves.show-list(fn(x) { "\n" ++ " ".repeat(indent) ++  x.fst.core/show ++ " -> " ++ x.snd.showGt(indent+2) })
+    Take(p,moves) -> p.show ++ moves.show(fn(x) { "\n" ++ " ".repeat(indent) ++  x.fst.core/show ++ " -> " ++ x.snd.showGt(indent+2) })
     Winner(p)     -> p.show ++ " wins"
   }
 }
@@ -269,7 +250,7 @@ fun main() {
   [""
   ,testPerfect1().show
   ,testPerfect2().show
-  ,testGt().show
+  ,testGt().showGt
   ,testCheck().show
   ,testPc2().show
   ,testChoose().show

--- a/test/algeff/nim.kk.out
+++ b/test/algeff/nim.kk.out
@@ -1,27 +1,28 @@
 -----------
-alice
+Alice
 -----------
-bob
+Bob
 -----------
-alice[
- 1 -> bob[
- 1 -> alice[
- 1 -> alice wins],
- 2 -> bob wins],
- 2 -> bob[
- 1 -> bob wins],
- 3 -> alice wins]
+Alice[
+ 1 -> Bob[
+ 1 -> Alice[
+ 1 -> Alice wins],
+ 2 -> Bob wins],
+ 2 -> Bob[
+ 1 -> Bob wins],
+ 3 -> Alice wins]
 -----------
-alice
+Alice
 -----------
-bob
+Bob
 -----------
-[bob,alice]
+[Bob,Alice]
 -----------
-uncaught exception: bob cheated!
+uncaught exception: Bob cheated!
 add default effect for std/core/exn
  
-algeff/nim/==: (p1 : player, p2 : player) -> bool
+algeff/nim/==: (gtree, gtree) -> div bool
+algeff/nim/==: forall<e> (player, player) -> e bool
 algeff/nim/Alice: player
 algeff/nim/Bob: player
 algeff/nim/Cheating: forall<e,a> (.hnd-cheating<e,a>) -> cheating
@@ -57,10 +58,10 @@ algeff/nim/put: forall<a> (x : a) -> (state<a>) ()
 algeff/nim/replay: forall<a,e> (n : int, action : () -> <div|e> a) -> <div|e> a
 algeff/nim/s0: list<(player, int)>
 algeff/nim/scoreUpdater: forall<e> (() -> <state<gstate>|e> player) -> <state<gstate>|e> player
-algeff/nim/show: (gt : gtree) -> div string
 algeff/nim/show: (ps : list<player>) -> string
-algeff/nim/show: (p : player) -> string
-algeff/nim/showGt: (gt : gtree, indent : int) -> div string
+algeff/nim/show: (gtree) -> div string
+algeff/nim/show: forall<e> (player) -> e string
+algeff/nim/showGt: (gt : gtree, indent : optional<int>) -> div string
 algeff/nim/state: forall<a,b,e> (init : a, action : () -> <div,state<a>|e> b) -> <div|e> b
 algeff/nim/testCheck: () -> pure player
 algeff/nim/testChoose: () -> div list<player>

--- a/test/algeff/open2.kk.out
+++ b/test/algeff/open2.kk.out
@@ -1,8 +1,10 @@
 42
  
+algeff/open2/==: forall<e,e1> (func<e>, func<e>) -> e1 bool
 algeff/open2/Func: forall<e> (f : (int) -> e int) -> func<e>
 algeff/open2/bar: () -> int
 algeff/open2/f: forall<e> (func : func<e>) -> ((int) -> e int)
 algeff/open2/main: () -> console ()
 algeff/open2/myfunc: forall<e> func<e>
 algeff/open2/myid: forall<a,e> () -> ((x : a) -> e a)
+algeff/open2/show: forall<e,e1> (func<e>) -> e1 string

--- a/test/cgen/javascript.kk.out
+++ b/test/cgen/javascript.kk.out
@@ -1,4 +1,8 @@
 3add default effect for std/core/exn
  
+test/cgen/javascript.kk(81, 1): warning: Type person may be better declared as a value type for efficiency (e.g. 'value type/struct')
+ or declare as a reference type (e.g. 'ref type/struct') to suppress this warning
 test/cgen/javascript.kk(84, 3): warning: Some branches in the match will never be reached: _
+test/cgen/javascript.kk(81, 1): warning: Type person may be better declared as a value type for efficiency (e.g. 'value type/struct')
+ or declare as a reference type (e.g. 'ref type/struct') to suppress this warning
 test/cgen/javascript.kk(84, 3): warning: Some branches in the match will never be reached: _

--- a/test/cgen/specialize/bintree.kk.out
+++ b/test/cgen/specialize/bintree.kk.out
@@ -1,7 +1,14 @@
-cgen/specialize/bintree/.lift000-main: (tree350 : tree<int>) -> tree<int>
-cgen/specialize/bintree/.lift000-main: (xs358 : list<int>) -> list<int>
-cgen/specialize/bintree/.lift000-main: (xs363 : list<int>) -> list<int>
+cgen/specialize/bintree/==: forall<a,e> (tree<a>, tree<a>, eq6 : (this-eq6 : a, other-eq6 : a) -> <div|e> bool) -> <div|e> bool
+cgen/specialize/bintree/.lift000-main: (tree1313 : tree<int>) -> tree<int>
+cgen/specialize/bintree/.lift000-main: (xs1321 : list<int>) -> list<int>
+cgen/specialize/bintree/.lift000-main: (xs1326 : list<int>) -> list<int>
+cgen/specialize/bintree/.mlift000-show: forall<e> (string, string) -> e string
+cgen/specialize/bintree/.mlift000-show: forall<a,e> (right : tree<a>, show6 : (a) -> e string, string) -> e string
+cgen/specialize/bintree/.mlift000-show: forall<e> (string) -> e string
+cgen/specialize/bintree/.mlift000-op: forall<a,e> (eq6 : (this-eq6 : a, other-eq6 : a) -> <div|e> bool, other-right : tree<a>, this-right : tree<a>, bool) -> 
+ <div|e> bool
 cgen/specialize/bintree/is-bin: forall<a> (tree : tree<a>) -> bool
 cgen/specialize/bintree/is-leaf: forall<a> (tree : tree<a>) -> bool
 cgen/specialize/bintree/main: () -> ()
 cgen/specialize/bintree/mapTree: forall<a,b> (tree : tree<a>, f : (a) -> b) -> tree<b>
+cgen/specialize/bintree/show: forall<a,e> (tree<a>, show6 : (a) -> e string) -> e string

--- a/test/cgen/specialize/branch.kk.out
+++ b/test/cgen/specialize/branch.kk.out
@@ -3,8 +3,8 @@
 2
 5
  
-cgen/specialize/branch/.lift000-main: (xs416 : list<int>) -> console ()
-cgen/specialize/branch/.lift000-main: (xs421 : list<int>) -> console ()
-cgen/specialize/branch/.lift000-main: forall<_e> (xs428 : list<int>) -> list<int>
+cgen/specialize/branch/.lift000-main: (xs439 : list<int>) -> console ()
+cgen/specialize/branch/.lift000-main: (xs444 : list<int>) -> console ()
+cgen/specialize/branch/.lift000-main: forall<_e> (xs451 : list<int>) -> list<int>
 cgen/specialize/branch/main: () -> console ()
 cgen/specialize/branch/map_other: forall<a,b> (xs : list<a>, f : (a) -> b, g : (a) -> b) -> list<b>

--- a/test/cgen/specialize/fold1.kk.out
+++ b/test/cgen/specialize/fold1.kk.out
@@ -4,7 +4,7 @@
 add default effect for std/core/exn
  
 cgen/specialize/fold1/.hmain: () -> console ()
-cgen/specialize/fold1/.lift000-main: (xs655 : list<int>, z656 : int) -> <console,exn> int
+cgen/specialize/fold1/.lift000-main: (xs787 : list<int>, z788 : int) -> <console,exn> int
 cgen/specialize/fold1/.mlift000-main: (int) -> <exn,console> ()
 cgen/specialize/fold1/.mlift000-main: (int) -> <console,exn> ()
 cgen/specialize/fold1/.mlift000-main: (int) -> <console,exn> ()

--- a/test/cgen/specialize/localdef.kk.out
+++ b/test/cgen/specialize/localdef.kk.out
@@ -1,7 +1,7 @@
 ["0","1","2","3","4","5","6","7","8","9","10"]
  
 cgen/specialize/localdef/.lift000-li: forall<a,e> (f : (int) -> e a, low : int, high : int, acc : list<a>) -> e list<a>
-cgen/specialize/localdef/.lift000-main: (low317 : int, high318 : int, acc319 : list<string>) -> console list<string>
-cgen/specialize/localdef/.mlift000-lift207-li: forall<a,e> (acc : list<a>, f : (int) -> e a, a00.000 : int, low : int, a) -> e list<a>
+cgen/specialize/localdef/.lift000-main: (low364 : int, high365 : int, acc366 : list<string>) -> console list<string>
+cgen/specialize/localdef/.mlift000-lift254-li: forall<a,e> (acc : list<a>, f : (int) -> e a, a00.000 : int, low : int, a) -> e list<a>
 cgen/specialize/localdef/li: forall<a,e> (lo : int, hi : int, f : (int) -> e a) -> e list<a>
 cgen/specialize/localdef/main: () -> console ()

--- a/test/cgen/specialize/map-alias.kk.out
+++ b/test/cgen/specialize/map-alias.kk.out
@@ -1,7 +1,7 @@
 [2,3,4]
  
-cgen/specialize/map-alias/.lift000-main: (xs411 : list<int>) -> console list<int>
-cgen/specialize/map-alias/.lift000-main: (xs416 : list<int>) -> console list<int>
+cgen/specialize/map-alias/.lift000-main: (xs400 : list<int>) -> console list<int>
+cgen/specialize/map-alias/.lift000-main: (xs405 : list<int>) -> console list<int>
 cgen/specialize/map-alias/main: () -> console ()
 cgen/specialize/map-alias/map2: forall<a,b,e> (xs : list<a>, f : (a) -> e b) -> e list<b>
 cgen/specialize/map-alias/map3: forall<a,b,e> (xs : list<a>, f : (a) -> e b) -> e list<b>

--- a/test/cgen/specialize/map.kk.out
+++ b/test/cgen/specialize/map.kk.out
@@ -1,8 +1,8 @@
 [2,3,4]
  
-cgen/specialize/map/.lift000-test: (xs226 : list<int>) -> list<int>
-cgen/specialize/map/.lift000-main: (xs234 : list<int>) -> list<int>
-cgen/specialize/map/.unroll117-map-int: (xs : list<int>, f : (int) -> int) -> list<int>
+cgen/specialize/map/.lift000-test: (xs269 : list<int>) -> list<int>
+cgen/specialize/map/.lift000-main: (xs277 : list<int>) -> list<int>
+cgen/specialize/map/.unroll160-map-int: (xs : list<int>, f : (int) -> int) -> list<int>
 cgen/specialize/map/main: () -> console ()
 cgen/specialize/map/map-int: (xs : list<int>, f : (int) -> int) -> list<int>
 cgen/specialize/map/test: () -> list<int>

--- a/test/cgen/specialize/map2.kk.out
+++ b/test/cgen/specialize/map2.kk.out
@@ -1,8 +1,8 @@
 [3,4,5]
  
-cgen/specialize/map2/.lift000-test: (y : int, xs236 : list<int>) -> list<int>
-cgen/specialize/map2/.lift000-main: (xs244 : list<int>) -> list<int>
-cgen/specialize/map2/.unroll124-map-int: (xs : list<int>, f : (int) -> int) -> list<int>
+cgen/specialize/map2/.lift000-test: (y : int, xs277 : list<int>) -> list<int>
+cgen/specialize/map2/.lift000-main: (xs285 : list<int>) -> list<int>
+cgen/specialize/map2/.unroll165-map-int: (xs : list<int>, f : (int) -> int) -> list<int>
 cgen/specialize/map2/main: () -> console ()
 cgen/specialize/map2/map-int: (xs : list<int>, f : (int) -> int) -> list<int>
 cgen/specialize/map2/test: (y : int) -> list<int>

--- a/test/cgen/specialize/map3.kk.out
+++ b/test/cgen/specialize/map3.kk.out
@@ -1,10 +1,10 @@
 [6,7,8,9,10,11,12,13,14,15]
  
-cgen/specialize/map3/.lift000-test: (y : int, xs391 : list<int>) -> list<int>
-cgen/specialize/map3/.lift000-main: (xs399 : list<int>) -> list<int>
-cgen/specialize/map3/.mlift000-unroll278-map-poly: forall<a,e> (a, list<a>) -> e list<a>
-cgen/specialize/map3/.mlift000-unroll278-map-poly: forall<a,b,e> (f : (a) -> e b, xx : list<a>, b) -> e list<b>
-cgen/specialize/map3/.unroll278-map-poly: forall<a,b,e> (xs : list<a>, f : (a) -> e b) -> e list<b>
+cgen/specialize/map3/.lift000-test: (y : int, xs358 : list<int>) -> list<int>
+cgen/specialize/map3/.lift000-main: (xs366 : list<int>) -> list<int>
+cgen/specialize/map3/.mlift000-unroll245-map-poly: forall<a,e> (a, list<a>) -> e list<a>
+cgen/specialize/map3/.mlift000-unroll245-map-poly: forall<a,b,e> (f : (a) -> e b, xx : list<a>, b) -> e list<b>
+cgen/specialize/map3/.unroll245-map-poly: forall<a,b,e> (xs : list<a>, f : (a) -> e b) -> e list<b>
 cgen/specialize/map3/main: () -> console ()
 cgen/specialize/map3/map-poly: forall<a,b,e> (xs : list<a>, f : (a) -> e b) -> e list<b>
 cgen/specialize/map3/test: (xs : list<int>, y : int) -> list<int>

--- a/test/cgen/specialize/tree-list.kk.out
+++ b/test/cgen/specialize/tree-list.kk.out
@@ -1,19 +1,36 @@
 Tree(2, [Tree(3, []), Tree(4, [])])
  
+cgen/specialize/tree-list/==: forall<a,e> (tree<a>, tree<a>, eq5 : (this-eq5 : a, other-eq5 : a) -> <div|e> bool) -> <div|e> bool
 cgen/specialize/tree-list/.copy: forall<a> (tree<a>, data : optional<a>, children : optional<list<tree<a>>>) -> tree<a>
-cgen/specialize/tree-list/.lift000-mapT: forall<a,b,e> (f : (a) -> <div|e> b, xs1147 : list<tree<a>>) -> <div|e> list<tree<b>>
-cgen/specialize/tree-list/.lift000-mapT: forall<a,b,e> (f : (a) -> <div|e> b, xs1152 : list<tree<a>>) -> <div|e> list<tree<b>>
-cgen/specialize/tree-list/.lift000-show: (xs1160 : list<tree<int>>) -> div list<string>
-cgen/specialize/tree-list/.lift000-show: (xs1165 : list<tree<int>>) -> div list<string>
+cgen/specialize/tree-list/.lift000-show: forall<a,e> (show5 : (a) -> <div|e> string, xs2058 : list<tree<a>>) -> <div|e> string
+cgen/specialize/tree-list/.lift000-show: forall<a,e> (show5 : (a) -> <div|e> string, xs2071 : list<tree<a>>) -> <div|e> list<string>
+cgen/specialize/tree-list/.lift000-op: forall<a,e> (eq5 : (this-eq5 : a, other-eq5 : a) -> <div|e> bool, l2079 : list<tree<a>>, l22080 : list<tree<a>>) -> <
+ div|e> bool
+cgen/specialize/tree-list/.lift000-op: forall<a,e> (eq5 : (this-eq5 : a, other-eq5 : a) -> <div|e> bool, l2087 : list<tree<a>>, l22088 : list<tree<a>>) -> <
+ div|e> bool
+cgen/specialize/tree-list/.lift000-mapT: forall<a,b,e> (f : (a) -> <div|e> b, xs2105 : list<tree<a>>) -> <div|e> list<tree<b>>
+cgen/specialize/tree-list/.lift000-mapT: forall<a,b,e> (f : (a) -> <div|e> b, xs2110 : list<tree<a>>) -> <div|e> list<tree<b>>
+cgen/specialize/tree-list/.lift000-show: (xs2118 : list<tree<int>>) -> div list<string>
+cgen/specialize/tree-list/.lift000-show: (xs2123 : list<tree<int>>) -> div list<string>
 cgen/specialize/tree-list/.lift000-main: (tree<int>) -> <div,console> tree<int>
-cgen/specialize/tree-list/.lift000-main: (xs1179 : list<tree<int>>) -> <div,console> list<tree<int>>
-cgen/specialize/tree-list/.lift000-main: (xs1184 : list<tree<int>>) -> <div,console> list<tree<int>>
-cgen/specialize/tree-list/.mlift000-lift1192-mapT: forall<a,e> (tree<a>, list<tree<a>>) -> <div|e> list<tree<a>>
-cgen/specialize/tree-list/.mlift000-lift1192-mapT: forall<a,b,e> (f : (a) -> <div|e> b, xx1156 : list<tree<a>>, tree<b>) -> <div|e> list<tree<b>>
+cgen/specialize/tree-list/.lift000-main: (xs2137 : list<tree<int>>) -> <div,console> list<tree<int>>
+cgen/specialize/tree-list/.lift000-main: (xs2142 : list<tree<int>>) -> <div,console> list<tree<int>>
+cgen/specialize/tree-list/.mlift000-lift2149-show: (list<string>) -> string
+cgen/specialize/tree-list/.mlift000-lift2150-show: forall<e> (string, list<string>) -> <div|e> list<string>
+cgen/specialize/tree-list/.mlift000-lift2150-show: forall<a,e> (show5 : (a) -> <div|e> string, xx2075 : list<tree<a>>, string) -> <div|e> list<string>
+cgen/specialize/tree-list/.mlift000-show: forall<e> (string, string) -> <div|e> string
+cgen/specialize/tree-list/.mlift000-show: forall<a,e> (children0 : list<tree<a>>, show5 : (a) -> <div|e> string, string) -> <div|e> string
+cgen/specialize/tree-list/.mlift000-lift2152-op: forall<a,e> (eq5 : (this-eq5 : a, other-eq5 : a) -> <div|e> bool, l2095' : list<tree<a>>, l22092' : list<tree
+ <a>>, bool) -> <div|e> bool
+cgen/specialize/tree-list/.mlift000-op: forall<a,e> (eq5 : (this-eq5 : a, other-eq5 : a) -> <div|e> bool, other-children : list<tree<a>>, this-children : list
+ <tree<a>>, bool) -> <div|e> bool
+cgen/specialize/tree-list/.mlift000-lift2154-mapT: forall<a,e> (tree<a>, list<tree<a>>) -> <div|e> list<tree<a>>
+cgen/specialize/tree-list/.mlift000-lift2154-mapT: forall<a,b,e> (f : (a) -> <div|e> b, xx2114 : list<tree<a>>, tree<b>) -> <div|e> list<tree<b>>
 cgen/specialize/tree-list/.mlift000-mapT: forall<a,e> (a, list<tree<a>>) -> <div|e> tree<a>
 cgen/specialize/tree-list/.mlift000-mapT: forall<a,b,e> (children0 : list<tree<a>>, f : (a) -> <div|e> b, b) -> <div|e> tree<b>
 cgen/specialize/tree-list/children: forall<a> (tree : tree<a>) -> list<tree<a>>
 cgen/specialize/tree-list/data: forall<a> (tree : tree<a>) -> a
 cgen/specialize/tree-list/main: () -> <console,div> ()
 cgen/specialize/tree-list/mapT: forall<a,b,e> (tree<a>, f : (a) -> <div|e> b) -> <div|e> tree<b>
+cgen/specialize/tree-list/show: forall<a,e> (tree<a>, show5 : (a) -> <div|e> string) -> <div|e> string
 cgen/specialize/tree-list/show: (tree<int>) -> div string

--- a/test/cgen/specialize/zipwithacc.kk.out
+++ b/test/cgen/specialize/zipwithacc.kk.out
@@ -1,8 +1,8 @@
 [21,24,27,30,33,36,39,42,45,48]
  
-cgen/specialize/zipwithacc/.lift000-main: (i374 : int, acc375 : list<int>, xs376 : list<int>, ys377 : list<int>) -> console list<int>
-cgen/specialize/zipwithacc/.mlift000-unroll261-zipwith-acc: forall<e,a,b,c> (acc : list<b>, f : (int, a, c) -> e b, i : int, xx : list<a>, yy : list<c>, b) -> 
+cgen/specialize/zipwithacc/.lift000-main: (i399 : int, acc400 : list<int>, xs401 : list<int>, ys402 : list<int>) -> console list<int>
+cgen/specialize/zipwithacc/.mlift000-unroll286-zipwith-acc: forall<e,a,b,c> (acc : list<b>, f : (int, a, c) -> e b, i : int, xx : list<a>, yy : list<c>, b) -> 
  e list<b>
-cgen/specialize/zipwithacc/.unroll261-zipwith-acc: forall<a,b,c,e> ((int, a, b) -> e c, int, list<c>, list<a>, list<b>) -> e list<c>
+cgen/specialize/zipwithacc/.unroll286-zipwith-acc: forall<a,b,c,e> ((int, a, b) -> e c, int, list<c>, list<a>, list<b>) -> e list<c>
 cgen/specialize/zipwithacc/main: () -> console ()
-cgen/specialize/zipwithacc/zipwith-acc: forall<a,b,c,e> ((int, a, b) -> e c, int, list<c>, list<a>, list<b>) -> e list<c>
+cgen/specialize/zipwithacc/zipwith-acc: forall<a,b,c,e> ((int, a, b) -> e c, int, list<c>, list<a>, list<b>) -> e list<c>"

--- a/test/lib/time7.kk
+++ b/test/lib/time7.kk
@@ -65,7 +65,7 @@ val infos = [
   Info( 2486076.5,  86076,  Sun,  "2094-07-18", "2094-W28-7", "2094-M07-14",  "2094-07-05", "1810-11-11", "2086-11-11" )
 ]
 
-fun show( info : info ) : string {
+fun showCSV( info : info ) : string {
   [info.jd.show,info.mjd.show,info.wday.show,info.greg,
    info.isoweek,info.isomonth,
    info.julian,info.coptic,info.ethiopian
@@ -86,7 +86,7 @@ fun check(name : string, res : string, got: string ) : io () {
 
 
 fun check-info( info : info ) : io () {
-  println("\n" ++ info.show)
+  println("\n" ++ info.showCSV)
   val i = instant-at-jd(info.jd,ts-ti)
   val t = i.time
   fun check-date( name : string, res : string, cal : calendar, mpre : string = "", swidth : int = 2 ) {

--- a/test/medium/garcia-wachs.kk.out
+++ b/test/medium/garcia-wachs.kk.out
@@ -1,5 +1,9 @@
 Node(Node("a",Node("b","c")),Node("d","e"))
  
+test/medium/garcia-wachs.kk(27, 1): warning: Type list1 may be better declared as a value type for efficiency (e.g. 'value type/struct')
+ or declare as a reference type (e.g. 'ref type/struct') to suppress this warning
+medium/garcia-wachs/==: forall<a,e> (tree<a>, tree<a>, eq10 : (this-eq10 : a, other-eq10 : a) -> <div|e> bool) -> <div|e> bool
+medium/garcia-wachs/==: forall<a,e> (list1<a>, list1<a>, eq4 : (this-eq4 : a, other-eq4 : a) -> e bool) -> e bool
 medium/garcia-wachs/Cons1: forall<a> (head : a, tail : list<a>) -> list1<a>
 medium/garcia-wachs/Leaf: forall<a> (value : a) -> tree<a>
 medium/garcia-wachs/Node: forall<a> (left : tree<a>, right : tree<a>) -> tree<a>
@@ -15,6 +19,8 @@ medium/garcia-wachs/main: () -> <console,div> ()
 medium/garcia-wachs/map: forall<a,b,e> (xs : list1<a>, f : (a) -> e b) -> e list1<b>
 medium/garcia-wachs/mark: forall<a,h> (depth : int, t : tree<(a, ref<h,int>)>) -> (write<h>) ()
 medium/garcia-wachs/show: (t : tree<string>) -> string
+medium/garcia-wachs/show: forall<a,e> (tree<a>, show10 : (a) -> e string) -> e string
+medium/garcia-wachs/show: forall<a,e> (list1<a>, show4 : (a) -> e string) -> e string
 medium/garcia-wachs/tail: forall<a> (list1 : list1<a>) -> list<a>
 medium/garcia-wachs/test: () -> div string
 medium/garcia-wachs/zip: forall<a,b> (xs : list1<a>, ys : list1<b>) -> list1<(a, b)>

--- a/test/parc/parc2.kk.out
+++ b/test/parc/parc2.kk.out
@@ -7,6 +7,6 @@ pub fun test : forall<a> (x : list<a>) -> list<a>
  (std/core/Nil() : (list<a>) )
  -> x;
  _
- -> std/core/.unroll17080-append((std/core/types/.dup(x)), x);
+ -> std/core/.unroll20148-append((std/core/types/.dup(x)), x);
  };
  };

--- a/test/parc/parc22.kk.out
+++ b/test/parc/parc22.kk.out
@@ -24,7 +24,9 @@ pub fun .copy : (.this : parc/parc22/hello, i : optional<int>) -> parc/parc22/he
  = std/core/types/.drop(.this, (std/core/int32(1)));
  .i;
  (.skip std/core/types/None() : (optional<int>) )
- -> (match (.this) {
+ -> val _ : ()
+ = std/core/types/.drop(i0);
+ (match (.this) {
  (.skip parc/parc22/World((.x: int)) : parc/parc22/hello )
  -> val _ : ()
  = (match ((std/core/types/.is-unique(.this))) {
@@ -45,9 +47,46 @@ pub fun .copy : (.this : parc/parc22/hello, i : optional<int>) -> parc/parc22/he
  });
  }));
  };
+// Automatically generated. Shows a string representation of the `hello` type.
+pub fun show : forall<e> (^ .this : parc/parc22/hello) -> e string
+ = fn<e>(.this: parc/parc22/hello){
+ match (.this) {
+ (.skip parc/parc22/World((i0: int)) : parc/parc22/hello )
+ -> std/core/(++.1)("World(", (std/core/(++.1)((std/core/(++.1)("i: ", (std/core/show((std/core/types/.dup(i0)))))), ")")));
+ };
+ };
+// Automatically generated. Equality comparison of the `hello` type (ignores function fields).
+pub fun (==) : forall<e> (^ .this : parc/parc22/hello, .other : parc/parc22/hello) -> e bool
+ = fn<e>(.this: parc/parc22/hello, .other: parc/parc22/hello){
+ match (.this, .other) {
+ (.skip parc/parc22/World((other-i: int)) : parc/parc22/hello ), (.skip parc/parc22/World((this-i: int)) : parc/parc22/hello )
+ -> val _ : ()
+ = (match ((std/core/types/.is-unique(.other))) {
+ (std/core/types/True() : bool )
+ -> val _ : ()
+ = std/core/types/();
+ std/core/types/.free(.other);
+ _
+ -> val _ : ()
+ = val _ : int
+ = std/core/types/.dup(other-i);
+ std/core/types/();
+ val _ : ()
+ = std/core/types/.dec-ref(.other);
+ std/core/types/();
+ });
+ val .brw : bool
+ = std/core/(==.1)(this-i, other-i);
+ val _ : ()
+ = std/core/types/.drop(other-i);
+ .brw;
+ };
+ };
 pub fun f : (h : parc/parc22/hello) -> parc/parc22/hello
  = fn(h: parc/parc22/hello){
+ val .ru : reuse
+ = std/core/types/no-reuse();
  val _ : ()
- = std/core/types/.drop(h, (std/core/int32(1)));
- parc/parc22/World(2);
+ = std/core/types/.assign-reuse(.ru, (std/core/types/.drop-reuse(h, (std/core/int32(1)))));
+ std/core/types/.alloc-at(.ru, (parc/parc22/World(2)));
  };

--- a/test/static/div1.kk.out
+++ b/test/static/div1.kk.out
@@ -1,6 +1,8 @@
 static/div1/nat: V
+static/div1/==: (nat, nat) -> div bool
 static/div1/Succ: (nat) -> nat
 static/div1/Zero: nat
 static/div1/h: (nat, nat) -> nat
 static/div1/is-succ: (nat : nat) -> bool
 static/div1/is-zero: (nat : nat) -> bool
+static/div1/show: forall<e> (nat) -> e string

--- a/test/static/div2-ack.kk.out
+++ b/test/static/div2-ack.kk.out
@@ -1,6 +1,8 @@
 static/div2-ack/nat: V
+static/div2-ack/==: (nat, nat) -> div bool
 static/div2-ack/Succ: (succ : nat) -> nat
 static/div2-ack/Zero: nat
 static/div2-ack/ack: (nat, nat) -> nat
 static/div2-ack/is-succ: (nat : nat) -> bool
 static/div2-ack/is-zero: (nat : nat) -> bool
+static/div2-ack/show: forall<e> (nat) -> e string

--- a/test/static/div3.kk.out
+++ b/test/static/div3.kk.out
@@ -1,4 +1,5 @@
 static/div3/ord: V
+static/div3/==: (ord, ord) -> div bool
 static/div3/Lim: (lim : (int) -> ord) -> ord
 static/div3/Succ: (pred : ord) -> ord
 static/div3/Zero: ord
@@ -6,3 +7,4 @@ static/div3/addord: (ord, ord) -> ord
 static/div3/is-lim: (ord : ord) -> bool
 static/div3/is-succ: (ord : ord) -> bool
 static/div3/is-zero: (ord : ord) -> bool
+static/div3/show: forall<e> (ord) -> e string

--- a/test/static/recursive1.kk.out
+++ b/test/static/recursive1.kk.out
@@ -1,5 +1,7 @@
 static/recursive1/list: V -> V
+static/recursive1/==: forall<a,e> (list<a>, list<a>, eq4 : (this-eq4 : a, other-eq4 : a) -> <div|e> bool) -> <div|e> bool
 static/recursive1/Cons: forall<a> (head : a, tail : list<a>) -> list<a>
 static/recursive1/Nil: forall<a> list<a>
 static/recursive1/is-cons: forall<a> (list : list<a>) -> bool
 static/recursive1/is-nil: forall<a> (list : list<a>) -> bool
+static/recursive1/show: forall<a,e> (list<a>, show4 : (a) -> e string) -> e string

--- a/test/static/wrong/duplicate3.kk.out
+++ b/test/static/wrong/duplicate3.kk.out
@@ -1,1 +1,3 @@
+test/static/wrong/duplicate3.kk(2, 1): warning: Type dup may be better declared as a value type for efficiency (e.g. 'value type/struct')
+ or declare as a reference type (e.g. 'ref type/struct') to suppress this warning
 test/static/wrong/duplicate3.kk(2,25): error: Constructor static/wrong/duplicate3/Dup1 is already defined at (2,13)

--- a/test/type/args1.kk.out
+++ b/test/type/args1.kk.out
@@ -1,4 +1,8 @@
+test/type/args1.kk(1, 1): warning: Type test may be better declared as a value type for efficiency (e.g. 'value type/struct')
+ or declare as a reference type (e.g. 'ref type/struct') to suppress this warning
+type/args1/==: forall<e> (test, test) -> e bool
 type/args1/Test: (x : int, y : int) -> test
 type/args1/foo: () -> test
+type/args1/show: forall<e> (test) -> e string
 type/args1/x: (test : test) -> int
 type/args1/y: (test : test) -> int

--- a/test/type/match1.kk.out
+++ b/test/type/match1.kk.out
@@ -1,3 +1,5 @@
+type/match1/==: forall<a,e> (test<a>, test<a>, eq3 : (this-eq3 : a, other-eq3 : a) -> e bool) -> e bool
 type/match1/Test: forall<a> (arg : a) -> test<a>
 type/match1/arg: forall<a> (test : test<a>) -> a
+type/match1/show: forall<a,e> (test<a>, show3 : (a) -> e string) -> e string
 type/match1/xtest: forall<a> (x : test<a>) -> console a


### PR DESCRIPTION
Generate .show / (==) methods for user datatypes. One issue is that compile time type errors are pretty terrible to work with since there are no source locations to point to for generated methods, so if there is a missing method for a nested type that the user is using they will get strange errors that happen at unification time instead of when the methods are generated.

Handles type parameters fine & recursive datatypes / datatypes with functions.

Happy to do some additional defensive programming and remove support unless a user annotates a type. It seems like it might be hard foresee all of the various problems that might occur, but it probably isn't as bad as I think. I've already covered only considering value kinded type arguments, and ignoring effects / other kind arguments. 

Finally I think a primitive pointer equivalence check might be good to optimize the equality a tiny bit.