### PR TITLE
Add implicits hint

### DIFF
--- a/src/Type/Operations.hs
+++ b/src/Type/Operations.hs
@@ -15,7 +15,7 @@ module Type.Operations( instantiate
                       , freshTVar
                       , Evidence(..)
                       , freshSub
-                      , isOptionalOrImplicit, splitOptionalImplicit
+                      , isOptionalOrImplicit, splitOptionalImplicit, requiresImplicits
                       ) where
 
 
@@ -28,6 +28,11 @@ import Type.TypeVar
 import Core.Core as Core
 import Type.Assumption
 
+requiresImplicits :: Type -> [(Name, Type)]
+requiresImplicits tp
+  = case splitFunScheme tp of
+      Just (_ ,_, pars,_,_) -> filter (isImplicitParamName . fst) pars
+      _               -> []
 
 isOptionalOrImplicit :: (Name,Type) -> Bool
 isOptionalOrImplicit (pname,ptype)


### PR DESCRIPTION
Report missing implicit definitions when an implicit cannot be found, needed in all candidates.
Also hint to reorder implicit definitions prior to functions that need them.