### PR TITLE
Fix duplicate label issue, include index for duplicate effect labels

### DIFF
--- a/lib/std/core/hnd.kk
+++ b/lib/std/core/hnd.kk
@@ -199,7 +199,7 @@ pub inline extern @evv-at<e,h> ( i : ev-index ) : ev<h>  // pretend total; don't
 
 // (dynamically) find evidence insertion/deletion index in the evidence vector
 // The compiler optimizes `@evv-index` to a static index when apparent from the effect type.
-pub extern @evv-index<e::E,h>( htag : htag<h> ) : e ev-index
+pub extern @evv-index<e::E,h>( i: ev-index, htag : htag<h> ) : e ev-index
   c  "kk_evv_index"
   js "__evv_index"
 

--- a/lib/std/core/inline/hnd.c
+++ b/lib/std/core/inline/hnd.c
@@ -73,14 +73,18 @@ static kk_std_core_hnd__ev* kk_evv_as_vec(kk_evv_t evv, kk_ssize_t* len, kk_std_
 // }
 
 
-kk_ssize_t kk_evv_index( struct kk_std_core_hnd_Htag htag, kk_context_t* ctx ) {
+kk_ssize_t kk_evv_index(int32_t index, struct kk_std_core_hnd_Htag htag, kk_context_t* ctx ) {
   // todo: drop htag?
   kk_ssize_t len;
+  kk_ssize_t off = index;
   kk_std_core_hnd__ev single;
   kk_std_core_hnd__ev* vec = kk_evv_as_vec(ctx->evv,&len,&single,ctx);
   for(kk_ssize_t i = 0; i < len; i++) {
     struct kk_std_core_hnd_Ev* ev = kk_std_core_hnd__as_Ev(vec[i],ctx);
-    if (kk_string_cmp_borrow(htag.tagname,ev->htag.tagname,ctx) <= 0) return i; // break on insertion point
+    if (kk_string_cmp_borrow(htag.tagname,ev->htag.tagname,ctx) <= 0) {
+      if (off == 0) return i; // break on insertion point
+      off--; // adjust for duplicate label
+    }
   }
   //string_t evvs = kk_evv_show(dup_datatype_as(kk_evv_t,ctx->evv),ctx);
   //fatal_error(EFAULT,"cannot find tag '%s' in: %s", string_cbuf_borrow(htag.htag), string_cbuf_borrow(evvs));

--- a/lib/std/core/inline/hnd.h
+++ b/lib/std/core/inline/hnd.h
@@ -114,7 +114,7 @@ static inline kk_evv_t kk_evv_swap_create1(kk_ssize_t i, kk_context_t* ctx) {
 }
 
 struct kk_std_core_hnd_Htag;
-kk_ssize_t      kk_evv_index( struct kk_std_core_hnd_Htag htag, kk_context_t* ctx );
+kk_ssize_t      kk_evv_index(int32_t index, struct kk_std_core_hnd_Htag htag, kk_context_t* ctx );
 kk_evv_t        kk_evv_create(kk_evv_t evv, kk_vector_t indices, kk_context_t* ctx);
 kk_evv_t        kk_evv_insert(kk_evv_t evv, kk_std_core_hnd__ev_t ev, kk_context_t* ctx);
 kk_evv_t        kk_evv_delete(kk_evv_t evv, kk_ssize_t index, bool behind, kk_context_t* ctx);

--- a/src/Backend/JavaScript/FromCore.hs
+++ b/src/Backend/JavaScript/FromCore.hs
@@ -891,7 +891,7 @@ genExprExternal tname formats argDocs0
          Nothing -> return (decls,doc)
          Just (pars,eff,res)
            -> let (ls,tl) = extractOrderedEffect eff
-              in case filter (\l -> labelName l == nameTpPartial) ls of
+              in case filter (\l -> labelName l == nameTpPartial) (map snd ls) of
                    [] -> return (decls,doc)
                    _  -> -- has an exception type, wrap it in a try handler
                          let try = parens $

--- a/src/Compile/BuildContext.hs
+++ b/src/Compile/BuildContext.hs
@@ -431,7 +431,7 @@ completeMain addShow exprName tp buildc
       Just (_,_,_,eff,resTp)
         -> let (ls,_) = extractHandledEffect eff  -- only effect that are in the evidence vector
            in do print    <- printExpr resTp
-                 (mainBody,extraImports) <- addDefaultHandlers rangeNull eff ls [] callExpr
+                 (mainBody,extraImports) <- addDefaultHandlers rangeNull eff (map snd ls) [] callExpr
                  return (resTp,print,mainBody,extraImports)
       _ -> return (tp, id, callExpr, []) -- todo: given an error?
   where

--- a/src/Core/Check.hs
+++ b/src/Core/Check.hs
@@ -299,7 +299,7 @@ matchSubEff when fdoc eff1 eff2
         (ls2,tl2) = extractHandledEffect eff2
     in if (length ls1 /= length ls2)
         then showCheck "handled effects do not match" when eff1 eff2 fdoc
-        else do sequence_ [match when fdoc targ1 targ2 | (targ1,targ2) <- zip ls1 ls2]
+        else do sequence_ [match when fdoc targ1 targ2 | (targ1,targ2) <- zip (map snd ls1) (map snd ls2)]
                 return ()
 
 

--- a/src/Type/InferMonad.hs
+++ b/src/Type/InferMonad.hs
@@ -308,7 +308,7 @@ isolate rng free ps eff  | src `endsWith` "std/core/hnd.kk"
 isolate rng free ps eff
   = -- trace ("isolate: " ++ show eff ++ " with free " ++ show (tvsList free)) $
     let (ls,tl) = extractOrderedEffect eff
-    in case filter (\l -> labelName l `elem` [nameTpLocal,nameTpRead,nameTpWrite]) ls of
+    in case filter (\l -> labelName l `elem` [nameTpLocal,nameTpRead,nameTpWrite]) (map snd ls) of
           (lab@(TApp labcon [TVar h]) : _)
             -> -- has heap variable 'h' in its effect
                do -- trace ("isolate:" ++ show (sourceName (rangeSource rng)) ++ ": " ++ show (pretty eff)) $ return ()
@@ -441,7 +441,7 @@ normalizeX close free tp
 nicefyEffect :: Effect -> Inf Effect
 nicefyEffect eff
   = do let (ls,tl) = extractOrderedEffect eff
-       ls' <- matchAliases [nameTpIO, nameTpST, nameTpPure, nameTpAsyncX] ls
+       ls' <- matchAliases [nameTpIO, nameTpST, nameTpPure, nameTpAsyncX] (map snd ls)
        return (foldr (\l t -> TApp (TCon tconEffectExtend) [l,t]) tl ls') -- cannot use effectExtends since we want to keep synonyms
   where
     matchAliases :: [Name] -> [Tau] -> Inf [Tau]
@@ -465,7 +465,7 @@ nicefyEffect eff
                  in if (null ls2 || not (isEffectEmpty tl2))
                      then return ([],ls)
                      else let params      = synInfoParams syn
-                              (sls,insts) = findInsts params ls2 ls
+                              (sls,insts) = findInsts params (map snd ls2) ls
                           in -- Lib.Trace.trace ("* try alias: " ++ show (synInfoName syn, ls, sls)) $
                              case (isSubset [] sls ls) of
                                 Just rest

--- a/src/Type/Kind.hs
+++ b/src/Type/Kind.hs
@@ -23,7 +23,7 @@ import Type.Type
 effectIsAffine :: Effect -> Bool
 effectIsAffine eff
   = let (labs,tl) = extractOrderedEffect eff
-    in (isEffectEmpty tl && all labelIsAffine labs)
+    in (isEffectEmpty tl && all (\l -> labelIsAffine (snd l)) labs)
 
 
 labelIsLinear :: Effect -> Bool
@@ -66,10 +66,10 @@ containsHandledEffect eff
     not $ null $ fst $ extractHandledEffect eff
 
 -- Get the effects that are reflected in the evidence vector
-extractHandledEffect :: Type -> ([Type], Tau)
+extractHandledEffect :: Type -> ([(Int, Type)], Tau)
 extractHandledEffect eff
   = let (ls,tl) = extractOrderedEffect eff
-    in (filter isHandledEffect ls, tl)
+    in (filter (\l -> isHandledEffect (snd l)) ls, tl)
 
 -- Is an effect reflected in the evidence vector?
 isHandledEffect :: Type -> Bool

--- a/src/Type/Operations.hs
+++ b/src/Type/Operations.hs
@@ -97,7 +97,7 @@ extend tp
         -> let (ls,tl) = extractOrderedEffect eff
            in if isEffectEmpty tl
                then do tv <- freshTVar kindEffect Meta
-                       let openEff = effectExtends ls tv
+                       let openEff = effectExtends (map snd ls) tv
                            openTp  = TFun args openEff res
                        -- return (openTp, id)
                        return (openTp, \core -> Core.openEffectExpr eff openEff tp openTp core)

--- a/src/Type/Unify.hs
+++ b/src/Type/Unify.hs
@@ -451,7 +451,8 @@ unifyEffect tp1 tp2
 extractNormalizeEffect :: Type -> Unify ([Type],Type)
 extractNormalizeEffect tp
   = do tp' <- subst tp
-       return $ extractOrderedEffect tp'
+       let (tps, ex) = extractOrderedEffect tp'
+       return (map snd tps, ex)
 
 
 unifyEffectVar tv1 tp2
@@ -461,7 +462,7 @@ unifyEffectVar tv1 tp2
            -> -- trace ("unifyEffectVar: " ++ show tv1 ++ ":=" ++ show tp2 ++ " is infinite") $
                  unifyError Infinite
          _ -> do -- tv <- freshTVar kindEffect Meta
-                 unifyTVar tv1 (effectExtends ls2 tl2)
+                 unifyTVar tv1 (effectExtends (map snd ls2) tl2)
 
 
 -- | Unify lists of ordered labels; return the differences.


### PR DESCRIPTION
Fixes #511 

@daanx, I understand if you would like to redo this yourself to make it cleaner, but this should illustrate the issue / solution.

Specifically `@evv-index` does not include an index for duplicate labels. This is fine for most effect expressions, since the effect row is incrementally adjusted. However, for the general `open` case where you use a vector of indices and there are multiple labels of the same kind, we get invalid offsets. This would happen with or without the code in `Simplify.hs` which turns them into constant offsets. 

In general I think the types for effect rows need to represent duplicate label indices more explicitly (when extracting the ordered effect), so I defaulted to including the count of duplicate labels (pseudo index) in `extractOrderedEffect`. However, the indices aren't really important till after type checking, so there are a lot of places where I needed to discard the indices. I don't know if you would rather do something to represent this invariant more explicitly in the type, or if you would rather create another function for when you don't care about indices, since there are only a few places that do.

In particular the issue is illustrated by the following short code snippet from the core output. (from the example in #511)
```koka
(std/core/hnd/@open1(
                        (std/core/vector/unvlist(
                       // Here is the problem both of these indices are the same!!!!
                        (std/core/types/Cons((std/core/types/@make-ssize_t(0)), 
                        (std/core/types/Cons((std/core/types/@make-ssize_t(0)), 
                        std/core/types/Nil)))))
```