### PR TITLE
handle `/etc/*-release` being a directory, not just a file

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -110,7 +110,7 @@ detect_osarch() {
   OSARCH="$OSNAME-$arch"
 
   if [ "$OSNAME" = "linux" ]; then
-    distrocfg=`cat /etc/*-release`
+    distrocfg=`cat $(find /etc/*-release -type f)`
     if contains "$distrocfg" "rhel"; then
       OSDISTRO="rhel"
     elif contains "$distrocfg" "opensuse"; then


### PR DESCRIPTION
Linux Mint 21.3 defines a few files that match `/etc/*-release`:
```
$ ls /etc/*-release
/etc/lsb-release  /etc/os-release

/etc/upstream-release:
lsb-release
```

One of these is a directory which causes the initialization of `distrocfg` when running `install.sh` to produce an error:
```
cat: /etc/upstream-release: Is a directory
```

While it looks like this error is somewhat spurious (a correct file does get cat'ed), it is misleading. Using `find` looks for a file that `cat` can handle so if an error is produced, no release file could be found.

I have not tested this on other distributions though I'd expect it to work. Famous last words, I know.