### PR TITLE
Create an overload for function fields to directly call the function

### DIFF
--- a/lib/std/time/instant.kk
+++ b/lib/std/time/instant.kk
@@ -105,15 +105,15 @@ fun convert( t : timestamp, from : timescale, to : timescale ) : timestamp
   else
     // transform through TAI
     // trace( "convert: " + from.name + " -> " + to.name +  ", t: " + t.show )
-    (to.from-tai)( (from.to-tai)(t) )
+    to.call/from-tai( from.call/to-tai(t) )
 
 
 // Return the `:duration` since the `epoch` for a timestamp `t` interpreted in time scale `ts`.
-pub fun to-tai(  ts : timescale, t : timestamp ) : duration
+pub fun pub/to-tai(  ts : timescale, t : timestamp ) : duration
   t.convert(ts,ts-tai).unsafe-duration
 
 // Given a `:duration` since the `epoch`, return a `:timespan` for that instant in time scale `ts`.
-pub fun from-tai(ts : timescale, d : duration ) : timestamp
+pub fun pub/from-tai(ts : timescale, d : duration ) : timestamp
   d.timestamp.convert(ts-tai,ts)
 
 /*----------------------------------------------------------------------------

--- a/src/Common/Name.hs
+++ b/src/Common/Name.hs
@@ -48,7 +48,7 @@ module Common.Name
           , toImplicitParamName, isImplicitParamName, splitImplicitParamName
           , fromImplicitParamName
 
-          , prepend, postpend
+          , prepend, postpend, addLocalPostfix
           , asciiEncode, moduleNameToPath, pathToModuleName
           -- , canonicalSep, canonicalName, nonCanonicalName, canonicalSplit
 
@@ -301,7 +301,13 @@ nameMapStem :: Name -> (String -> String) -> Name
 nameMapStem (Name m hm l hl n _) f
   = let fn = f n in Name m hm l hl fn (hash fn)
 
+nameMapLocal :: Name -> (String -> String) -> Name
+nameMapLocal (Name m hm l hl n hn) f
+  = let fl = f l in Name m hm fl (hash fl) n hn
 
+addLocalPostfix :: Name -> String -> Name
+addLocalPostfix nm postfix
+  = nameMapLocal nm $ \l -> join l postfix
 
 readQualifiedName :: String -> Name
 readQualifiedName ('?':s)
@@ -580,7 +586,6 @@ postpend post name
   = nameMapStem name $ \stem ->
     let (xs,ys) = span (\c -> c=='?' || c=='\'') (reverse stem)
     in reverse (xs ++ reverse post ++ ys)
-
 
 ----------------------------------------------------------------
 -- hidden names

--- a/test/algeff/open2.kk.out
+++ b/test/algeff/open2.kk.out
@@ -1,6 +1,7 @@
 42
  
-algeff/open2/func/f: forall<e> (func : func<e>) -> ((int) -> e int)
+algeff/open2/func/call/f: forall<e> (func : func<e>, int) -> e int
+algeff/open2/func/get/f: forall<e> (func : func<e>) -> ((int) -> e int)
 algeff/open2/Func: forall<e> (f : (int) -> e int) -> func<e>
 algeff/open2/bar: () -> int
 algeff/open2/main: () -> console ()

--- a/test/type/fn-field.kk
+++ b/test/type/fn-field.kk
@@ -1,6 +1,11 @@
 struct fn-field
   xrun: (string) -> io ()
+  funx: (?name: string) -> io ()
+  noarg: () -> io ()
 
 fun main()
-  val f = Fn-field(fn(s) println(s))
+  val f = Fn-field(fn(s) println(s), fn(?name) println("Hello, " ++ name), fn() println("No arg"))
   f.xrun("Hello, World!")
+  val name = "John"
+  f.funx()
+  f.call/noarg()

--- a/test/type/fn-field.kk
+++ b/test/type/fn-field.kk
@@ -1,0 +1,6 @@
+struct fn-field
+  xrun: (string) -> io ()
+
+fun main()
+  val f = Fn-field(fn(s) println(s))
+  f.xrun("Hello, World!")

--- a/test/type/fn-field.kk.out
+++ b/test/type/fn-field.kk.out
@@ -1,4 +1,8 @@
+type/fn-field/fn-field/call/funx: (fn-field, ?name : string) -> io ()
+type/fn-field/fn-field/call/noarg: (fn-field) -> io ()
 type/fn-field/fn-field/call/xrun: (fn-field, string) -> io ()
+type/fn-field/fn-field/get/funx: (fn-field) -> ((?name : string) -> io ())
+type/fn-field/fn-field/get/noarg: (fn-field) -> (() -> io ())
 type/fn-field/fn-field/get/xrun: (fn-field) -> ((string) -> io ())
-type/fn-field/Fn-field: (xrun : (string) -> io ()) -> fn-field
+type/fn-field/Fn-field: (xrun : (string) -> io (), funx : (?name : string) -> io (), noarg : () -> io ()) -> fn-field
 type/fn-field/main: () -> io ()

--- a/test/type/fn-field.kk.out
+++ b/test/type/fn-field.kk.out
@@ -1,0 +1,4 @@
+type/fn-field/fn-field/call/xrun: (fn-field, string) -> io ()
+type/fn-field/fn-field/get/xrun: (fn-field) -> ((string) -> io ())
+type/fn-field/Fn-field: (xrun : (string) -> io ()) -> fn-field
+type/fn-field/main: () -> io ()

--- a/test/type/inf1.kk
+++ b/test/type/inf1.kk
@@ -4,7 +4,7 @@ pub value struct linear-set<v>
   eq: some<e> (v, v) -> e bool
 
 pub fun val/(+)(l: linear-set<v>, a: v) : e linear-set<v>
-  if (l.list.any(fn(x) (l.eq)(x, a))) then l else l(list=Cons(a, l.list))
+  if (l.list.any(fn(x) l.eq(x, a))) then l else l(list=Cons(a, l.list))
 
 pub fun set/(+)(l1: linear-set<v>, l2: linear-set<v>) : e linear-set<v>
   l2.list.foldl(l1, fn(acc, x) acc + x)

--- a/test/type/inf1.kk.out
+++ b/test/type/inf1.kk.out
@@ -1,4 +1,5 @@
-type/inf1/linear-set/eq: forall<a,e> (linear-set<a>) -> ((a, a) -> e bool)
+type/inf1/linear-set/call/eq: forall<a> (linear-set<a>, a, a) -> bool
+type/inf1/linear-set/get/eq: forall<a,e> (linear-set<a>) -> ((a, a) -> e bool)
 type/inf1/linear-set/list: forall<a> (linear-set<a>) -> list<a>
 type/inf1/set/(+): forall<e,a> (l1 : linear-set<a>, l2 : linear-set<a>) -> e linear-set<a>
 type/inf1/val/(+): forall<e,a> (l : linear-set<a>, a : a) -> e linear-set<a>


### PR DESCRIPTION
Generates another function to access and directly call a function field of a type.

This gets rid of the weird `mystruct.func()()` when getting and then directly calling a function.

I still generate the plain accessors with a locally qualified prefix `thetype/get/function-field`, and generate the caller with the locally qualified prefix `typetype/call/function-field`, this way for no-arg functions you can use `mystruct.call/func()` when the result type doesn't disambiguate.