### PR TITLE
small int updates

### DIFF
--- a/kklib/include/kklib/box.h
+++ b/kklib/include/kklib/box.h
@@ -245,6 +245,16 @@ static inline kk_box_t kk_int16_box(int16_t i, kk_context_t* ctx) {
 }
 #endif
 
+static inline int8_t kk_int8_unbox(kk_box_t v, kk_context_t* ctx) {
+  kk_unused(ctx);
+  kk_intf_t i = kk_intf_unbox(v);
+  kk_assert_internal((i >= INT8_MIN && i <= INT8_MAX) || kk_box_is_any(v));
+  return (int8_t)(i);
+}
+static inline kk_box_t kk_int8_box(int8_t i, kk_context_t* ctx) {
+  return kk_intf_box(i);
+}
+
 #if (KK_INTF_SIZE == 8) && KK_BOX_DOUBLE64
 kk_decl_export kk_box_t kk_double_box(double d, kk_context_t* ctx);
 kk_decl_export double   kk_double_unbox(kk_box_t b, kk_borrow_t borrow, kk_context_t* ctx);

--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -1197,6 +1197,62 @@ pub fip extern int8( i : int) : int8
   cs "Primitive.IntToInt8"
   js "$std_core._int_clamp8"
 
+// multiply two int8 values
+pub inline fip extern (*)( i : int8, i2: int8) : int8
+  inline "(#1 * #2)"
+
+// divide two int8 values
+pub inline fip extern (/)( i : int8, i2: int8) : int8
+  inline "(#1 / #2)"
+
+// multiply two int8 values
+pub inline fip extern (%)( i : int8, i2: int8) : int8
+  inline "(#1 % #2)"
+
+// add two int8 values
+pub inline fip extern (+)( i : int8, i2: int8) : int8
+  inline "(#1 + #2)"
+
+// subtract two int8 values
+pub inline fip extern (-)( i : int8, i2: int8) : int8
+  inline "(#1 - #2)"
+
+// add two int8 values
+pub inline fip extern inc( i : int8) : int8
+  inline "(#1 + 1)"
+
+// add two int8 values
+pub inline fip extern dec( i : int8) : int8
+  inline "(#1 - 1)"
+
+// check inequality of two int8 values
+pub inline fip extern (!=)( i : int8, i2: int8) : bool
+  inline "(#1 != #2)"
+
+// check equality of two int8 values
+pub inline fip extern (==)( i : int8, i2: int8) : bool
+  inline "(#1 == #2)"
+
+// compare two int8 values
+pub inline fip extern (<=)( i : int8, i2: int8) : bool
+  inline "(#1 <= #2)"
+
+// compare two int8 values
+pub inline fip extern (<)( i : int8, i2: int8) : bool
+  inline "(#1 < #2)"
+
+// compare two int8 values
+pub inline fip extern (>)( i : int8, i2: int8) : bool
+  inline "(#1 > #2)"
+
+// compare two int8 values
+pub inline fip extern (>=)( i : int8, i2: int8) : bool
+  inline "(#1 >= #2)"
+
+// check against 0
+pub inline fip extern is-zero( i : int8) : bool
+  inline "(#1 == 0)"
+
 // Convert an `:int8` to an `:int`.
 pub inline fip extern int( i : int8 ) : int
   c  "kk_integer_from_int8"
@@ -1234,6 +1290,62 @@ pub inline fip extern int( i : int16 ) : int
   cs inline "(new BigInteger(#1))"
   js "$std_core._int_from_int32"
 
+
+// multiply two int16 values
+pub inline fip extern (*)( i : int16, i2: int16) : int16
+  inline "(#1 * #2)"
+
+// divide two int16 values
+pub inline fip extern (/)( i : int16, i2: int16) : int16
+  inline "(#1 / #2)"
+
+// multiply two int16 values
+pub inline fip extern (%)( i : int16, i2: int16) : int16
+  inline "(#1 % #2)"
+
+// add two int16 values
+pub inline fip extern (+)( i : int16, i2: int16) : int16
+  inline "(#1 + #2)"
+
+// subtract two int16 values
+pub inline fip extern (-)( i : int16, i2: int16) : int16
+  inline "(#1 - #2)"
+
+// add two int16 values
+pub inline fip extern inc( i : int16) : int16
+  inline "(#1 + 1)"
+
+// add two int16 values
+pub inline fip extern dec( i : int16) : int16
+  inline "(#1 - 1)"
+
+// check inequality of two int16 values
+pub inline fip extern (!=)( i : int16, i2: int16) : bool
+  inline "(#1 != #2)"
+
+// check equality of two int16 values
+pub inline fip extern (==)( i : int16, i2: int16) : bool
+  inline "(#1 == #2)"
+
+// compare two int16 values
+pub inline fip extern (<=)( i : int16, i2: int16) : bool
+  inline "(#1 <= #2)"
+
+// compare two int16 values
+pub inline fip extern (<)( i : int16, i2: int16) : bool
+  inline "(#1 < #2)"
+
+// compare two int16 values
+pub inline fip extern (>)( i : int16, i2: int16) : bool
+  inline "(#1 > #2)"
+
+// compare two int16 values
+pub inline fip extern (>=)( i : int16, i2: int16) : bool
+  inline "(#1 >= #2)"
+
+// check against 0
+pub inline fip extern is-zero( i : int16) : bool
+  inline "(#1 == 0)"
 
 // ----------------------------------------------------------------------------
 // int64
@@ -1902,11 +2014,11 @@ pub fun vector( ^n : int, default : a) : vector<a>
   vector-initz(n.ssize_t, fn(_i){ default } )
 
 // Create a new vector of length `n`  with initial elements given by function `f` .
-pub fun vector-init( ^n : int, f : int -> a ) : vector<a>
+pub fun vector-init( ^n : int, f : int -> e a ) : e vector<a>
   vector-initz( n.ssize_t, fn(i) { f(i.int) } )
 
 // Create a new vector of length `n`  with initial elements given by function `f` .
-extern vector-initz(n : ssize_t, f : ssize_t -> a) : vector<a>
+extern vector-initz(n : ssize_t, f : ssize_t -> e a) : e vector<a>
   c "kk_vector_init"
   cs inline "Primitive.NewArray<##1>(#1,#2)"
   js inline "_vector(#1,#2)"


### PR DESCRIPTION
Some missing small int functions, including boxing 8bit integers, which the compiler generated calls to, but did not have appropriate definitions for.

Question for Daan, why do we not have unsigned versions of integers as well?