### PR TITLE
Support external managed memory

### DIFF
--- a/lib/std/core/cextern.kk
+++ b/lib/std/core/cextern.kk
@@ -7,6 +7,78 @@ import std/core/int
 extern import
   c header-file "inline/cextern.h"
 
+// TIM: Some thoughts / notes on wrapping C libraries and C / extern memory management
+
+// C structs / memory has the following allocation / ownership behavior for function calls
+
+// Parameters to C functions
+// - Passed as value: 
+//   + Caller is not responsible for the struct's memory anymore, but could be responsible for embedded pointers
+//   + Allocation of the struct itself is stack based, and unimportant for memory management
+// - Passed as pointer
+//   + Could be stack or heap allocated pointer, and could be caller owned or transfer of ownership to callee (for heap allocated references)
+//   + If ownership is transferred the caller should not have any other references to the memory, and should not use it anymore.
+// Return values from C functions
+// - As value
+//   + Caller is responsible for continuing to hold onto the important pieces by value
+//   + or if the struct escapes the stack / is returned by value the caller needs to allocate + own (at least the outer struct)
+// - As pointer
+//   + Could be stack or heap allocated pointer, and could be callee owned or transferred to caller (for heap allocated references)
+//   + If ownership is transferred to caller then the caller needs to become responsible for deallocation 
+//   + Unlikely to be a stack allocated pointer, unless it is of one that we have access to otherwise, (e.g. a pointer into an array we allocated on the stack)
+
+// In summary we have values, stack references and heap references. Following covers the difference between these.
+
+// Stack allocated values
+//   The normal value types of Koka could be used with no changes, other than the object header, which would require a boxing step, which happens anyways. 
+//   We'd just need to specialize the boxing step for this kind of memory.
+//   Maybe we could introduce a `raw struct` variant - to ensure native (C) ordering / representation, and restrict fields to native compatible types
+//   Raw structs embedded within other structs are boxed
+//   
+// Stack allocated references
+// Could we reuse Koka's `local<h>` effect, maybe `local-raw<h>` to prevent scope escaping? 
+//   For example we could have a function that like `local-new` returns a local that cannot escape the stack - but for a `raw value` type.
+// 
+// Stack allocation: 
+//   On the parameter side, we would need to be able to pass the struct by value or by reference
+//   We could also have a `.ref` to get the reference to the stack location, and a `.value` to copy a stack allocated ref into the value type. 
+//   Return types from C functions could introduce the `local-raw<h>` effect tied to the return value (for reference types), and transparently represent `raw struct`s.
+//   Stack allocation is similar to the concept of Rust lifetimes. However, I expect that Koka's lifetime will always be stack related (region-like?) and not infinitely relatable to other objects (other than through invariant type polymorphism?)
+
+// Heap allocated raw types (all heap types are references)
+//   In the heap we have two main concepts owned and borrowed
+//   - The owner is in charge of determining the lifetime and deallocating the pointer
+//   - A borrower should not deallocate the pointer, and needs to know that the memory is still valid
+
+// Owned references:
+//   This one is somewhat easy for Koka. 
+//   We can use a reference counting wrapper to determine how many references to the pointer are from Koka
+//   The C object might have specific deallocation / cleanup functions to call, and might have been allocated with a different allocator.
+//   Unfortunately the wrapper won't transparently pass through the C code.
+//   Function calls will require domain specific understanding of the APIs and whether C maintains it's own references or not.
+//   If the reference is duplicated and both sides can access it (shared ownership), the `dup` / `drop` calls needs to happen in a domain specific manner.
+//     Using borrow annotations on the parameters should help to handle this, but the C code needs the raw pointer, so we also want to unwrap it when we generate the binding code.
+//     Also we need to defer the `drop` call to after the C function is run so that the memory is still accessible to the function.
+//   If the reference should be accessible by only one side at a time, and ownership should be passed, we need to guard calls to C by making sure the reference count is one when handing it off.
+//     This is where we would need some sort of static reference counting / escape analysis at compile time to make a guarantee that this won't cause an error.
+//   When C passes an owned reference to us that is much easier, we do as normal and wrap it up. Again, some automatic wrapping would be nice here.
+
+// Borrowed references: These are really just a special case of owned references, with specific patterns
+//   C code might want to borrow a reference, this is fine with a Koka owned reference, as long as we know when the C code is done with it and we can `drop` the reference count.
+//   C code might give us a reference (e.g. in a callback) that we should not own permanently, which it is in charge of cleaning up (likely after the function returns).
+//     In this case, treating it as a stack allocated region limited reference is the appropriate thing to do, with maybe some restrictions / warnings on copying it into a value?
+//     Some fields might be okay or intended for you to copy / own, and some may not.
+
+// I imagine that most C interfaces follow these common patterns:
+//  - Owned handles with create() and destruct() functions, with the user of the library in charge of cleaning up & lifetime as long as the user wants.
+//  - Passing / returning by value
+//  - Taking in a stack allocated reference (i.e. calls where the C code doesn't store the reference long term)
+//  - Embedded owned handles. (Composition of heap allocated references)
+
+// The tricky part is likely not any of the basics, but rather dealing with nested / nullable fields / mutation.
+// Rust is complicated because of lifetime annotation equivalence, upper bounds, multiple lifetimes, etc. 
+
+
 // A managed koka pointer to C memory
 // Owned values can be freely passed around, captured in lambdas, escape their scope, etc.
 pub alias owned-c<t> = extern-owned<t>

--- a/lib/std/core/cextern.kk
+++ b/lib/std/core/cextern.kk
@@ -1,0 +1,60 @@
+module std/core/cextern
+
+import std/num/int32
+import std/core/types
+
+extern import
+  c file "inline/cextern.h"
+
+pub alias owned-c<t> = extern-owned<t>
+pub alias borrowed-c<s::S,t> = extern-borrowed<t>
+pub type c-array<t>
+pub alias c-null<t> = intptr_t
+
+pub inline extern cnull(): c-null<t>
+  c inline "(kk_addr_t)NULL"
+
+pub fun array/malloc<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
+  int/malloc(n, size-of(cnull())).c-own
+
+pub fun single/malloc<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
+  int/malloc(1.int32, size-of(cnull())).c-own
+
+pub fun array/malloc-c<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
+  int/malloc-c(n, size-of(cnull())).c-own-free-calloc
+
+pub fun single/malloc-c<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
+  int/malloc-c(1.int32, size-of(cnull())).c-own-free-calloc
+
+extern int/malloc<t>(n: int32, size-of: int32): intptr_t
+  c inline "(kk_addr_t)kk_malloc(#1*#2, kk_context())"
+
+extern int/malloc-c<t>(n: int32, size-of: int32): intptr_t
+  c inline "(kk_addr_t)malloc(#1*#2)"
+
+// Transform a c ptr into a managed koka value, which will be freed when koka's reference count reaches 0
+pub extern c-own<t>(c: intptr_t): owned-c<t>
+  c inline "kk_cptr_raw_box(&kk_free_fun, (void *)#1, kk_context())"
+
+// Transform a c ptr into a managed koka value, which will be freed when koka's reference count reaches 0
+pub extern c-own-free-calloc<t>(c: intptr_t): owned-c<t>
+  c inline "kk_cptr_raw_box(&kk_free_calloc, (void *)#1, kk_context())"
+
+// Transform a c ptr into a koka value that holds the c reference without freeing it
+// The pointer should be valid
+pub extern c-borrow<t>(c: intptr_t, f: forall<s> borrowed-c<s,t> -> e a): e a
+  c "kk_borrow_ptr"
+
+// Transform a koka owned c value into a c ptr (keeping the koka reference alive during the scope of the function)
+pub extern owned/with-ptr(^t: owned-c<t>, f: intptr_t -> e a): e a
+  c "kk_owned_with_ptr"
+
+// Transform a koka owned value into a c ptr (keeping the koka reference alive during the scope of the function)
+pub extern borrowed/with-ptr(^t: borrowed-c<s,t>, f: intptr_t -> e a): e a
+  c "kk_borrowed_with_ptr"
+
+pub fun c-array/with-ptr(^t: owned-c<c-array<t>>, idx: ssize_t, f: forall<s> borrowed-c<s,t> -> e a, ?size-of: (c-null<t>) -> int32): e a
+  offset/with-ptr(t, idx, fn(p) c-borrow(p, f), size-of(cnull()))
+
+extern offset/with-ptr(^t: owned-c<c-array<t>>, idx: ssize_t, f: intptr_t -> e a, size-of: int32): e a
+  c "kk_owned_with_ptr_idx"

--- a/lib/std/core/cextern.kk
+++ b/lib/std/core/cextern.kk
@@ -17,8 +17,7 @@ pub alias owned-c<t> = extern-owned<t>
 pub alias borrowed-c<s::S,t> = extern-borrowed<t>
 
 // A raw pointer to C memory
-pub value struct c-pointer<t>
-  ptr: intptr_t
+pub type c-pointer<t>
 
 // An opaque type to designate c-array types in Koka
 pub type c-array<t>
@@ -27,43 +26,78 @@ pub type c-array<t>
 pub alias c-null<t> = c-pointer<t>
 
 // The null pointer in C
-pub inline fun cnull(): c-null<t>
-  C-pointer(0.intptr_t)
+pub inline extern cnull(): c-null<t>
+  c inline "(intptr_t)0"
+
+// A null callback pointer
+pub val null-cb = 0.intptr_t
+
+// Needs to be extern otherwise, the compiler will optimize out the function and not keep the reference alive
+// Ensure that a reference is > 1 until after this point
+pub extern owned/keepalive(^s: owned-c<a>): <> ()
+  ""
+
+// Release a reference (decref an owned reference)
+pub fun owned/release(s: owned-c<a>): <> ()
+  ()
+
+// Retain a reference (incref an owned reference)
+pub extern owned/retain(s: owned-c<a>): <> ()
+  ""
+
+pub inline extern int/ptr<t>(i: intptr_t): c-pointer<t>
+  c inline "(intptr_t)#1"
+
+pub inline extern carray/intptr<t>(c: c-array<t>): intptr_t
+  c inline "#1"
+
+pub inline extern carray/ptr<t>(c: c-array<t>): c-pointer<t>
+  c inline "#1"
+
+pub inline extern intptr/carray<t>(c: intptr_t): c-array<t>
+  c inline "#1"
+
+pub inline extern ptr/carray<t>(c: c-pointer<t>): c-array<t>
+  c inline "#1"
+
+// Allow casting between different types of pointers
+pub inline extern unsafe/cptr-cast<s>(c: c-pointer<t>): c-pointer<s>
+  c inline "#1"
 
 // Allocate `n*size-of` bytes of memory using kk_malloc and return a pointer to the allocated memory
-extern int/malloc<t>(n: int32, size-of: int32): intptr_t
+inline extern int/malloc<t>(n: int32, size-of: int32): c-pointer<t>
   c inline "(kk_addr_t)kk_malloc(#1*#2, kk_context())"
 
 // Allocate `n*size-of` bytes of memory using C's malloc and return a pointer to the allocated memory
-extern int/malloc-c<t>(n: int32, size-of: int32): intptr_t
+inline extern int/malloc-c<t>(n: int32, size-of: int32): c-pointer<t>
   c inline "(kk_addr_t)malloc(#1*#2)"
 
 // Allocate a single element of type `t` using `kk_malloc` and return a managed pointer
 // Type `t` should:
 // - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
 // - Have a `size-of` function that returns the size of the structure in bytes
-pub fun single/malloc<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
+pub inline fun single/malloc<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
   int/malloc(1.int32, size-of(cnull())).c-own-extern
 
 // Allocate `n` elements of type `t` using `kk_malloc` and return a managed pointer to the array
 // Type `t` should:
 // - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
 // - Have a `size-of` function that returns the size of the structure in bytes
-pub fun array/malloc<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
+pub inline fun array/malloc<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
   int/malloc(n, size-of(cnull())).c-own-extern
 
 // Allocate a single element of type `t` using C's `malloc` and return a managed pointer
 // Type `t` should:
 // - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
 // - Have a `size-of` function that returns the size of the structure in bytes
-pub fun single/malloc-c<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
+pub inline fun single/malloc-c<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
   int/malloc-c(1.int32, size-of(cnull())).c-own-free-calloc-extern
 
 // Allocate `n` elements of type `t` using C's `malloc` and return a managed pointer to the array
 // Type `t` should:
 // - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
 // - Have a `size-of` function that returns the size of the structure in bytes
-pub fun array/malloc-c<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
+pub inline fun array/malloc-c<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
   int/malloc-c(n, size-of(cnull())).c-own-free-calloc-extern
 
 // !!!WARNING!!! UNSAFE API
@@ -77,8 +111,8 @@ pub fun array/malloc-c<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-a
 // Raw `c-pointer<t>` should be used in low-level generated koka ffi functions since the pointer is unknown to be managed or not.
 // Conversion routines for `owned-c<t>` and `borrowed-c<s,t>` then should be used to get the raw pointers to be used in the ffi functions
 // Higher level apis to c libraries should then provide an interface using `owned-c<t>` and `borrowed-c<s,t>` instead of `c-pointer<t>`
-pub fun ptr/unsafe-malloc<t>(n: int32, ?size-of: (c-null<t>) -> int32): c-pointer<t>
-  C-pointer(int/malloc(n, size-of(cnull())))
+pub inline fun ptr/unsafe-malloc<t>(n: int32, ?size-of: (c-null<t>) -> int32): c-pointer<t>
+  int/malloc(n, size-of(cnull()))
 
 // !!!WARNING!!! UNSAFE API
 // Allocate `n` elements of type `t` using C's `malloc` and return a managed pointer to the array
@@ -91,69 +125,54 @@ pub fun ptr/unsafe-malloc<t>(n: int32, ?size-of: (c-null<t>) -> int32): c-pointe
 // Raw `c-pointer<t>` should be used in low-level generated koka ffi functions since the pointer is unknown to be managed or not.
 // Conversion routines for `owned-c<t>` and `borrowed-c<s,t>` then should be used to get the raw pointers to be used in the ffi functions
 // Higher level apis to c libraries should then provide an interface using `owned-c<t>` and `borrowed-c<s,t>` instead of `c-pointer<t>`
-pub fun ptr/unsafe-malloc-c<t>(n: int32, ?size-of: (c-null<t>) -> int32): c-pointer<t>
-  C-pointer(int/malloc-c(n, size-of(cnull())))
+pub inline fun ptr/unsafe-malloc-c<t>(n: int32, ?size-of: (c-null<t>) -> int32): c-pointer<t>
+  int/malloc-c(n, size-of(cnull()))
 
 // Transform a C ptr into a managed koka value, which will be freed by `kk_free` when koka's reference count reaches 0
-extern c-own-extern(c: intptr_t): a
+inline extern c-own-extern(c: c-pointer<a>): owned-c<a>
   c inline "kk_cptr_raw_box(&kk_free_fun, (void *)#1, kk_context())"
 
 // Transform a C ptr into a managed koka value, which will be freed by C's `free` when koka's reference count reaches 0
-extern c-own-free-calloc-extern(c: intptr_t): a
+inline extern c-own-free-calloc-extern(c: c-pointer<a>): owned-c<a>
   c inline "kk_cptr_raw_box(&kk_free_calloc, (void *)#1, kk_context())"
 
 // Transform a C ptr `c` into a koka value that holds the c reference without freeing it
 // The pointer should be valid for the duration of the callback `f`.
-extern c-borrow-extern(c: intptr_t, f: b -> e a): e a
+inline extern c-borrow(c: c-pointer<t>, f: forall<s> borrowed-c<s,t> -> e a): e a
   c "kk_borrow_ptr"
 
 // !!!WARNING!!!: Extremely unsafe API (needed for `c-borrow`), get approval to use anywhere else.
-extern unsafe-cast(b: b): a
+inline extern unsafe-cast<s>(b: c-pointer<t>): borrowed-c<s,t>
   c inline "#1"
 
 // Transform an unmanaged C ptr into a managed koka reference to C memory
 // Ensure the pointer is not going to be freed by C code, otherwise use `c-borrow` instead
 // Also ensure the memory was allocated using `kk_malloc`
-pub fun c-own<t>(t: c-pointer<t>): owned-c<t>
-  t.ptr.c-own-extern
+pub inline fun c-own<t>(t: c-pointer<t>): owned-c<t>
+  t.c-own-extern
 
 // Transform an unmanaged C ptr into a managed koka reference to C memory
 // Ensure the pointer is not going to be freed by C code, otherwise use `c-borrow` instead
 // Also ensure the memory was allocated using C's `malloc`
 pub fun c-own-free-calloc<t>(t: c-pointer<t>): owned-c<t>
-  t.ptr.c-own-free-calloc-extern
-
-// Transform an unmanaged C ptr into a borrowed koka reference to C memory
-// The pointer must be guaranteed to be valid for the duration of the callback `f`
-pub fun c-borrow<t>(c: c-pointer<t>, f: forall<s> borrowed-c<s,t> -> e a): e a
-  c-borrow-extern(c.ptr, fn(p) f(p.unsafe-cast()))
+  t.c-own-free-calloc-extern
 
 // Transform a koka `owned-c` managed pointer into a C ptr 
 // Keeps the koka reference alive during the scope of the callback `f`
-extern owned/with-ptr-extern(^t: b, f: intptr_t -> e a): e a
+pub inline extern owned/with-ptr(^t: owned-c<t>, f: c-pointer<t> -> e a): e a
   c "kk_owned_with_ptr"
 
-// Transform a koka `owned-c` managed pointer into a C ptr 
-// Keeps the koka reference alive during the scope of the callback `f`
-pub fun owned/with-ptr(t: owned-c<t>, f: c-pointer<t> -> e a): e a
-  owned/with-ptr-extern(t, fn(p) f(C-pointer(p)))
-
 // Transform a koka `borrowed-c` managed pointer into a C ptr
 // Keeps the koka reference alive during the scope of the callback `f`
-extern borrowed/with-ptr-extern(^t: b, f: intptr_t -> e a): e a
+pub inline extern borrowed/with-ptr(^t: borrowed-c<s,t>, f: c-pointer<t> -> e a): e a
   c "kk_borrowed_with_ptr"
-
-// Transform a koka `borrowed-c` managed pointer into a C ptr
-// Keeps the koka reference alive during the scope of the callback `f`
-pub fun borrowed/with-ptr(t: borrowed-c<s,t>, f: c-pointer<t> -> e a): e a
-  borrowed/with-ptr-extern(t, fn(i) f(C-pointer(i)))
 
 // !!!WARNING!!! Extremely UNSAFE API
 // Get the raw C pointer from a `borrowed-c` managed pointer to use immediately in an ffi function
 // This doesn't return a typed pointer, and accepts any boxed type as input, so it is very dangerous
 //   Use `borrowed/with-ptr` most of the time and
 //       `borrow/use-ffi-ptr` if directly passing to an safe ffi call
-pub extern unsafe-borrowed-ffi-ptr-extern<t>(c: b): intptr_t
+pub inline extern unsafe-borrowed-ffi-ptr-extern<t>(c: borrowed-c<s,t>): c-pointer<t>
   c inline "(kk_addr_t)kk_cptr_unbox_borrowed(#1, kk_context())"
 
 // !!!WARNING!!! UNSAFE API
@@ -163,46 +182,35 @@ pub extern unsafe-borrowed-ffi-ptr-extern<t>(c: b): intptr_t
 //   This is due borrowed pointers being guaranteed to be valid during their whole scope (the lambda enclosing the call to this method) 
 //   A similar api for `owned-c` is not possible since converting an owned pointer to a raw pointer could allow the owned pointer to be freed if this was its last use
 //   For owned pointers use `owned/with-ptr` instead
-pub fun borrow/use-ffi-ptr<t>(c: borrowed-c<s,t>): c-pointer<t>
-  C-pointer(c.unsafe-borrowed-ffi-ptr-extern)
+pub inline fun borrow/use-ffi-ptr<t>(c: borrowed-c<s,t>): c-pointer<t>
+  c.unsafe-borrowed-ffi-ptr-extern
 
 // Transform a koka `owned-c` managed pointer to an array into a C ptr pointing to the element at index `idx` of type `t` and size `size-of(cnull())`
 // Keeps the koka reference alive during the scope of the callback `f`
 // This is guaranteed due to be this being an external function (`f` is not inlineable), and `t` being borrowed
-extern offset/with-ptr(^t: b, idx: ssize_t, f: intptr_t -> e a, size-of: int32): e a
+pub inline extern offset/with-ptr(^t: owned-c<c-array<t>>, idx: ssize_t, f: c-pointer<t> -> e a, size-of: int32): e a
   c "kk_owned_with_ptr_idx"
 
 // Transform a koka `owned-c` managed pointer to an array into a C ptr pointing to the element at index `idx` of type `t` and size `size-of(cnull())`
 // Keeps the koka reference alive during the scope of the callback `f`
-pub fun c-array/with-ptr(t: owned-c<c-array<t>>, idx: ssize_t, f: forall<s> borrowed-c<s,t> -> e a, ?size-of: (c-null<t>) -> int32): e a
-  offset/with-ptr(t, idx, fn(p) c-borrow(C-pointer(p), f), size-of(cnull()))
+pub inline fun c-array/with-ptr(t: owned-c<c-array<t>>, idx: ssize_t, f: forall<s> borrowed-c<s,t> -> e a, ?size-of: (c-null<t>) -> int32): e a
+  offset/with-ptr(t, idx, fn(p) c-borrow(p, f), size-of(cnull()))
 
 // Transform an assumed pointer to a C string into a Koka string
 // Copies the memory
-extern ptr/to-string(ptr: intptr_t): string
+pub inline extern ptr/to-string(ptr: c-pointer<int8>): string
   c inline "kk_string_alloc_raw((const char *)#1, false, kk_context())"
-
-// Transform an unmanaged `c-pointer<int8>` into a Koka string
-// Copies the memory
-pub fun cptr/to-string(c: c-pointer<int8>): string
-  ptr/to-string(c.ptr)
 
 // Transform an assumed pointer to a C string of length len into a Koka string
 // Copies the memory
 // Assume the array is non-null terminated and adds the terminating character
-extern strlen-ptr/to-string(ptr: intptr_t, len: int64): string
-  c inline "kk_string_alloc_raw_buff(#2, (const char *)#1, false, kk_context())"
-
-// Transform an unmanaged `c-pointer<int8>` into a Koka string of length len
-// Copies the memory
-// Assume the array is non-null terminated and adds the terminating character
-pub fun cptr-len/to-string(c: c-pointer<int8>, len: int64): string
-  strlen-ptr/to-string(c.ptr, len)
+pub inline extern strlen-ptr/to-string(ptr: c-pointer<int8>, len: int64): string
+  c inline "kk_string_alloc_raw_buff(#2, (char *)#1, false, kk_context())"
 
 // Borrows the c pointer to a koka managed string for the duration of the callback `f`
-extern ptr/with-c-string(^s: string, f: intptr_t -> e a): e a
+inline extern ptr/with-c-string(^s: string, f: c-pointer<int8> -> e a): e a
   c "kk_with_c_string"
 
 // Borrows the c pointer to a koka managed string for the duration of the callback `f`
-pub fun cptr/with-c-string(^s: string, f: forall<s> borrowed-c<s,int8> -> e a): e a
-  with-c-string(s, fn(p) c-borrow(C-pointer(p), f))
+pub inline fun cptr/with-c-string(^s: string, f: forall<s> borrowed-c<s,int8> -> e a): e a
+  with-c-string(s, fn(p) c-borrow(p, f))

--- a/lib/std/core/cextern.kk
+++ b/lib/std/core/cextern.kk
@@ -2,59 +2,207 @@ module std/core/cextern
 
 import std/num/int32
 import std/core/types
+import std/core/int
 
 extern import
-  c file "inline/cextern.h"
+  c header-file "inline/cextern.h"
 
+// A managed koka pointer to C memory
+// Owned values can be freely passed around, captured in lambdas, escape their scope, etc.
 pub alias owned-c<t> = extern-owned<t>
+
+// A borrowed koka pointer to C memory during a scope s
+// Borrowed values are only guaranteed valid during their scope, should not escape the scope
+// For example an `owned-c<array<t>>` should only allow borrowed references to the middle of an array during a scope where the owned pointer will not be dropped
 pub alias borrowed-c<s::S,t> = extern-borrowed<t>
+
+// A raw pointer to C memory
+pub value struct c-pointer<t>
+  ptr: intptr_t
+
+// An opaque type to designate c-array types in Koka
 pub type c-array<t>
-pub alias c-null<t> = intptr_t
 
-pub inline extern cnull(): c-null<t>
-  c inline "(kk_addr_t)NULL"
+// A type alias for a null pointer of type `t`
+pub alias c-null<t> = c-pointer<t>
 
-pub fun array/malloc<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
-  int/malloc(n, size-of(cnull())).c-own
+// The null pointer in C
+pub inline fun cnull(): c-null<t>
+  C-pointer(0.intptr_t)
 
-pub fun single/malloc<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
-  int/malloc(1.int32, size-of(cnull())).c-own
-
-pub fun array/malloc-c<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
-  int/malloc-c(n, size-of(cnull())).c-own-free-calloc
-
-pub fun single/malloc-c<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
-  int/malloc-c(1.int32, size-of(cnull())).c-own-free-calloc
-
+// Allocate `n*size-of` bytes of memory using kk_malloc and return a pointer to the allocated memory
 extern int/malloc<t>(n: int32, size-of: int32): intptr_t
   c inline "(kk_addr_t)kk_malloc(#1*#2, kk_context())"
 
+// Allocate `n*size-of` bytes of memory using C's malloc and return a pointer to the allocated memory
 extern int/malloc-c<t>(n: int32, size-of: int32): intptr_t
   c inline "(kk_addr_t)malloc(#1*#2)"
 
-// Transform a c ptr into a managed koka value, which will be freed when koka's reference count reaches 0
-pub extern c-own<t>(c: intptr_t): owned-c<t>
+// Allocate a single element of type `t` using `kk_malloc` and return a managed pointer
+// Type `t` should:
+// - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
+// - Have a `size-of` function that returns the size of the structure in bytes
+pub fun single/malloc<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
+  int/malloc(1.int32, size-of(cnull())).c-own-extern
+
+// Allocate `n` elements of type `t` using `kk_malloc` and return a managed pointer to the array
+// Type `t` should:
+// - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
+// - Have a `size-of` function that returns the size of the structure in bytes
+pub fun array/malloc<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
+  int/malloc(n, size-of(cnull())).c-own-extern
+
+// Allocate a single element of type `t` using C's `malloc` and return a managed pointer
+// Type `t` should:
+// - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
+// - Have a `size-of` function that returns the size of the structure in bytes
+pub fun single/malloc-c<t>(?size-of: (c-null<t>) -> int32): owned-c<t>
+  int/malloc-c(1.int32, size-of(cnull())).c-own-free-calloc-extern
+
+// Allocate `n` elements of type `t` using C's `malloc` and return a managed pointer to the array
+// Type `t` should:
+// - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
+// - Have a `size-of` function that returns the size of the structure in bytes
+pub fun array/malloc-c<t>(n: int32, ?size-of: (c-null<t>) -> int32): owned-c<c-array<t>>
+  int/malloc-c(n, size-of(cnull())).c-own-free-calloc-extern
+
+// !!!WARNING!!! UNSAFE API
+// Allocate `n` elements of type `t` using `kk_malloc` and return a managed pointer to the array
+// Type `t` should:
+// - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
+// - Have a `size-of` function that returns the size of the structure in bytes
+//
+// NOTES:
+// Prefer using `array/malloc` or `single/malloc` instead of this function which return a managed pointer.
+// Raw `c-pointer<t>` should be used in low-level generated koka ffi functions since the pointer is unknown to be managed or not.
+// Conversion routines for `owned-c<t>` and `borrowed-c<s,t>` then should be used to get the raw pointers to be used in the ffi functions
+// Higher level apis to c libraries should then provide an interface using `owned-c<t>` and `borrowed-c<s,t>` instead of `c-pointer<t>`
+pub fun ptr/unsafe-malloc<t>(n: int32, ?size-of: (c-null<t>) -> int32): c-pointer<t>
+  C-pointer(int/malloc(n, size-of(cnull())))
+
+// !!!WARNING!!! UNSAFE API
+// Allocate `n` elements of type `t` using C's `malloc` and return a managed pointer to the array
+// Type `t` should:
+// - Be an opaque type in Koka corresponding to a C type (e.g. `pub type cstruct` with no members)
+// - Have a `size-of` function that returns the size of the structure in bytes
+//
+// NOTES:
+// Prefer using `array/malloc-c` or `single/malloc-c` instead of this function which return a managed pointer.
+// Raw `c-pointer<t>` should be used in low-level generated koka ffi functions since the pointer is unknown to be managed or not.
+// Conversion routines for `owned-c<t>` and `borrowed-c<s,t>` then should be used to get the raw pointers to be used in the ffi functions
+// Higher level apis to c libraries should then provide an interface using `owned-c<t>` and `borrowed-c<s,t>` instead of `c-pointer<t>`
+pub fun ptr/unsafe-malloc-c<t>(n: int32, ?size-of: (c-null<t>) -> int32): c-pointer<t>
+  C-pointer(int/malloc-c(n, size-of(cnull())))
+
+// Transform a C ptr into a managed koka value, which will be freed by `kk_free` when koka's reference count reaches 0
+extern c-own-extern(c: intptr_t): a
   c inline "kk_cptr_raw_box(&kk_free_fun, (void *)#1, kk_context())"
 
-// Transform a c ptr into a managed koka value, which will be freed when koka's reference count reaches 0
-pub extern c-own-free-calloc<t>(c: intptr_t): owned-c<t>
+// Transform a C ptr into a managed koka value, which will be freed by C's `free` when koka's reference count reaches 0
+extern c-own-free-calloc-extern(c: intptr_t): a
   c inline "kk_cptr_raw_box(&kk_free_calloc, (void *)#1, kk_context())"
 
-// Transform a c ptr into a koka value that holds the c reference without freeing it
-// The pointer should be valid
-pub extern c-borrow<t>(c: intptr_t, f: forall<s> borrowed-c<s,t> -> e a): e a
+// Transform a C ptr `c` into a koka value that holds the c reference without freeing it
+// The pointer should be valid for the duration of the callback `f`.
+extern c-borrow-extern(c: intptr_t, f: b -> e a): e a
   c "kk_borrow_ptr"
 
-// Transform a koka owned c value into a c ptr (keeping the koka reference alive during the scope of the function)
-pub extern owned/with-ptr(^t: owned-c<t>, f: intptr_t -> e a): e a
+// !!!WARNING!!!: Extremely unsafe API (needed for `c-borrow`), get approval to use anywhere else.
+extern unsafe-cast(b: b): a
+  c inline "#1"
+
+// Transform an unmanaged C ptr into a managed koka reference to C memory
+// Ensure the pointer is not going to be freed by C code, otherwise use `c-borrow` instead
+// Also ensure the memory was allocated using `kk_malloc`
+pub fun c-own<t>(t: c-pointer<t>): owned-c<t>
+  t.ptr.c-own-extern
+
+// Transform an unmanaged C ptr into a managed koka reference to C memory
+// Ensure the pointer is not going to be freed by C code, otherwise use `c-borrow` instead
+// Also ensure the memory was allocated using C's `malloc`
+pub fun c-own-free-calloc<t>(t: c-pointer<t>): owned-c<t>
+  t.ptr.c-own-free-calloc-extern
+
+// Transform an unmanaged C ptr into a borrowed koka reference to C memory
+// The pointer must be guaranteed to be valid for the duration of the callback `f`
+pub fun c-borrow<t>(c: c-pointer<t>, f: forall<s> borrowed-c<s,t> -> e a): e a
+  c-borrow-extern(c.ptr, fn(p) f(p.unsafe-cast()))
+
+// Transform a koka `owned-c` managed pointer into a C ptr 
+// Keeps the koka reference alive during the scope of the callback `f`
+extern owned/with-ptr-extern(^t: b, f: intptr_t -> e a): e a
   c "kk_owned_with_ptr"
 
-// Transform a koka owned value into a c ptr (keeping the koka reference alive during the scope of the function)
-pub extern borrowed/with-ptr(^t: borrowed-c<s,t>, f: intptr_t -> e a): e a
+// Transform a koka `owned-c` managed pointer into a C ptr 
+// Keeps the koka reference alive during the scope of the callback `f`
+pub fun owned/with-ptr(t: owned-c<t>, f: c-pointer<t> -> e a): e a
+  owned/with-ptr-extern(t, fn(p) f(C-pointer(p)))
+
+// Transform a koka `borrowed-c` managed pointer into a C ptr
+// Keeps the koka reference alive during the scope of the callback `f`
+extern borrowed/with-ptr-extern(^t: b, f: intptr_t -> e a): e a
   c "kk_borrowed_with_ptr"
 
-pub fun c-array/with-ptr(^t: owned-c<c-array<t>>, idx: ssize_t, f: forall<s> borrowed-c<s,t> -> e a, ?size-of: (c-null<t>) -> int32): e a
-  offset/with-ptr(t, idx, fn(p) c-borrow(p, f), size-of(cnull()))
+// Transform a koka `borrowed-c` managed pointer into a C ptr
+// Keeps the koka reference alive during the scope of the callback `f`
+pub fun borrowed/with-ptr(t: borrowed-c<s,t>, f: c-pointer<t> -> e a): e a
+  borrowed/with-ptr-extern(t, fn(i) f(C-pointer(i)))
 
-extern offset/with-ptr(^t: owned-c<c-array<t>>, idx: ssize_t, f: intptr_t -> e a, size-of: int32): e a
+// !!!WARNING!!! Extremely UNSAFE API
+// Get the raw C pointer from a `borrowed-c` managed pointer to use immediately in an ffi function
+// This doesn't return a typed pointer, and accepts any boxed type as input, so it is very dangerous
+//   Use `borrowed/with-ptr` most of the time and
+//       `borrow/use-ffi-ptr` if directly passing to an safe ffi call
+pub extern unsafe-borrowed-ffi-ptr-extern<t>(c: b): intptr_t
+  c inline "(kk_addr_t)kk_cptr_unbox_borrowed(#1, kk_context())"
+
+// !!!WARNING!!! UNSAFE API
+// Get the raw C pointer from an `borrowed-c` managed pointer to use immediately in an ffi function
+// Not safe to pass around Koka code
+// However, since an immediate use is still within the scope of the `borrowed-c` it is safe
+//   This is due borrowed pointers being guaranteed to be valid during their whole scope (the lambda enclosing the call to this method) 
+//   A similar api for `owned-c` is not possible since converting an owned pointer to a raw pointer could allow the owned pointer to be freed if this was its last use
+//   For owned pointers use `owned/with-ptr` instead
+pub fun borrow/use-ffi-ptr<t>(c: borrowed-c<s,t>): c-pointer<t>
+  C-pointer(c.unsafe-borrowed-ffi-ptr-extern)
+
+// Transform a koka `owned-c` managed pointer to an array into a C ptr pointing to the element at index `idx` of type `t` and size `size-of(cnull())`
+// Keeps the koka reference alive during the scope of the callback `f`
+// This is guaranteed due to be this being an external function (`f` is not inlineable), and `t` being borrowed
+extern offset/with-ptr(^t: b, idx: ssize_t, f: intptr_t -> e a, size-of: int32): e a
   c "kk_owned_with_ptr_idx"
+
+// Transform a koka `owned-c` managed pointer to an array into a C ptr pointing to the element at index `idx` of type `t` and size `size-of(cnull())`
+// Keeps the koka reference alive during the scope of the callback `f`
+pub fun c-array/with-ptr(t: owned-c<c-array<t>>, idx: ssize_t, f: forall<s> borrowed-c<s,t> -> e a, ?size-of: (c-null<t>) -> int32): e a
+  offset/with-ptr(t, idx, fn(p) c-borrow(C-pointer(p), f), size-of(cnull()))
+
+// Transform an assumed pointer to a C string into a Koka string
+// Copies the memory
+extern ptr/to-string(ptr: intptr_t): string
+  c inline "kk_string_alloc_raw((const char *)#1, false, kk_context())"
+
+// Transform an unmanaged `c-pointer<int8>` into a Koka string
+// Copies the memory
+pub fun cptr/to-string(c: c-pointer<int8>): string
+  ptr/to-string(c.ptr)
+
+// Transform an assumed pointer to a C string of length len into a Koka string
+// Copies the memory
+// Assume the array is non-null terminated and adds the terminating character
+extern strlen-ptr/to-string(ptr: intptr_t, len: int64): string
+  c inline "kk_string_alloc_raw_buff(#2, (const char *)#1, false, kk_context())"
+
+// Transform an unmanaged `c-pointer<int8>` into a Koka string of length len
+// Copies the memory
+// Assume the array is non-null terminated and adds the terminating character
+pub fun cptr-len/to-string(c: c-pointer<int8>, len: int64): string
+  strlen-ptr/to-string(c.ptr, len)
+
+// Borrows the c pointer to a koka managed string for the duration of the callback `f`
+extern ptr/with-c-string(^s: string, f: intptr_t -> e a): e a
+  c "kk_with_c_string"
+
+// Borrows the c pointer to a koka managed string for the duration of the callback `f`
+pub fun cptr/with-c-string(^s: string, f: forall<s> borrowed-c<s,int8> -> e a): e a
+  with-c-string(s, fn(p) c-borrow(C-pointer(p), f))

--- a/lib/std/core/inline/cextern.h
+++ b/lib/std/core/inline/cextern.h
@@ -25,3 +25,13 @@ kk_box_t kk_owned_with_ptr_idx(kk_box_t owned, kk_ssize_t idx, kk_function_t f, 
   kk_addr_t cptr_idx = (kk_addr_t)(cptr + (idx*size));
   return kk_function_call(kk_box_t,(kk_function_t,kk_addr_t,kk_context_t*), f, (f, cptr_idx, kk_context()), kk_context());
 }
+
+kk_string_t kk_string_alloc_raw_buff(kk_ssize_t len, char* s, bool free, kk_context_t* ctx){
+  s[len] = 0;
+  return kk_string_alloc_raw_len(len, s, free, ctx);
+}
+
+kk_box_t kk_with_c_string(kk_string_t s, kk_function_t f, kk_context_t* _ctx){
+  kk_addr_t cptr = (kk_addr_t)kk_string_cbuf_borrow(s, NULL, kk_context());
+  return kk_function_call(kk_box_t,(kk_function_t,kk_addr_t,kk_context_t*), f, (f, cptr, kk_context()), kk_context());
+}

--- a/lib/std/core/inline/cextern.h
+++ b/lib/std/core/inline/cextern.h
@@ -1,0 +1,27 @@
+// free memory using default C allocator
+void kk_free_calloc(void* p, kk_block_t* b, kk_context_t* _ctx) {
+  kk_unused(b);
+  kk_unused(_ctx);
+  free(p);
+}
+
+kk_box_t kk_owned_with_ptr(kk_box_t owned, kk_function_t f, kk_context_t* _ctx) {
+  kk_addr_t cptr = (kk_addr_t)kk_cptr_raw_unbox_borrowed(owned, kk_context());
+  return kk_function_call(kk_box_t,(kk_function_t,kk_addr_t,kk_context_t*), f, (f, cptr, kk_context()), kk_context());
+}
+
+kk_box_t kk_borrowed_with_ptr(kk_box_t borrowed, kk_function_t f, kk_context_t* _ctx) {
+  kk_addr_t cptr = (kk_addr_t)kk_cptr_unbox_borrowed(borrowed, kk_context());
+  return kk_function_call(kk_box_t,(kk_function_t,kk_addr_t,kk_context_t*), f, (f, cptr, kk_context()), kk_context());
+}
+
+kk_box_t kk_borrow_ptr(kk_addr_t cptr, kk_function_t f, kk_context_t* _ctx) {
+  kk_box_t ptr = kk_cptr_box((void *)cptr, kk_context());
+  return kk_function_call(kk_box_t,(kk_function_t,kk_box_t,kk_context_t*), f, (f, ptr, kk_context()), kk_context());
+}
+
+kk_box_t kk_owned_with_ptr_idx(kk_box_t owned, kk_ssize_t idx, kk_function_t f, int32_t size, kk_context_t* _ctx) {
+  uint8_t* cptr = (uint8_t*)kk_cptr_raw_unbox_borrowed(owned, kk_context());
+  kk_addr_t cptr_idx = (kk_addr_t)(cptr + (idx*size));
+  return kk_function_call(kk_box_t,(kk_function_t,kk_addr_t,kk_context_t*), f, (f, cptr_idx, kk_context()), kk_context());
+}

--- a/lib/std/core/inline/cextern.h
+++ b/lib/std/core/inline/cextern.h
@@ -1,37 +1,37 @@
 // free memory using default C allocator
-void kk_free_calloc(void* p, kk_block_t* b, kk_context_t* _ctx) {
+static void kk_free_calloc(void* p, kk_block_t* b, kk_context_t* _ctx) {
   kk_unused(b);
   kk_unused(_ctx);
   free(p);
 }
 
-kk_box_t kk_owned_with_ptr(kk_box_t owned, kk_function_t f, kk_context_t* _ctx) {
+static kk_box_t kk_owned_with_ptr(kk_box_t owned, kk_function_t f, kk_context_t* _ctx) {
   kk_addr_t cptr = (kk_addr_t)kk_cptr_raw_unbox_borrowed(owned, kk_context());
   return kk_function_call(kk_box_t,(kk_function_t,kk_addr_t,kk_context_t*), f, (f, cptr, kk_context()), kk_context());
 }
 
-kk_box_t kk_borrowed_with_ptr(kk_box_t borrowed, kk_function_t f, kk_context_t* _ctx) {
+static kk_box_t kk_borrowed_with_ptr(kk_box_t borrowed, kk_function_t f, kk_context_t* _ctx) {
   kk_addr_t cptr = (kk_addr_t)kk_cptr_unbox_borrowed(borrowed, kk_context());
   return kk_function_call(kk_box_t,(kk_function_t,kk_addr_t,kk_context_t*), f, (f, cptr, kk_context()), kk_context());
 }
 
-kk_box_t kk_borrow_ptr(kk_addr_t cptr, kk_function_t f, kk_context_t* _ctx) {
+static kk_box_t kk_borrow_ptr(kk_addr_t cptr, kk_function_t f, kk_context_t* _ctx) {
   kk_box_t ptr = kk_cptr_box((void *)cptr, kk_context());
   return kk_function_call(kk_box_t,(kk_function_t,kk_box_t,kk_context_t*), f, (f, ptr, kk_context()), kk_context());
 }
 
-kk_box_t kk_owned_with_ptr_idx(kk_box_t owned, kk_ssize_t idx, kk_function_t f, int32_t size, kk_context_t* _ctx) {
+static kk_box_t kk_owned_with_ptr_idx(kk_box_t owned, kk_ssize_t idx, kk_function_t f, int32_t size, kk_context_t* _ctx) {
   uint8_t* cptr = (uint8_t*)kk_cptr_raw_unbox_borrowed(owned, kk_context());
   kk_addr_t cptr_idx = (kk_addr_t)(cptr + (idx*size));
   return kk_function_call(kk_box_t,(kk_function_t,kk_addr_t,kk_context_t*), f, (f, cptr_idx, kk_context()), kk_context());
 }
 
-kk_string_t kk_string_alloc_raw_buff(kk_ssize_t len, char* s, bool free, kk_context_t* ctx){
+static kk_string_t kk_string_alloc_raw_buff(kk_ssize_t len, char* s, bool free, kk_context_t* ctx){
   s[len] = 0;
   return kk_string_alloc_raw_len(len, s, free, ctx);
 }
 
-kk_box_t kk_with_c_string(kk_string_t s, kk_function_t f, kk_context_t* _ctx){
+static kk_box_t kk_with_c_string(kk_string_t s, kk_function_t f, kk_context_t* _ctx){
   kk_addr_t cptr = (kk_addr_t)kk_string_cbuf_borrow(s, NULL, kk_context());
   return kk_function_call(kk_box_t,(kk_function_t,kk_addr_t,kk_context_t*), f, (f, cptr, kk_context()), kk_context());
 }

--- a/lib/std/core/types.kk
+++ b/lib/std/core/types.kk
@@ -101,6 +101,12 @@ pub value type float32
 // See `module std/core/vector` for vector operations.
 pub type vector<a>
 
+// The type of an external (i.e. C) value where the memory is owned and managed by koka's refcounting
+pub ref type extern-owned<t>
+
+// The type of an external (i.e. C) value where the memory is borrowed and managed by external code
+pub ref type extern-borrowed<t>
+
 // An any type. Used for external calls.
 pub type any
 

--- a/src/Backend/C/Box.hs
+++ b/src/Backend/C/Box.hs
@@ -375,6 +375,7 @@ cType tp
         -> CFun (map (cType . snd) pars) (cType res)
       TApp t ts
         -> cType t
+      TCon (TypeCon nm _) | nm == nameTpExternOwned || nm == nameTpExternBorrowed -> CBox
       TCon c
         -> CData
       TVar v

--- a/src/Backend/C/FromCore.hs
+++ b/src/Backend/C/FromCore.hs
@@ -1322,6 +1322,10 @@ cTypeCon c
          then CPrim "kk_integer_t"
         else if (name == nameTpString)
          then CPrim "kk_string_t"
+        else if (name == nameTpExternOwned)
+         then CPrim "kk_box_t"
+        else if (name == nameTpExternBorrowed)
+         then CPrim "kk_box_t"
         else if (name == nameTpVector)
          then CPrim "kk_vector_t"
         else if (name ==  nameTpEvv)

--- a/src/Backend/C/FromCore.hs
+++ b/src/Backend/C/FromCore.hs
@@ -1336,6 +1336,10 @@ cTypeCon c
          then CPrim "kk_ssize_t"
         else if (name == nameTpIntPtrT)
          then CPrim "intptr_t"
+        else if (name == nameTpCPointer)
+         then CPrim "intptr_t"
+        else if (name == nameTpCArray)
+         then CPrim "intptr_t"
         else if (name == nameTpFloat)
          then CPrim "double"
         else if (name == nameTpBool)

--- a/src/Backend/C/Parc.hs
+++ b/src/Backend/C/Parc.hs
@@ -1035,7 +1035,7 @@ extractDataDefType tp
 
 
 isBoxType :: Type -> Bool
-isBoxType (TCon (TypeCon name _))  = name == nameTpBox
+isBoxType (TCon (TypeCon name _))  = name == nameTpBox || name == nameTpExternBorrowed || name == nameTpExternOwned
 isBoxType (TVar _)                 = True
 isBoxType (TSyn _ _ tp)            = isBoxType tp
 isBoxType (TApp tp _)              = isBoxType tp

--- a/src/Common/NamePrim.hs
+++ b/src/Common/NamePrim.hs
@@ -132,6 +132,7 @@ module Common.NamePrim
           , makeTpHandled
           , nameTpHandled, nameTpHandled1, nameTpNHandled, nameTpNHandled1
           , nameTpMarker
+          , nameTpExternOwned, nameTpExternBorrowed
           {-
           , nameTpOperation, nameYieldOp
           , nameTpCps, nameTpYld, nameTpCont
@@ -402,6 +403,9 @@ nameByref       = coreTypesName "@byref"
 
 namePredHeapDiv = coreTypesName "hdiv"
 namePredEffDiv  = coreTypesName "ediv"
+
+nameTpExternOwned    = coreTypesName "extern-owned"
+nameTpExternBorrowed = coreTypesName "extern-borrowed"
 
 nameTpRef       = coreTypesName "ref"
 nameTpLocalVar  = coreTypesName "local-var"

--- a/src/Common/NamePrim.hs
+++ b/src/Common/NamePrim.hs
@@ -132,7 +132,7 @@ module Common.NamePrim
           , makeTpHandled
           , nameTpHandled, nameTpHandled1, nameTpNHandled, nameTpNHandled1
           , nameTpMarker
-          , nameTpExternOwned, nameTpExternBorrowed
+          , nameTpExternOwned, nameTpExternBorrowed, nameTpCPointer, nameTpCArray
           {-
           , nameTpOperation, nameYieldOp
           , nameTpCps, nameTpYld, nameTpCont
@@ -404,6 +404,8 @@ nameByref       = coreTypesName "@byref"
 namePredHeapDiv = coreTypesName "hdiv"
 namePredEffDiv  = coreTypesName "ediv"
 
+nameTpCPointer    = qualify (newModuleName "std/core/cextern") (newName "c-pointer")
+nameTpCArray    = qualify (newModuleName "std/core/cextern") (newName "c-array")
 nameTpExternOwned    = coreTypesName "extern-owned"
 nameTpExternBorrowed = coreTypesName "extern-borrowed"
 

--- a/test/cgen/extern.h
+++ b/test/cgen/extern.h
@@ -1,0 +1,3 @@
+typedef struct c_struct_s {
+  int xint;
+} c_struct_t;

--- a/test/cgen/extern.kk
+++ b/test/cgen/extern.kk
@@ -12,10 +12,10 @@ pub alias kstructb<s> = borrowed-c<s,c-struct>;
 pub extern size-of(c: c-null<c-struct>): int32
   c inline "sizeof(c_struct_t)"
 
-inline extern ptr/xint(s: intptr_t): int32
+inline extern ptr/xint(s: c-pointer<c-struct>): int32
   c inline "((c_struct_t*)#1)->xint"
  
-inline extern ptr/set-xint(s: intptr_t, x: int32): ()
+inline extern ptr/set-xint(s: c-pointer<c-struct>, x: int32): ()
   c inline "((c_struct_t*)#1)->xint = #2"
 
 pub fun kstructo(): kstructo
@@ -33,7 +33,7 @@ pub inline fun kstruct/xint(^s: kstructo): int32
 pub inline fun kstructb/xint(^s: kstructb<s>): int32
   s.with-ptr(xint)
 
-pub fun set-xintf(x: int32): ((intptr_t) -> ())
+pub fun set-xintf(x: int32): ((c-pointer<c-struct>) -> ())
   fn(p) set-xint(p, x)
 
 pub inline fun kstruct/set-xint(^s: kstructo, x: int32): ()

--- a/test/cgen/extern.kk
+++ b/test/cgen/extern.kk
@@ -1,0 +1,60 @@
+import std/core/cextern
+import std/num/int32
+
+extern import
+  c file "extern.h"
+
+pub type c-struct;
+pub alias kstructo = owned-c<c-struct>;
+pub alias kstructoa = owned-c<c-array<c-struct>>;
+pub alias kstructb<s> = borrowed-c<s,c-struct>;
+
+pub extern size-of(c: c-null<c-struct>): int32
+  c inline "sizeof(c_struct_t)"
+
+inline extern ptr/xint(s: intptr_t): int32
+  c inline "((c_struct_t*)#1)->xint"
+ 
+inline extern ptr/set-xint(s: intptr_t, x: int32): ()
+  c inline "((c_struct_t*)#1)->xint = #2"
+
+pub fun kstructo(): kstructo
+  malloc()
+
+pub fun kstructoc(): kstructo
+  malloc-c()
+
+pub fun kstruct-array(n: int): kstructoa
+  malloc(n.int32)
+
+pub inline fun kstruct/xint(^s: kstructo): int32
+  s.with-ptr(xint)
+
+pub inline fun kstructb/xint(^s: kstructb<s>): int32
+  s.with-ptr(xint)
+
+pub fun set-xintf(x: int32): ((intptr_t) -> ())
+  fn(p) set-xint(p, x)
+
+pub inline fun kstruct/set-xint(^s: kstructo, x: int32): ()
+  s.with-ptr(set-xintf(x))
+
+pub inline fun kstructb/set-xint(^s: kstructb<s>, x: int32): ()
+  s.with-ptr(set-xintf(x))
+
+fun main()
+  val s = kstructo()
+  set-xint(s, 42.int32)
+  println(xint(s))
+
+  val s2 = kstructoc()
+  set-xint(s2, 43.int32)
+  println(xint(s2))
+
+  val ss = kstruct-array(10)
+  for(10) fn(i)
+    ss.with-ptr(i.ssize_t) fn(b)
+      b.set-xint(i.int32)
+  for(10) fn(i)
+    ss.with-ptr(i.ssize_t) fn(b)
+      println(b.xint)


### PR DESCRIPTION
I've been thinking a bit about automated generation of C wrappers (along the lines of a port of Dart's ffigen), but of course first we need a way of managing external ffi resources in Koka. After searching in `kklib` for a bit, I found the `kk_cptr*` functions which don't currently have a corresponding Koka api. Here is an initial Koka api for these functions, allowing us to manage allocated C memory completely from Koka.