### PR TITLE
Fix aliases

### DIFF
--- a/src/Kind/Infer.hs
+++ b/src/Kind/Infer.hs
@@ -786,6 +786,7 @@ resolveTypeDef isRec recNames (Synonym syn params tp range vis doc)
        -- trace (showTypeBinder syn') $
        addRangeInfo range (Decl "alias" (getName syn') (mangleTypeName (getName syn')))
        let synInfo = SynInfo (getName syn') (typeBinderKind syn') etaParams etaTp (maxSynonymRank etaTp + 1) range vis doc
+       addSynonym synInfo
        return (Core.Synonym synInfo)
   where
     kindArity (KApp (KApp kcon k1) k2)  | kcon == kindArrow = k1 : kindArity k2

--- a/test/type/alias.kk
+++ b/test/type/alias.kk
@@ -1,0 +1,13 @@
+alias newtest = test;
+
+type test
+  Test(nt: newtest)
+  Empty
+
+fun test1(n: newtest)
+  match n
+    Test(nt) -> nt.test1 + 1
+    Empty -> 0
+
+fun main()
+  test1(Test(Test(Empty))).println

--- a/test/type/alias.kk.out
+++ b/test/type/alias.kk.out
@@ -1,0 +1,6 @@
+type/alias/Empty: test
+type/alias/Test: (nt : newtest) -> test
+type/alias/is-empty: (test : test) -> bool
+type/alias/is-test: (test : test) -> bool
+type/alias/main: () -> console ()
+type/alias/test1: (n : newtest) -> int


### PR DESCRIPTION
Fixes mutually recursive alias and type definitions

Previously, it would infer that the alias was a `TCon` instead of the proper `TSyn`.