### PR TITLE
Fix effect var error

### DIFF
--- a/src/Syntax/Parse.hs
+++ b/src/Syntax/Parse.hs
@@ -2253,9 +2253,14 @@ textend
 
 
 tlabel
-  = do tp1 <- tid
-       tp2 <- typeApp tp1
-       return tp2
+  = do 
+       pos <- getPosition
+       tp1 <- tid
+       case tp1 of
+          TpVar name rng -> do
+            setPosition pos
+            fail $ "encountered effect variable " ++ show name ++ " when an effect label was expected\n  hint: effect variables must be after `|` (e.g `<labels|e>`), or by themselves (e.g. `e`)"
+          _              -> typeApp tp1
 
 
 tresultTotal :: LexParser (UserType,UserType)

--- a/test/algeff/eff-constant.kk
+++ b/test/algeff/eff-constant.kk
@@ -1,0 +1,3 @@
+// issue: https://github.com/koka-lang/koka/issues/353
+fun x() : <e> ()
+  ()

--- a/test/algeff/eff-constant.kk.out
+++ b/test/algeff/eff-constant.kk.out
@@ -1,0 +1,3 @@
+test/algeff/eff-constant.kk(2,12): error: invalid syntax
+ encountered effect variable e when an effect label was expected
+ hint: effect variables must be after `|` (e.g `<labels|e>`), or by themselves (e.g. `e`)

--- a/test/algeff/eff-constant2.kk
+++ b/test/algeff/eff-constant2.kk
@@ -1,0 +1,11 @@
+// issue: https://github.com/koka-lang/koka/issues/60
+effect gen<a> {
+  ctl yield(item: a): ()
+}
+
+fun list<a,e>(program : () -> <gen<a>, e> ()): e list<a> {
+  handle(program) {
+    yield(x) -> Cons(x, resume(()))
+    return _ -> Nil
+  }
+}

--- a/test/algeff/eff-constant2.kk.out
+++ b/test/algeff/eff-constant2.kk.out
@@ -1,0 +1,3 @@
+test/algeff/eff-constant2.kk(6,40): error: invalid syntax
+ encountered effect variable e when an effect label was expected
+ hint: effect variables must be after `|` (e.g `<labels|e>`), or by themselves (e.g. `e`)


### PR DESCRIPTION
Fixes #353 and #60

The issue was that effect variables were making it to inference to places where only effect labels were expected, which causes a crash in the compiler. This PR catches and reports the error in the parser.