### PR TITLE
Fix vector out of bounds for JS backend

### DIFF
--- a/lib/std/core/core-inline.js
+++ b/lib/std/core/core-inline.js
@@ -266,7 +266,7 @@ export function _vector(n, f) {
 export function _vector_at( v, i ) {
   var j = _int_to_number(i);
   var x = v[j];
-  if (x === undefined) { exn_error_range(); }
+  if (x === undefined) { throw_exn(Exception("index out of bounds"), ExnRange); }
   return x;
 }
 


### PR DESCRIPTION
Hello! I noticed that vector out of bounds checks don't appear to be working on either the C or JS backends. This pull request fixes them on the JS backend.

I haven't figured out how to fix them on the C backend yet. I was looking for an example of throwing a Koka error from C, but haven't found one. Is this possible? If it is and you can point me in the right direction in terms of how to do so, I'd be happy to fix the C backend too.