### PR TITLE
Fix error in docs

### DIFF
--- a/doc/rise4fun/guide.kk.md
+++ b/doc/rise4fun/guide.kk.md
@@ -687,8 +687,8 @@ function copy( p, age = p.age, name = p.name,
 }
 ```
 
-When arguments follow a data value, as in ``p( age = age + 1)``, it is desugared to call this
-copy function, as in `p.copy( age = p.age+1 )`. Again, there are no special
+When arguments follow a data value, as in ``p( age = p.age + 1)``, it is desugared to call this
+copy function, as in `p.copy( age = p.age + 1 )`. Again, there are no special
 rules for record updates and everything is just function calls with optional
 and named parameters.
 

--- a/doc/rise4fun/guide.kkdoc
+++ b/doc/rise4fun/guide.kkdoc
@@ -687,8 +687,8 @@ function copy( p, age = p.age, name = p.name,
 }
 ```
 
-When arguments follow a data value, as in ``p( age = age + 1)``, it is desugared to call this
-copy function, as in `p.copy( age = p.age+1 )`. Again, there are no special
+When arguments follow a data value, as in ``p( age = p.age + 1)``, it is desugared to call this
+copy function, as in `p.copy( age = p.age + 1 )`. Again, there are no special
 rules for record updates and everything is just function calls with optional
 and named parameters.
 

--- a/doc/spec/tour.kk.md
+++ b/doc/spec/tour.kk.md
@@ -769,8 +769,8 @@ fun copy( p, age = p.age, name = p.name, realname = p.realname )
   Person(age, name, realname)
 ```
 
-When arguments follow a data value, as in ``p( age = age + 1)``, it is expanded to call this
-copy function, as in `p.copy( age = p.age+1 )`. In adherence with the _min-gen_ principle,
+When arguments follow a data value, as in ``p( age = p.age + 1)``, it is expanded to call this
+copy function, as in `p.copy( age = p.age + 1 )`. In adherence with the _min-gen_ principle,
 there are no special rules for record updates but using plain function calls with optional
 and named parameters.
 


### PR DESCRIPTION
The docs mention that `p( age = age + 1)` is valid syntax for the copy constructor, which I found slightly surprising, since in other places `age` is properly called with an argument, like `p.age`. As it doesn't actually seem to work either, I assume it's a mistake/typo in the docs.