### PR TITLE
fix lex of names with underscore (sometimes in core)

### DIFF
--- a/src/Syntax/Lexer.x
+++ b/src/Syntax/Lexer.x
@@ -83,10 +83,11 @@ $charesc      = [nrt\\\'\"]    -- "
 
 @idchar       = $letter | $digit | _ | \-
 @lowerid      = $lower @idchar* $finalid*
+@loweridcont  = ($lower|_) @idchar* $finalid*
 @upperid      = $upper @idchar* $finalid*
 @conid        = @upperid
-@modulepath   = (@lowerid\/)+
-@qvarid       = @modulepath @lowerid
+@modulepath   = (@lowerid\/)(@loweridcont\/)*
+@qvarid       = @modulepath @loweridcont
 @qconid       = @modulepath @conid
 @symbols      = $symbol+ | \/
 @qidop        = @modulepath \(@symbols\)


### PR DESCRIPTION
Sometimes in the core interface files identifiers appear with underscores.