### PR TITLE
Eta expand functions with optional parameters when resolving implicits

### DIFF
--- a/lib/std/core/console.kk
+++ b/lib/std/core/console.kk
@@ -71,7 +71,7 @@ pub fun string/print(s : string)
   prints(s)
 
 // Print a value that has a `show` function
-pub fun show/print( x : a, ?show : a -> string ) : console ()
+pub fun show/print( x : a, ?show : a -> <console|e> string ) : <console|e> ()
   prints(x.show)
 
 // Print a string to the console, including a final newline character.
@@ -79,5 +79,5 @@ pub fun string/println(s : string) : console ()
   printsln(s)
 
 // Print a value that has a `show` function, including a final newline character.
-pub fun show/println( x : a, ?show : a -> string ) : console ()
+pub fun show/println( x : a, ?show : a -> <console|e> string ) : <console|e> ()
   printsln(x.show)

--- a/src/Type/Operations.hs
+++ b/src/Type/Operations.hs
@@ -15,7 +15,7 @@ module Type.Operations( instantiate
                       , freshTVar
                       , Evidence(..)
                       , freshSub
-                      , isOptionalOrImplicit, splitOptionalImplicit
+                      , isOptionalOrImplicit, isOptionalParam, splitOptionalImplicit
                       ) where
 
 
@@ -32,6 +32,10 @@ import Type.Assumption
 isOptionalOrImplicit :: (Name,Type) -> Bool
 isOptionalOrImplicit (pname,ptype)
   = isImplicitParamName pname || isOptional ptype
+
+isOptionalParam :: (Name,Type) -> Bool
+isOptionalParam (pname,ptype)
+  = isOptional ptype
 
 splitOptionalImplicit :: [(Name,Type)] -> ([(Name,Type)],[(Name,Type)],[(Name,Type)])
 splitOptionalImplicit pars


### PR DESCRIPTION
When using a function with an optional parameter as implicit, the types do not unify. Eta-expanding the function fixes the issue. This is particularly important due to `double/show` having the default parameter for precision.