### PR TITLE
Variable _host should be exported

### DIFF
--- a/lib/std/core/inline/console.js
+++ b/lib/std/core/inline/console.js
@@ -9,7 +9,7 @@
 // internal exports
 const $std_core_console = { "_host": _host, "_trace": _trace }
 
-var _host = "unknown"
+export var _host = "unknown"
 
 if (typeof window !== 'undefined' && window.document) {
   _host = "browser";


### PR DESCRIPTION
`_host` is a global variable that's used for determining the platform from JavaScript code. It's used from other JavaScript files besides `console.js` and therefore should be exported. I found this trying when trying to execute `test/async/async1.kk` on @TimWhiting's fork with `async.kk`.