### PR TITLE
fix cpp/java benchmark program: wrong output due to logic error

### DIFF
--- a/test/bench/cpp/deriv.cpp
+++ b/test/bench/cpp/deriv.cpp
@@ -96,10 +96,10 @@ static const Expr* mul( const Expr* x, const Expr* y ) {
     return new ValExpr(((ValExpr*)x)->value * ((ValExpr*)y)->value);
   }
   else if (x->kind==Val && ((ValExpr*)x)->value==0) {
-    return x;
+    return new ValExpr(0);
   }
   else if (y->kind==Val && ((ValExpr*)y)->value==0) {
-    return y;
+    return new ValExpr(0);
   }
   else if (x->kind==Val && ((ValExpr*)x)->value==1) {
     return y;

--- a/test/bench/java/deriv.java
+++ b/test/bench/java/deriv.java
@@ -93,10 +93,10 @@ public class deriv {
       return new ValExpr( a.value * b.value );
     }
     else if (x instanceof ValExpr a && a.value == 0) {
-      return x;
+      return new ValExpr(0);
     }
     else if (y instanceof ValExpr b && b.value == 0) {
-      return y;
+      return new ValExpr(0);
     }
     else if (x instanceof ValExpr a && a.value == 1) {
       return y;
@@ -110,7 +110,7 @@ public class deriv {
     else if (x instanceof ValExpr a && y instanceof MulExpr b && b.left instanceof ValExpr bl) {
       return mul(new ValExpr(a.value * bl.value), b.right);
     }
-    else if (y instanceof MulExpr b && b.left instanceof MulExpr) {
+    else if (y instanceof MulExpr b && b.left instanceof ValExpr) {
       return mul(b.left, mul(x,b.right));
     }
     else if (x instanceof MulExpr a) {


### PR DESCRIPTION
The C++/Java program for the `deriv` benchmark produces wrong output, due to logical error in several pattern match cases. This PR fixes the benchmark programs.

I re-run the benchmark locally, the overall result is unchanged compared to the figures in README.

BTW: I notice that the C++/Java version of `deriv` performs more sharing than the Koka/OCaml version in some cases. For example in this case:
```
    (f,Val(n))             -> add(Val(n),f)
```
the `Val(n)` node is reused directly in C++/Java. This seems a bit unfair? It should not impact benchmark result a lot though, due to Koka's FBIP/OCaml's bump allocation.