### PR TITLE
fix vector init

### DIFF
--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -1914,17 +1914,15 @@ inline extern lengthz( ^v : vector<a> ) : ssize_t
 
 // Create a new vector of length `n`  with initial elements `default` .
 pub fun vector( ^n : int, default : a) : vector<a>
-  vector-initz(n.ssize_t, fn(_i){ default } )
+  vector-init(n, fn(_i){ default } )
 
 // Create a new vector of length `n`  with initial elements given by function `f` .
 pub fun vector-init( ^n : int, f : int -> e a ) : e vector<a>
-  vector-initz( n.ssize_t, fn(i) { f(i.int) } )
-
-// Create a new vector of length `n`  with initial elements given by function `f` .
-extern vector-initz(n : ssize_t, f : ssize_t -> e a) : e vector<a>
-  c "kk_vector_init"
-  cs inline "Primitive.NewArray<##1>(#1,#2)"
-  js inline "_vector(#1,#2)"
+  val n' = n.ssize_t
+  val v = unsafe-vector(n')
+  forz( 0.ssize_t, n' ) fn(i)
+    unsafe-assign(v,i,f(i.int))
+  v
 
 // Create an empty vector.
 pub inline extern vector : forall<a> () -> vector<a>

--- a/lib/std/core/core-inline.c
+++ b/lib/std/core/core-inline.c
@@ -57,16 +57,6 @@ kk_vector_t kk_list_to_vector(kk_std_core__list xs, kk_context_t* ctx) {
   return v;
 }
 
-kk_vector_t kk_vector_init( kk_ssize_t n, kk_function_t init, kk_context_t* ctx) {
-  kk_box_t* p;
-  kk_vector_t v = kk_vector_alloc_uninit(n, &p, ctx);  
-  for(kk_ssize_t i = 0; i < n; i++) {
-    kk_function_dup(init,ctx);
-    p[i] = kk_function_call(kk_box_t,(kk_function_t,kk_ssize_t,kk_context_t*),init,(init,i,ctx),ctx);
-  }
-  kk_function_drop(init,ctx);
-  return v;
-}
 
 kk_box_t kk_main_console( kk_function_t action, kk_context_t* ctx ) {
   return kk_function_call(kk_box_t,(kk_function_t,kk_unit_t,kk_context_t*),action,(action,kk_Unit,ctx),ctx);

--- a/lib/std/core/core-inline.js
+++ b/lib/std/core/core-inline.js
@@ -252,16 +252,6 @@ export function _unvlist(list) {
   return elems;
 }
 
-// Create a vector with a function initializer
-export function _vector(n, f) {
-  if (n<=0) return [];
-  var a = new Array(n);
-  for(var i = 0; i < n; i++) {
-    a[i] = f(i);
-  }
-  return a;
-}
-
 // Index a vector
 export function _vector_at( v, i ) {
   var j = _int_to_number(i);


### PR DESCRIPTION
Fixes: #416 
Vector init wasn't working properly for control effects. I don't know if you'd rather just make the effect `io-noexn`, but it seems to me that we would at least want to support `st<>` or `ref<>` as well. Either way it probably should be documented that using multiple resumptions with this API is bad practice because it doesn't copy the vector.

I went through the rest of core.kk and made sure there were no more functions being passed to c that have polymorphic effect types. 
