### PR TITLE
Add support to read lines longer than 1023 bytes

### DIFF
--- a/kklib/src/bytes.c
+++ b/kklib/src/bytes.c
@@ -152,8 +152,16 @@ kk_ssize_t kk_decl_pure kk_bytes_count_pattern_borrow(kk_bytes_t b, kk_bytes_t p
 kk_bytes_t kk_bytes_cat(kk_bytes_t b1, kk_bytes_t b2, kk_context_t* ctx) {
   kk_ssize_t len1;
   const uint8_t* s1 = kk_bytes_buf_borrow(b1, &len1, ctx);
+  if(len1 == 0) {
+    kk_bytes_drop(b1, ctx);
+    return b2;
+  }
   kk_ssize_t len2;
   const uint8_t* s2 = kk_bytes_buf_borrow(b2, &len2, ctx);
+  if(len2 == 0) {
+    kk_bytes_drop(b2, ctx);
+    return b1;
+  }
   uint8_t* p;
   kk_bytes_t t = kk_bytes_alloc_buf(len1 + len2, &p, ctx );
   kk_memcpy(p, s1, len1);


### PR DESCRIPTION
This pull request includes changes to improve the handling of empty byte sequences in `kk_bytes_cat` and the reading of lines from standard input in `kk_os_read_line`.

### Enhancements to `kk_os_read_line` function:
* Added support to read lines longer than 1023 bytes. Achieved by concatenating 1024-byte chunks until new-line or EOF is reached.
* Fixes problem #571.
* Remove redundant call to `strlen` by allocating string with `kk_string_alloc_from_qutf8n` instead of `kk_string_alloc_from_qutf8`.
* Other small improvements.
(`kklib/src/os.c`)

### Improvements to `kk_bytes_cat` function:
* Added checks to handle cases where either of the byte sequences is empty, such that the function returns the non-empty sequence and drops the empty one. Leads to an early return in these cases.
(`kklib/src/bytes.c`)

### Considerations
* Runtime for `kk_os_read_line` can degrade to `O(n^2)` for **extremely** long lines. However, this seems very unlikely, and I believe this to be a lesser issue than lines being incomplete for lengths `>1023` bytes. To solve this we would have to scale `buf` by a factor `>1` for each iteration in the loop, which can not be done safely on the stack. Thus it's hard to find a balance between solution complexity, constant overhead and algorithmic complexity. My approach prioritizes solution complexity and constant overhead as it stays true to the previous approach. An approach prioritizing solution complexity and algorithmic complexity can be achieved using the `POSIX`/[Dynamic Memory TR](https://en.cppreference.com/w/c/experimental/dynamic/getline) `getline(3)` function.