### PR TITLE
fix recursive effects #483

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -140,7 +140,7 @@ runKoka cfg kokaDir fp
          else do let stackFlags = if (sysghc (options cfg)) then ["--system-ghc","--skip-ghc-check"] else []
                      argv = ["exec","koka"] ++ stackFlags ++ ["--"] ++ kokaFlags ++ [relTest]
                  (exitCode, stdout, stderr) <- readProcessWithExitCode "stack" argv ""
-                 -- putStrLn stdout
+                --  putStrLn (stdout ++ "\n" ++ stderr)
                  return (testSanitize kokaDir stdout)
 
 

--- a/test/kind/rec-effect.kk
+++ b/test/kind/rec-effect.kk
@@ -1,0 +1,4 @@
+// https://github.com/koka-lang/koka/issues/483
+// Thanks @hflsmax for the report
+rec effect process
+  fun fork(p: () -> <process> ()): ()

--- a/test/kind/rec-effect.kk.out
+++ b/test/kind/rec-effect.kk.out
@@ -1,0 +1,1 @@
+process : (E, V) -> V


### PR DESCRIPTION
Fixes #483

DataInfo is requested to get dataEffect in kind inference, to make a handled effect type with the correct linearity / named information.

However, for recursive effect type declarations we don't have the dataInfo yet for the type in the definition since we are in the process of inferring it. So we need to add the dataEffects for the mutually recursive type definition group prior to inferring them. This makes that change.