### PR TITLE
fix extend type

### DIFF
--- a/src/Kind/Infer.hs
+++ b/src/Kind/Infer.hs
@@ -152,7 +152,7 @@ synTypeDef :: Name -> Core.TypeDef -> DefGroups Type
 synTypeDef modName (Core.Synonym synInfo) = []
 synTypeDef modName (Core.Data dataInfo isExtend) | isHiddenName (dataInfoName dataInfo) = []
 synTypeDef modName (Core.Data dataInfo isExtend)
-  = synAccessors modName dataInfo
+  = (if not (dataInfoIsOpen dataInfo) && not isExtend then synAccessors modName dataInfo else [])
     ++
     (if (length (dataInfoConstrs dataInfo) == 1 && not (dataInfoIsOpen dataInfo)
          && not (isHiddenName (conInfoName (head (dataInfoConstrs dataInfo))))


### PR DESCRIPTION
Previously, accessors were being generated when adding a single constructor to an open type (since all of the added constructors had the same fields), creating a dummy constructor with no fields is a workaround, but the real fix is to not generate accessors for open or extend types.