### PR TITLE
support language-server over stdio

### DIFF
--- a/src/Compile/Options.hs
+++ b/src/Compile/Options.hs
@@ -58,6 +58,7 @@ import Core.Core( dataInfoIsValue )
   Convert flags to pretty environment
 --------------------------------------------------------------------------}
 import qualified Type.Pretty as TP
+import System.IO (hPutStrLn, stderr)
 
 prettyEnvFromFlags :: Flags -> TP.Env
 prettyEnvFromFlags flags
@@ -1217,12 +1218,12 @@ ccFromPath flags path
                 , ccFlagsLink    = ccFlagsLink cc0 ++ ccompLinkArgs flags }
 
     in do when (isTargetWasm (target flags) && not (name `startsWith` "emcc")) $
-            putStrLn ("\nwarning: a wasm target should use the emscripten compiler (emcc),\n  but currently '"
+            hPutStrLn stderr ("\nwarning: a wasm target should use the emscripten compiler (emcc),\n  but currently '"
                        ++ ccPath cc ++ "' is used."
                        ++ "\n  hint: specify the emscripten path using --cc=<emcc path>?")
           if (asan flags)
             then if (not (ccName cc `startsWith` "clang" || ccName cc `startsWith` "gcc" || ccName cc `startsWith` "g++"))
-                    then do putStrLn "warning: can only use address sanitizer with clang or gcc (--fasan is ignored)"
+                    then do hPutStrLn stderr "warning: can only use address sanitizer with clang or gcc (--fasan is ignored)"
                             return (cc,False)
                     -- asan on Apple Silicon can't find leaks and throws an error
                     -- We can't check for arch, since GHC 8.10 runs on Rosetta and detects x86_64
@@ -1243,11 +1244,11 @@ ccCheckExist cc
        mbPath <- searchPaths paths [exeExtension] (ccPath cc)
        case mbPath of
          Just _  -> return ()
-         Nothing -> do putStrLn ("\nwarning: cannot find the C compiler: " ++ ccPath cc)
+         Nothing -> do hPutStrLn stderr ("\nwarning: cannot find the C compiler: " ++ ccPath cc)
                        when (ccName cc == "cl") $
-                         putStrLn ("   hint: run in an x64 Native Tools command prompt? or use the --cc=clang-cl flag?")
+                         hPutStrLn stderr ("   hint: run in an x64 Native Tools command prompt? or use the --cc=clang-cl flag?")
                        when (ccName cc == "clang-cl") $
-                         putStrLn ("   hint: install clang for Windows from <https://github.com/llvm/llvm-project/releases/latest> ?")
+                         hPutStrLn stderr ("   hint: install clang for Windows from <https://github.com/llvm/llvm-project/releases/latest> ?")
 
 
 quote s

--- a/src/Compile/Options.hs
+++ b/src/Compile/Options.hs
@@ -184,6 +184,7 @@ data Flags
          , semiInsert       :: !Bool
          , genRangeMap      :: !Bool
          , languageServerPort :: !Int
+         , languageServerStdio :: !Bool
          , localBinDir      :: !FilePath  -- directory of koka executable
          , localDir         :: !FilePath  -- install prefix: /usr/local
          , localLibDir      :: !FilePath  -- precompiled object files: <prefix>/lib/koka/v2.x.x  /<cc>-<config>/libkklib.a, /<cc>-<config>/std_core.kki, ...
@@ -330,6 +331,7 @@ flagsNull
           True  -- semi colon insertion
           False -- generate range map
           6061  -- language server port
+          False -- language server stdio
           ""    -- koka executable dir
           ""    -- prefix dir (default: <program-dir>/..)
           ""    -- localLib dir
@@ -466,6 +468,7 @@ options = (\(xss,yss) -> (concat xss, concat yss)) $ unzip
  , hide $ fflag       ["unroll"]      (\b f -> f{optUnroll=(if b then 1 else 0)}) "enable recursive definition unrolling"
  , hide $ fflag       ["eagerpatbind"] (\b f -> f{optEagerPatBind=b}) "load pattern fields as early as possible"
  , hide $ numOption (-1) "port" [] ["lsport"]    (\i f -> f{languageServerPort=i}) "language Server port"
+ , hide $ flag []     ["lsstdio"]     (\b f -> f{languageServerStdio=b}) "language Server stdio"
  , hide $ flag []     ["buildhash"]   (\b f -> f{useBuildDirHash=b})   "use hash in build directory name"
 
  -- deprecated

--- a/src/Main/langserver/LanguageServer/Run.hs
+++ b/src/Main/langserver/LanguageServer/Run.hs
@@ -18,8 +18,8 @@ import System.Exit            ( exitFailure )
 import GHC.IO.IOMode (IOMode(ReadWriteMode))
 import GHC.Conc (atomically)
 import GHC.IO.Handle (BufferMode(NoBuffering), hSetBuffering)
-import GHC.IO.StdHandles (stdout, stderr)
-import Control.Monad (void, forever)
+import GHC.IO.StdHandles (stdin, stdout, stderr)
+import Control.Monad (void, forever, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.STM ( atomically )
 import Control.Concurrent.STM.TChan ( newTChan, readTChan, TChan )
@@ -37,61 +37,64 @@ import Network.Simple.TCP ( connect )
 import Network.Socket ( socketToHandle )
 import LanguageServer.Handlers ( lspHandlers, ReactorInput(..) )
 import LanguageServer.Monad (newLSStateVar, runLSM, LSM, getLSState, LSState (messages, progress), getProgress, updateSignatureContext, SignatureContext(..))
-import Compile.Options (Flags (languageServerPort))
+import Compile.Options (Flags (languageServerPort, languageServerStdio))
 import Debug.Trace (trace)
 
 runLanguageServer :: Flags -> [FilePath] -> IO ()
 runLanguageServer flags files = do
-  if languageServerPort flags == -1 then do
-    putStr "No port specified for language server\n. Use --lsport=<port> to specify a port."
+  when (not useStdio && languageServerPort flags == -1) $ do
+    putStrLn "No port specified for language server.\nUse --lsport=<port> to specify a port or --lsstdio to use stdio."
     exitFailure
-  else return ()
   -- Have to set line buffering, otherwise the client doesn't receive data until buffers fill up
   hSetBuffering stdout NoBuffering
   hSetBuffering stderr NoBuffering
-  -- Connect to localhost on the port given by the client
-  connect "127.0.0.1" (show $ languageServerPort flags) (\(socket, _) -> do
-    -- Create a handle to the client from the socket
-    handle <- socketToHandle socket ReadWriteMode
-    -- Create a new language server state
-    state <- newLSStateVar flags
-    -- Get the message channel
-    messageChan <- liftIO $ messages <$> readMVar state
-    progressChan <- liftIO $ progress <$> readMVar state
-    -- Create a new channel for the reactor to receive messages on
-    rin <- atomically newTChan :: IO (TChan ReactorInput)
-    void $
-      runServerWithHandles
-        ioLogger
-        lspLogger
-        handle
-        handle
-        $
-        ServerDefinition
-          { parseConfig = const $ const $ Right (),
-            onConfigChange = const $ pure (),
-            defaultConfig = (),
-            configSection = T.pack "koka",
-            -- Two threads, the request thread and the message thread (so we can send messages to the client, while the compilation is happening)
-            doInitialize = \env _ -> forkIO (reactor rin) >> forkIO (messageHandler messageChan env state) >> forkIO (progressHandler progressChan env state) >> pure (Right env),
-            staticHandlers = \_caps -> lspHandlers rin,
-            interpretHandler = \env -> Iso (\lsm -> runLSM lsm state env) liftIO,
-            options =
-              defaultOptions
-                { optTextDocumentSync = Just syncOptions,
-                  optExecuteCommandCommands = Just [T.pack "koka/compile", T.pack "koka/compileFunction", T.pack "koka/signature-help/set-context"],
-                  optCompletionTriggerCharacters = Just ['.', ':', '/', ' '],
-                  optSignatureHelpTriggerCharacters = Just ['(', ',', ' ']
-                -- TODO: ? https://www.stackage.org/haddock/lts-18.21/lsp-1.2.0.0/src/Language.LSP.Server.Core.html#Options
-                }
-          })
+  if useStdio then do
+    hSetBuffering stdin NoBuffering
+    runLanguageServerWithHandles stdin stdout
+    -- Connect to localhost on the port given by the client
+  else connect "127.0.0.1" (show $ languageServerPort flags) (\(socket, _) -> do
+      -- Create a handle to the client from the socket
+      handle <- socketToHandle socket ReadWriteMode
+      runLanguageServerWithHandles handle handle)
   where
-    -- io logger, prints all log level messages to stdout
+    useStdio = languageServerStdio flags
+    runLanguageServerWithHandles inHandle outHandle = do
+      -- Create a new language server state
+      state <- newLSStateVar flags
+      -- Get the message channel
+      messageChan <- liftIO $ messages <$> readMVar state
+      progressChan <- liftIO $ progress <$> readMVar state
+      -- Create a new channel for the reactor to receive messages on
+      rin <- atomically newTChan :: IO (TChan ReactorInput)
+      void $
+        runServerWithHandles
+          ioLogger
+          lspLogger
+          inHandle
+          outHandle
+          $
+          ServerDefinition
+            { parseConfig = const $ const $ Right (),
+              onConfigChange = const $ pure (),
+              defaultConfig = (),
+              configSection = T.pack "koka",
+              -- Two threads, the request thread and the message thread (so we can send messages to the client, while the compilation is happening)
+              doInitialize = \env _ -> forkIO (reactor rin) >> forkIO (messageHandler messageChan env state) >> forkIO (progressHandler progressChan env state) >> pure (Right env),
+              staticHandlers = \_caps -> lspHandlers rin,
+              interpretHandler = \env -> Iso (\lsm -> runLSM lsm state env) liftIO,
+              options =
+                defaultOptions
+                  { optTextDocumentSync = Just syncOptions,
+                    optExecuteCommandCommands = Just [T.pack "koka/compile", T.pack "koka/compileFunction", T.pack "koka/signature-help/set-context"],
+                    optCompletionTriggerCharacters = Just ['.', ':', '/', ' '],
+                    optSignatureHelpTriggerCharacters = Just ['(', ',', ' ']
+                  -- TODO: ? https://www.stackage.org/haddock/lts-18.21/lsp-1.2.0.0/src/Language.LSP.Server.Core.html#Options
+                  }
+            }
+    -- io logger, prints all log level messages to stdout or stderr
     ioLogger :: LogAction IO (WithSeverity LspServerLog)
-    ioLogger = L.cmap show L.logStringStdout
-    stderrLogger :: LogAction IO (WithSeverity T.Text)
-    stderrLogger = L.cmap show L.logStringStderr
-    -- lsp logger, prints all messages to stdout and to the client
+    ioLogger = L.cmap show (if useStdio then L.logStringStderr else L.logStringStdout)
+    -- lsp logger, prints all messages to stdout or stderr and to the client
     lspLogger :: LogAction (LspM config) (WithSeverity LspServerLog)
     lspLogger =
       let clientLogger = L.cmap (fmap (T.pack . show)) defaultClientLogger

--- a/src/Syntax/Layout.hs
+++ b/src/Syntax/Layout.hs
@@ -9,7 +9,7 @@
     Add braces and semicolons based on layout.
 -}
 -----------------------------------------------------------------------------
-module Syntax.Layout( layout, testFile, combineLineComments, lexSource ) where
+module Syntax.Layout( layout, combineLineComments, lexSource ) where
 
 import Data.Char(isSpace)
 import Data.List(partition)
@@ -23,18 +23,6 @@ import Syntax.Lexeme
 import Syntax.Lexer
 import Common.Name  ( Name, nameLocal, nameStem )
 import Common.File  ( startsWith, seqList, isLiteralDoc )
-
-testFile fname
-  = do input <- readInput ("test/" ++ fname)
-       testEx fname input
-
-test xs
-  = testEx "" xs
-
-testEx fname input
-  = let source = Source fname input
-        xs = lexing source 1 input
-    in putStrLn (unlines (map show (layout True True xs)))
 
 -- Lex a source
 lexSource :: Bool -> Bool -> ([Lexeme]-> [Lexeme]) -> Int -> Source -> [Lexeme]


### PR DESCRIPTION
This pull request adds support for a hidden `--lsstdio` flag which, when set, causes the language server to communicate using stdin/stdout (logging to stderr), instead of over the network. This is useful since some editors prefer this method of communication, such as [helix](https://github.com/helix-editor/helix). Behaviour should be unchanged when using it over the network, but I don't have a VSCode setup, so I'd appreciate if someone could confirm that I haven't accidentally broken anything on that end.