### PR TITLE
Fix off-by-one bug in `range/fold*`

### DIFF
--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -156,7 +156,7 @@ pub fun range/for-while( start: int, end : int, action : (int) -> e maybe<a> ) :
 
 // Fold over the integers between [`start`,`end`] (including `end`).
 pub fun range/fold( start : int, end : int, init : a, f : (int,a) -> e a ) : e a
-  if start >= end then init else
+  if start > end then init else
     val x = f(start,init)
     fold(pretend-decreasing(start.inc), end, x, f)
 
@@ -164,9 +164,9 @@ pub fun range/fold( start : int, end : int, init : a, f : (int,a) -> e a ) : e a
 pub fun fold( upto : int, init : a, f : (int,a) -> e a ) : e a
   fold( 0, upto.dec, init, f )
 
-// Fold over the integers between [`start``,`end`] (including `end`) or until `f` returns `Nothing`
+// Fold over the integers between [`start`,`end`] (including `end`) or until `f` returns `Nothing`
 pub fun range/fold-while( start : int, end : int, init : a, f : (int,a) -> e maybe<a> ) : e a
-  if start >= end then init else
+  if start > end then init else
     match f(start,init)
       Just(x) -> fold-while(pretend-decreasing(start.inc), end, x, f)
       Nothing -> init


### PR DESCRIPTION
`range/fold(start, end, init, f)` is described as follows:

https://github.com/koka-lang/koka/blob/f48555f1e2ba211f3e86524a15668597cad19118/lib/std/core.kk#L157

But `end` is not actually included. For instance, `range/fold(1, 3, 0, (+))` is expected to evaluate to `6` (= `1+2+3`), but it evaluates to `3` (= `1+2`) (in version 3.0.4). The same issue exists in `range/fold-while`.

This PR fixes the off-by-one bug.

Note: perhaps I should also fix `fold-int*` and `fold-while-int*` (`*` = 32 or 64) for consistency. However these functions do not have spec comments and I am not certain of the expected behavior. Moreover some programs in this repository expect them to end with `end - 1` (not `end`).

Examples:

https://github.com/koka-lang/koka/blob/f48555f1e2ba211f3e86524a15668597cad19118/lib/std/num/random.kk#L57
https://github.com/koka-lang/koka/blob/f48555f1e2ba211f3e86524a15668597cad19118/test/fip/src/tmap/tmap-fip.kk#L40