### PR TITLE
Explicit struct tag is outside union

### DIFF
--- a/src/Kind/Infer.hs
+++ b/src/Kind/Infer.hs
@@ -836,7 +836,7 @@ resolveTypeDef isRec recNames (DataType newtp params constructors range vis sort
            conCount       = length conInfos0
            willNeedStructTag   = dataDefIsValue ddef && conCount > 1 && maxMembers >= 1
            extraFields = if (dataDefIsOpen ddef) then 1 {- open datatype tag -}
-                         else if willNeedStructTag then 1 {- explicit struct tag -} 
+                         else if willNeedStructTag then 0 {- explicit struct tag -} 
                          else 0
        platform <- getPlatform
        (ddef1,conInfos1) 
@@ -848,19 +848,6 @@ resolveTypeDef isRec recNames (DataType newtp params constructors range vis sort
        assertion ("Kind.Infer.resolveTypeDef: assuming value struct tag but not inferred as such " ++ show (ddef,ddef1)) 
                  ((willNeedStructTag && Core.needsTagField (fst (Core.getDataRepr dataInfo))) || not willNeedStructTag) $ return ()
 
-
-       {-
-       -- adjust datainfo in case an extra value tag was needed
-       dataInfo  <- case ddef1 of
-                      DataDefValue (ValueRepr m n a)  | Core.needsTagField (fst (Core.getDataRepr dataInfo0))
-                        ->  -- recalculate with extra required tag field to the size
-                            do (ddef2,conInfos2) <- createDataDef emitError emitWarning lookupDataInfo
-                                                      platform qname resultHasKindStar isRec sort
-                                                        1 {- extra field for tag -} ddef1 {- guarantees value type again -} conInfos1
-                               let dataInfo1 = dataInfo0{ dataInfoDef = ddef2, dataInfoConstrs = conInfos2 }
-                               return dataInfo1
-                      _ -> return dataInfo0
-       -}                     
        -- trace (showTypeBinder newtp') $
        addRangeInfo range (Decl (show sort) (getName newtp') (mangleTypeName (getName newtp')))
        return (Core.Data dataInfo isExtend)


### PR DESCRIPTION
@daanx 
The union does not contain the tag for the struct. This was causing exceptions because the field access was incorrect.

Was happening with both Optional and Error types. 

Running util/bundle.kk works now. Prior to this change it does not.

Current dev branch emits structs like this

```c
// value type std/core/types/optional
struct kk_std_core_types_Optional {
  kk_box_t value;
};
struct kk_std_core_types_None {
  kk_box_t _unused;
};
struct kk_std_core_types_optional_s {
  kk_value_tag_t _tag;
  union {
    struct kk_std_core_types_Optional Optional;
    struct kk_std_core_types_None None;
    kk_box_t _fields[2];
  } _cons;
};
typedef struct kk_std_core_types_optional_s kk_std_core_types__optional;
static inline kk_std_core_types__optional kk_std_core_types__new_None(kk_context_t* _ctx) {
  kk_std_core_types__optional _con;
  _con._tag = kk_value_tag(2);
  _con._cons._fields[1] = kk_box_null();
  return _con;
}
```