### PR TITLE
Add a lazy string builder

### DIFF
--- a/lib/std/core/stringb.kk
+++ b/lib/std/core/stringb.kk
@@ -1,0 +1,174 @@
+import std/core/string
+import std/core/types
+import std/core/lazy
+import std/core/undiv
+import std/core/int
+
+pub infixr 60  (|.|)
+pub infixr 60  (|-|)
+pub infixr 60  (\)
+pub infixr 60  (\-)
+
+// A string builder allows processing a concatenated string one piece at a time
+//    without waiting for the rest to be appended / generated.
+// As such it is like a list of strings but: 
+//   1. Will convert polymorphic values to strings
+//     - only when / as needed
+//     - ensuring a short lifetime for the converted string values (for unique references to the builder)
+//     - only converting once (for non-unique references to the builder)
+//   2. Will concat two string builders incrementally
+// 
+// For example this datastructure is useful for writing to a file
+//   where we can start writing the first part of the string (?async) while the rest is still being processed. 
+// Also it is useful in places like debug output / assert strings
+//   where we can specify how to build the debug string, without taking up processing to build it eagerly (in case the assertion is not triggered)
+// 
+// The string builder has some pretty-printing ability as well with newlines and indentation handled specially
+// Additionally spaces are handled specially so that they don't need to be materialized as values until the string is demanded.
+type stringb
+  SDone 
+  // Denotes a partially built string with the first part ready
+  SStep( str: string, acc: stringb)
+  SIndent( acc: stringb )
+  SNewline( acc : stringb )
+  SSpace( acc : stringb )
+  SUnindent( acc : stringb )
+  
+  lazy SBuilderString(a: string, b : stringb) -> 
+    match b
+      SDone -> SStep(a, SDone)
+      // TODO: Optimize so we allocate the right buffer for the strings, and then just do a low level copy of the data
+      SStep(s1, acc) -> SStep(a, SStep(s1, acc))
+      SIndent(acc) -> SStep(a, SIndent(acc))
+      SUnindent(acc) -> SStep(a, SUnindent(acc))
+      SNewline(acc) -> SStep(a, SNewline(acc))
+      SSpace(acc) -> SStep(a, SSpace(acc))
+
+  // Delays conversion until the string is actually needed
+  lazy SBuilderAny<a>( a: a, b: stringb, show: (a) -> string) ->
+    match b  // TODO: Split strings on newlines?
+      SDone -> SStep(show(a), SDone)
+      SStep(s1, acc) -> SStep(show(a), SStep(s1, acc))
+      SIndent(acc) -> SStep(show(a), SIndent(acc))
+      SUnindent(acc) -> SStep(show(a), SUnindent(acc))
+      SNewline(acc) -> SStep(show(a), SNewline(acc))
+      SSpace(acc) -> SStep(show(a), SSpace(acc))
+  
+  // Delays the concatenation 
+  lazy SBuilderConcat(str : stringb, str2: stringb) ->
+    match str
+      SDone -> str2
+      SIndent(acc) -> SIndent(SBuilderConcat(acc, str2))
+      SUnindent(acc) -> SUnindent(SBuilderConcat(acc, str2))
+      SNewline(acc) -> SNewline(SBuilderConcat(acc, str2))
+      SSpace(acc) -> SSpace(SBuilderConcat(acc, str2))
+      SStep(s1, acc) -> 
+        match acc
+          SDone -> SStep(s1, str2)
+          SIndent(acc2) -> SStep(s1, SIndent(SBuilderConcat(acc2, str2)))
+          SUnindent(acc2) -> SStep(s1, SUnindent(SBuilderConcat(acc2, str2)))
+          SNewline(acc2) -> SStep(s1, SNewline(SBuilderConcat(acc2, str2)))
+          SSpace(acc2) -> SStep(s1, SSpace(SBuilderConcat(acc2, str2)))
+          SStep(s2, acc2) -> SStep(s1, SStep(s2, SBuilderConcat(acc2, str2))) 
+
+// Concatenates two string builders with no space between
+inline fun builder/(|.|)(a: stringb, b: stringb) : stringb
+  SBuilderConcat(a, b)
+
+// Concatenates two string builders with a space between
+inline fun builder/(|-|)(a: stringb, b: stringb) : stringb
+  SBuilderConcat(a, SSpace(b))
+
+// Concatenates two string builders with a newline between
+inline fun builder/(\)(a: stringb, b: stringb) : stringb
+  SBuilderConcat(a, SNewline(b))
+
+// Concatenates two string builders with a newline and indented block
+inline fun builder/(\-)(a: stringb, b: stringb) : stringb
+  SBuilderConcat(a, SIndent(SNewline(b)))
+
+// Concatenates a string and a string builder with no space between
+inline fun string/(|.|)(a: string, b: stringb) : stringb
+  SBuilderString(a, b)
+
+// Concatenates a string and a string builder with a space between
+inline fun stringb/(|-|)(a: string, b: stringb) : stringb
+  SBuilderString(a, SSpace(b))
+
+// Concatenates a string and a string builder with a newline between
+inline fun stringb/(\)(a: string, b: stringb) : stringb
+  SBuilderString(a, SNewline(b))
+
+// Concatenates a string and a string builder with a newline and indented block
+inline fun stringb/(\-)(a: string, b: stringb) : stringb
+  SBuilderString(a, SIndent(SNewline(b)))
+
+// Concatenates any value and a string builder with no space between
+inline fun any/(|.|)(a: a, s: stringb, ?show: (a) -> string) : stringb
+  SBuilderAny(a, s, ?show)
+
+// Concatenates any value and a string builder with a space between
+inline fun any/(|-|)(a: a, s: stringb, ?show: (a) -> string) : stringb
+  SBuilderAny(a, SSpace(s), ?show)
+
+// Concatenates any value and a string builder with a newline between
+inline fun any/(\)(a: a, s: stringb, ?show: (a) -> string) : stringb
+  SBuilderAny(a, SNewline(s), ?show)
+
+// Concatenates any value and a string builder with a newline and indented block
+inline fun any/(\-)(a: a, s: stringb, ?show: (a) -> string) : stringb
+  SBuilderAny(a, SIndent(SNewline(s)), ?show)
+
+fun indented(s: stringb): stringb
+  SBuilderConcat(SIndent(SNewline(s)), SUnindent(SNewline(SDone)))
+
+fun string/build(): stringb
+  SDone
+
+// Show the string builder as a string
+fun stringb/show(s: stringb, indent: int = 0): string
+  match s
+    SDone -> ""
+    SIndent(acc) -> acc.pretend-decreasing.show(indent = indent + 2)
+    SNewline(acc) -> "\n" ++ " ".repeat(indent) ++ acc.pretend-decreasing.show(indent = indent)
+    SSpace(acc) -> " " ++ acc.pretend-decreasing.show(indent = indent)
+    SStep(str, acc) -> str ++ acc.pretend-decreasing.show(indent = indent)
+    SUnindent(acc) -> acc.pretend-decreasing.show(indent = max(0, indent - 2))
+
+// Print the string builder to the console
+fun stringb/println(s: stringb, indent: int = 0): console ()
+  match s
+    SDone -> "".println
+    SIndent(acc) -> 
+      acc.pretend-decreasing.println(indent = indent + 2)
+    SNewline(acc) -> 
+      "\n".print
+      " ".repeat(indent).print
+      acc.pretend-decreasing.println(indent = indent)
+    SSpace(acc) -> 
+      " ".print
+      acc.pretend-decreasing.println(indent = indent)
+    SStep(str, acc) -> 
+      str.print
+      acc.pretend-decreasing.println(indent = indent)
+    SUnindent(acc) -> 
+      acc.pretend-decreasing.println(indent = max(0, indent - 2))
+
+// Print the string builder to the console with no ending newline
+fun stringb/print(s: stringb, indent: int = 0): console ()
+  match s
+    SDone -> "".print
+    SIndent(acc) -> 
+      acc.pretend-decreasing.print(indent = indent + 2)
+    SNewline(acc) ->
+      "\n".print
+      " ".repeat(indent).print
+      acc.pretend-decreasing.print(indent = indent)
+    SSpace(acc) ->
+      " ".print
+      acc.pretend-decreasing.print(indent = indent)
+    SStep(str, acc) -> 
+      str.print
+      acc.pretend-decreasing.print(indent = indent)
+    SUnindent(acc) -> 
+      acc.pretend-decreasing.print(indent = max(0, indent - 2))

--- a/lib/std/core/stringb.kk
+++ b/lib/std/core/stringb.kk
@@ -34,7 +34,7 @@ type stringb
   SSpace( acc : stringb )
   SUnindent( acc : stringb )
   
-  lazy SBuilderString(a: string, b : stringb) -> 
+  lazy fip SBuilderString(a: string, b : stringb) -> 
     match b
       SDone -> SStep(a, SDone)
       // TODO: Optimize so we allocate the right buffer for the strings, and then just do a low level copy of the data
@@ -45,7 +45,7 @@ type stringb
       SSpace(acc) -> SStep(a, SSpace(acc))
 
   // Delays conversion until the string is actually needed
-  lazy SBuilderAny<a>( a: a, b: stringb, show: (a) -> string) ->
+  lazy fip SBuilderAny<a>( a: a, b: stringb, show: (a) -> string) ->
     match b  // TODO: Split strings on newlines?
       SDone -> SStep(show(a), SDone)
       SStep(s1, acc) -> SStep(show(a), SStep(s1, acc))
@@ -62,14 +62,7 @@ type stringb
       SUnindent(acc) -> SUnindent(SBuilderConcat(acc, str2))
       SNewline(acc) -> SNewline(SBuilderConcat(acc, str2))
       SSpace(acc) -> SSpace(SBuilderConcat(acc, str2))
-      SStep(s1, acc) -> 
-        match acc
-          SDone -> SStep(s1, str2)
-          SIndent(acc2) -> SStep(s1, SIndent(SBuilderConcat(acc2, str2)))
-          SUnindent(acc2) -> SStep(s1, SUnindent(SBuilderConcat(acc2, str2)))
-          SNewline(acc2) -> SStep(s1, SNewline(SBuilderConcat(acc2, str2)))
-          SSpace(acc2) -> SStep(s1, SSpace(SBuilderConcat(acc2, str2)))
-          SStep(s2, acc2) -> SStep(s1, SStep(s2, SBuilderConcat(acc2, str2))) 
+      SStep(s1, acc) -> SStep(s1, SBuilderConcat(acc, str2))
 
 // Concatenates two string builders with no space between
 inline fun builder/(|.|)(a: stringb, b: stringb) : stringb
@@ -120,19 +113,19 @@ inline fun any/(\-)(a: a, s: stringb, ?show: (a) -> string) : stringb
   SBuilderAny(a, SIndent(SNewline(s)), ?show)
 
 // Creates an indented block starting and ending with a newline
-fun indented(s: stringb): stringb
+inline fun indented(s: stringb): stringb
   SBuilderConcat(SIndent(SNewline(s)), SUnindent(SNewline(SDone)))
 
 // Ends a string builder with a string
-fun string/build(a: string): stringb
+inline fun string/build(a: string): stringb
   SStep(a, SDone)
 
 // Ends a string builder with a value
-fun any/build(a: a, ?show: (a) -> string): stringb
+inline fun any/build(a: a, ?show: (a) -> string): stringb
   SBuilderAny(a, SDone, ?show)
 
 // Ends a string builder with an empty value
-fun empty/build(): stringb
+inline fun empty/build(): stringb
   SDone
 
 // Show the string builder as a string

--- a/lib/std/core/stringb.kk
+++ b/lib/std/core/stringb.kk
@@ -1,8 +1,11 @@
-import std/core/string
+module std/core/stringb
+
 import std/core/types
 import std/core/lazy
-import std/core/undiv
+import std/core/string
 import std/core/int
+import std/core/console
+import std/core/undiv
 
 pub infixr 60  (|.|)
 pub infixr 60  (|-|)
@@ -25,7 +28,7 @@ pub infixr 60  (\-)
 // 
 // The string builder has some pretty-printing ability as well with newlines and indentation handled specially
 // Additionally spaces are handled specially so that they don't need to be materialized as values until the string is demanded.
-type stringb
+pub type stringb
   SDone 
   // Denotes a partially built string with the first part ready
   SStep( str: string, acc: stringb)
@@ -65,71 +68,71 @@ type stringb
       SStep(s1, acc) -> SStep(s1, SBuilderConcat(acc, str2))
 
 // Concatenates two string builders with no space between
-inline fun builder/(|.|)(a: stringb, b: stringb) : stringb
+pub inline fun builder/(|.|)(a: stringb, b: stringb) : stringb
   SBuilderConcat(a, b)
 
 // Concatenates two string builders with a space between
-inline fun builder/(|-|)(a: stringb, b: stringb) : stringb
+pub inline fun builder/(|-|)(a: stringb, b: stringb) : stringb
   SBuilderConcat(a, SSpace(b))
 
 // Concatenates two string builders with a newline between
-inline fun builder/(\)(a: stringb, b: stringb) : stringb
+pub inline fun builder/(\)(a: stringb, b: stringb) : stringb
   SBuilderConcat(a, SNewline(b))
 
 // Concatenates two string builders with a newline and indented block
-inline fun builder/(\-)(a: stringb, b: stringb) : stringb
+pub inline fun builder/(\-)(a: stringb, b: stringb) : stringb
   SBuilderConcat(a, SIndent(SNewline(b)))
 
 // Concatenates a string and a string builder with no space between
-inline fun string/(|.|)(a: string, b: stringb) : stringb
+pub inline fun string/(|.|)(a: string, b: stringb) : stringb
   SBuilderString(a, b)
 
 // Concatenates a string and a string builder with a space between
-inline fun stringb/(|-|)(a: string, b: stringb) : stringb
+pub inline fun stringb/(|-|)(a: string, b: stringb) : stringb
   SBuilderString(a, SSpace(b))
 
 // Concatenates a string and a string builder with a newline between
-inline fun stringb/(\)(a: string, b: stringb) : stringb
+pub inline fun stringb/(\)(a: string, b: stringb) : stringb
   SBuilderString(a, SNewline(b))
 
 // Concatenates a string and a string builder with a newline and indented block
-inline fun stringb/(\-)(a: string, b: stringb) : stringb
+pub inline fun stringb/(\-)(a: string, b: stringb) : stringb
   SBuilderString(a, SIndent(SNewline(b)))
 
 // Concatenates any value and a string builder with no space between
-inline fun any/(|.|)(a: a, s: stringb, ?show: (a) -> string) : stringb
+pub inline fun any/(|.|)(a: a, s: stringb, ?show: (a) -> string) : stringb
   SBuilderAny(a, s, ?show)
 
 // Concatenates any value and a string builder with a space between
-inline fun any/(|-|)(a: a, s: stringb, ?show: (a) -> string) : stringb
+pub inline fun any/(|-|)(a: a, s: stringb, ?show: (a) -> string) : stringb
   SBuilderAny(a, SSpace(s), ?show)
 
 // Concatenates any value and a string builder with a newline between
-inline fun any/(\)(a: a, s: stringb, ?show: (a) -> string) : stringb
+pub inline fun any/(\)(a: a, s: stringb, ?show: (a) -> string) : stringb
   SBuilderAny(a, SNewline(s), ?show)
 
 // Concatenates any value and a string builder with a newline and indented block
-inline fun any/(\-)(a: a, s: stringb, ?show: (a) -> string) : stringb
+pub inline fun any/(\-)(a: a, s: stringb, ?show: (a) -> string) : stringb
   SBuilderAny(a, SIndent(SNewline(s)), ?show)
 
 // Creates an indented block starting and ending with a newline
-inline fun indented(s: stringb): stringb
+pub inline fun indented(s: stringb): stringb
   SBuilderConcat(SIndent(SNewline(s)), SUnindent(SNewline(SDone)))
 
 // Ends a string builder with a string
-inline fun string/build(a: string): stringb
+pub inline fun string/build(a: string): stringb
   SStep(a, SDone)
 
 // Ends a string builder with a value
-inline fun any/build(a: a, ?show: (a) -> string): stringb
+pub inline fun any/build(a: a, ?show: (a) -> string): stringb
   SBuilderAny(a, SDone, ?show)
 
 // Ends a string builder with an empty value
-inline fun empty/build(): stringb
+pub inline fun empty/build(): stringb
   SDone
 
 // Show the string builder as a string
-fun stringb/show(s: stringb, indent: int = 0): string
+pub fun stringb/show(s: stringb, indent: int = 0): string
   match s
     SDone -> ""
     SIndent(acc) -> acc.pretend-decreasing.show(indent = indent + 2)
@@ -139,7 +142,7 @@ fun stringb/show(s: stringb, indent: int = 0): string
     SUnindent(acc) -> acc.pretend-decreasing.show(indent = max(0, indent - 2))
 
 // Print the string builder to the console
-fun stringb/println(s: stringb, indent: int = 0): console ()
+pub fun stringb/println(s: stringb, indent: int = 0): console ()
   match s
     SDone -> "".println
     SIndent(acc) -> 
@@ -158,7 +161,7 @@ fun stringb/println(s: stringb, indent: int = 0): console ()
       acc.pretend-decreasing.println(indent = max(0, indent - 2))
 
 // Print the string builder to the console with no ending newline
-fun stringb/print(s: stringb, indent: int = 0): console ()
+pub fun stringb/print(s: stringb, indent: int = 0): console ()
   match s
     SDone -> "".print
     SIndent(acc) -> 

--- a/lib/std/core/stringb.kk
+++ b/lib/std/core/stringb.kk
@@ -14,8 +14,8 @@ pub infixr 60  (\-)
 // As such it is like a list of strings but: 
 //   1. Will convert polymorphic values to strings
 //     - only when / as needed
-//     - ensuring a short lifetime for the converted string values (for unique references to the builder)
 //     - only converting once (for non-unique references to the builder)
+//     - ensuring a short lifetime for the converted string values (for unique references to the builder, and immediate usage)
 //   2. Will concat two string builders incrementally
 // 
 // For example this datastructure is useful for writing to a file

--- a/lib/std/core/stringb.kk
+++ b/lib/std/core/stringb.kk
@@ -119,10 +119,20 @@ inline fun any/(\)(a: a, s: stringb, ?show: (a) -> string) : stringb
 inline fun any/(\-)(a: a, s: stringb, ?show: (a) -> string) : stringb
   SBuilderAny(a, SIndent(SNewline(s)), ?show)
 
+// Creates an indented block starting and ending with a newline
 fun indented(s: stringb): stringb
   SBuilderConcat(SIndent(SNewline(s)), SUnindent(SNewline(SDone)))
 
-fun string/build(): stringb
+// Ends a string builder with a string
+fun string/build(a: string): stringb
+  SStep(a, SDone)
+
+// Ends a string builder with a value
+fun any/build(a: a, ?show: (a) -> string): stringb
+  SBuilderAny(a, SDone, ?show)
+
+// Ends a string builder with an empty value
+fun empty/build(): stringb
   SDone
 
 // Show the string builder as a string

--- a/samples/lazy/stringb.kk
+++ b/samples/lazy/stringb.kk
@@ -9,6 +9,17 @@ fun sb(l: list<int>)
     Cons(x, xs) ->
       x |-| sb(xs)
 
+fun tupled(l: list<a>, ?show: a -> string)
+  "(" |.| tuprec(l) |.| ")".build()
+
+fun tuprec(l : list<a>, ?show: a -> string)
+  match l
+    Nil -> build()
+    Cons(x, Nil) ->
+      x.build()
+    Cons(x, xs) ->
+      x |.| "," |-| tuprec(xs)
+
 fun main()
   [1, 2, 3].sb.println
   "".println
@@ -21,7 +32,7 @@ fun main()
 
   val b1 = "Hello" |-| "world!" 
               \- [1, 2, 3].sb 
-                \- [1, 2, 3] 
+                \- [1, 2, 3].tupled
                   \- 2 
                   \ 4.5.build()
   b1.println

--- a/samples/lazy/stringb.kk
+++ b/samples/lazy/stringb.kk
@@ -5,7 +5,7 @@ fun sb(l: list<int>)
   match l
     Nil -> build()
     Cons(x, Nil) ->
-      x |.| build()
+      x.build()
     Cons(x, xs) ->
       x |-| sb(xs)
 
@@ -14,8 +14,8 @@ fun main()
   "".println
 
   val b = "Hello" |-| "world!" |.|
-            indented([1, 2, 3].sb \ [1, 2, 3] |.| build()) |.|
-            2 \ 4.5 |.| build()
+            indented([1, 2, 3].sb \ [1, 2, 3].build()) |.|
+            2 \ 4.5.build()
   b.println
   "".println
 
@@ -23,5 +23,5 @@ fun main()
               \- [1, 2, 3].sb 
                 \- [1, 2, 3] 
                   \- 2 
-                  \ 4.5 |.| build()
+                  \ 4.5.build()
   b1.println

--- a/samples/lazy/stringb.kk
+++ b/samples/lazy/stringb.kk
@@ -1,0 +1,27 @@
+import std/core/stringb
+import std/num/float64
+
+fun sb(l: list<int>)
+  match l
+    Nil -> build()
+    Cons(x, Nil) ->
+      x |.| build()
+    Cons(x, xs) ->
+      x |-| sb(xs)
+
+fun main()
+  [1, 2, 3].sb.println
+  "".println
+
+  val b = "Hello" |-| "world!" |.|
+            indented([1, 2, 3].sb \ [1, 2, 3] |.| build()) |.|
+            2 \ 4.5 |.| build()
+  b.println
+  "".println
+
+  val b1 = "Hello" |-| "world!" 
+              \- [1, 2, 3].sb 
+                \- [1, 2, 3] 
+                  \- 2 
+                  \ 4.5 |.| build()
+  b1.println


### PR DESCRIPTION
Hi @daanx,

Wanted to have some fun this weekend, and try out the new lazy constructors.

Ended up making this lazy string builder, partly inspired by your pretty print module.
Conversions / additions to string builder for polymorphic types are made using `show` for the type - but lazily.
You can always create a small method for any type to build it in a particular way, and use these basic building blocks just for combining.

I understand if this is not something you want in std/core, but I wanted to share.