### PR TITLE
language server function generation

### DIFF
--- a/koka.cabal
+++ b/koka.cabal
@@ -109,6 +109,7 @@ library
       Syntax.Lexeme
       Syntax.Lexer
       Syntax.Parse
+      Syntax.Pretty
       Syntax.Promote
       Syntax.RangeMap
       Syntax.Syntax
@@ -171,6 +172,7 @@ executable koka
   main-is: Main.hs
   other-modules:
       LanguageServer.Conversions
+      LanguageServer.Handler.CodeAction
       LanguageServer.Handler.Commands
       LanguageServer.Handler.Completion
       LanguageServer.Handler.Definition

--- a/src/Main/langserver/LanguageServer/Handler/CodeAction.hs
+++ b/src/Main/langserver/LanguageServer/Handler/CodeAction.hs
@@ -1,0 +1,489 @@
+------------------------------------------------------------------------------
+-- Copyright 2024, Tim Whiting
+--
+-- This is free software; you can redistribute it and/or modify it under the
+-- terms of the Apache License, Version 2.0. A copy of the License can be
+-- found in the LICENSE file at the root of this distribution.
+-----------------------------------------------------------------------------
+
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+module LanguageServer.Handler.CodeAction(codeActionHandler) where
+import Language.LSP.Server (Handlers, requestHandler)
+import qualified Data.Map.Strict as M
+import GHC.Unicode (isAlphaNum)
+import Data.List (find, intersperse, foldl', intercalate)
+import Data.Maybe (mapMaybe)
+import qualified Data.Text as Text
+import Control.Lens
+import Control.Monad.IO.Class (liftIO)
+import qualified Language.LSP.Protocol.Types as J
+import qualified Language.LSP.Protocol.Lens as J
+import qualified Language.LSP.Protocol.Message as J
+import LanguageServer.Monad
+import LanguageServer.Conversions
+import Syntax.RangeMap
+import Syntax.Syntax
+import Syntax.Pretty
+import Common.NamePrim
+import Common.Name
+import Common.Range
+import Common.IdNice
+import Common.Syntax
+import Common.Error
+import Kind.Kind
+import Kind.Newtypes
+import Kind.Constructors
+import Type.Type
+import Type.Pretty
+import qualified Type.TypeVar as TV
+import qualified Core.Core as Core
+import Compile.Module (modCoreImports)
+import Lib.Trace (trace)
+
+-- Handles codeAction requests
+codeActionHandler :: Handlers LSM
+codeActionHandler
+  = requestHandler J.SMethod_TextDocumentCodeAction $ \req responder ->
+    do let J.CodeActionParams _ _ docid rng0 _ = req ^. J.params
+           origuri = (docid ^. J.uri)
+           uri = J.toNormalizedUri origuri
+
+           done :: LSM ()
+           done = responder $ Right $ J.InR J.Null
+
+           liftMaybe :: LSM (Maybe a) -> (a -> LSM ()) -> LSM ()
+           liftMaybe action next = do res <- action
+                                      maybe done next res
+       rng <- liftIO $ fromLspRange uri rng0
+       liftMaybe (lookupModuleName uri) $ \(fpath,modname) ->
+        liftMaybe (lookupProgram modname) $ \program ->
+        do
+          defs <- lookupDefinitions [modname]
+          case findType defs rng of
+            Just info -> do
+              let actions = [("show", synShowString modname info), ("==", synEquality modname info),
+                             ("cmp", synOrd modname info), ("order2", synOrder2 modname info)]
+              let results = map (\(nm, action) -> (nm, Core.runCorePhase 0 action)) actions
+              env <- getPrettyEnvFor modname
+              responder $ Right $ J.InL (mapMaybe (\(nm, res) -> J.InR <$> toCodeAction env origuri (dataInfoRange info) nm res) results)
+            _ -> done
+
+findType :: Definitions -> Range -> Maybe DataInfo
+findType defs range = do
+  let dataInfos = M.elems $ newtypesTypeDefs $ defsNewtypes defs
+  find (\di -> dataInfoRange di `rangeContains` rangeEnd range || dataInfoRange di `rangeContains` rangeStart range) dataInfos
+
+toCodeAction :: Env -> J.Uri -> Range -> String ->  Error b (Def UserType) -> Maybe J.CodeAction
+toCodeAction env uri rng kind err =
+  case checkError err of
+    Left errs -> Nothing
+    Right (def, _) -> Just $
+      J.CodeAction
+        (case kind of
+          "show" -> "Generate show function"
+          "==" -> "Generate (==) function"
+          "cmp" -> "Generate cmp (comparison) function"
+          "order2" -> "Generate order2 (fip comparison) function"
+        )
+        (Just J.CodeActionKind_QuickFix) Nothing Nothing Nothing
+        (Just (J.WorkspaceEdit (Just (M.singleton uri [
+             J.TextEdit (toLspRange (rangeJustAfter rng)) (Text.pack $ "\n\n" ++ show (ppSyntaxDefUserType env def))
+          ])) Nothing Nothing)) -- TODO: Ensure correct document version etc.
+        Nothing Nothing
+
+nameShow = newName "show"
+nameEq = newName "=="
+nameCmp = newName "cmp"
+nameOrder2 = newName "order2"
+
+isStarType_ :: Type -> Bool
+isStarType_ (TVar (TypeVar id kind _)) = hasKindStarResult kind
+isStarType_ (TApp (TCon (TypeCon _ kind)) _) = hasKindStarResult kind
+isStarType_ (TCon (TypeCon _ kind)) = hasKindStarResult kind
+isStarType_ _ = False
+
+isStarType :: Type -> Bool
+isStarType = isStarType_ . canonicalForm
+
+isStarTypeVar :: TypeVar -> Bool
+isStarTypeVar (TypeVar id kind _) = hasKindStarResult kind
+
+mkBind :: Name -> Range -> ValueBinder (Maybe UserType) (Maybe (Expr UserType))
+mkBind arg r = ValueBinder arg Nothing Nothing r r
+
+mkBindt :: Name -> UserType -> Range -> ValueBinder (Maybe UserType) (Maybe (Expr UserType))
+mkBindt arg tp r = ValueBinder arg (Just tp) Nothing r r
+
+nonFunctionFields fields = map snd (filter fst fields)
+
+tpForall :: [UserType] -> UserType -> UserType
+tpForall [] tp = tp
+tpForall (TpVar nm _:rest) tp = TpQuan QForall (TypeBinder nm KindNone rangeNull rangeNull) (tpForall rest tp) rangeNull
+
+tpString :: UserType
+tpString = TpCon nameTpString rangeNull
+
+tpBool :: UserType
+tpBool = TpCon nameTpBool rangeNull
+
+tpVarName :: UserType -> Name
+tpVarName (TpVar x _) = x
+
+userTp :: Nice -> Type -> UserType
+userTp nice tp =
+  case tp of
+    TVar tv -> TpVar (showTV tv) rangeNull
+    TFun xs eff y -> TpFun (map (\(x, t) -> (x, userTp nice t)) xs) (userTp nice eff) (userTp nice y) rangeNull
+    TCon (TypeCon x _) -> TpCon x rangeNull
+    TApp f xs -> TpApp (userTp nice f) (map (userTp nice) xs) rangeNull
+    TSyn syn xs _ -> TpApp (TpCon (typesynName syn) rangeNull) (map (userTp nice) xs) rangeNull
+    TForall tvs _ x -> tpForall (map (\tv -> TpVar (showTV tv) rangeNull) tvs) (userTp nice x)
+  where showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
+
+instance Eq UserQuantifier where
+  QForall == QForall = True
+  QExists == QExists = True
+  QSome == QSome = True
+  _ == _ = False
+
+instance Eq (TypeBinder k) where
+  TypeBinder x _ _ _ == TypeBinder y _ _ _ = x == y
+
+instance Eq UserType where
+  TpVar x _ == TpVar y _ = x == y
+  TpCon x _ == TpCon y _ = x == y
+  TpApp x xs _ == TpApp y ys _ = x == y && xs == ys
+  TpFun xs eff y _ == TpFun xs' eff' y' _ = xs == xs' && eff == eff' && y == y'
+  TpQuan q x y _ == TpQuan q' x' y' _ = q == q' && x == x' && y == y'
+  TpQual x y == TpQual x' y' = x == x' && y == y'
+  _ == _ = False
+
+appendOp :: Expr UserType
+appendOp = Var (newName "++") True rangeNull
+
+appendStr :: Expr UserType -> Expr UserType -> Expr UserType
+appendStr (Lit (LitString s1 _)) (App (Var op _ _) [(_, Lit (LitString s2 _)), (_, s3)] _) =
+                 -- combine basic adjacent string literals 
+                appendStr (Lit (LitString (s1 ++ s2) rangeNull)) s3
+appendStr expr1 expr2 = App appendOp [(Nothing, expr1), (Nothing, expr2)] rangeNull
+
+synShowString :: Name -> DataInfo -> Core.CorePhase b (Def UserType)
+synShowString modName info = do
+  evar <- TV.freshTypeVar kindEffect Bound
+  let drng        = dataInfoRange info
+      dataName    = dataInfoName info
+      defName     = newLocallyQualified "" (nameStem dataName) "show"
+      visibility  = dataInfoVis info
+      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
+      doc         = "// Automatically generated.\n// Shows a string representation of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
+      def         = Def (ValueBinder defName () showExpr drng drng) drng visibility (DefFun [Borrow] (NoFip False)) InlineAlways doc
+      tyParams    = dataInfoParams info
+      nice        = niceTypeExtendVars (evar:tyParams) niceEmpty
+      showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
+      tpParams    = map (\tv -> TpVar (showTV tv) drng) tyParams
+      dive        = TpVar (showTV evar) drng
+      dataTp      = TpApp (TpCon dataName drng) tpParams drng
+      selfArg     = if all isAlphaNum (show dataName) then dataName else newName "this"
+      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ tpVarName tv) "show")
+      starTVs     = map (\tv -> TpVar (showTV tv) drng) $ filter isStarTypeVar tyParams
+      tvArgs      = map (\x -> (tVarName x, TpFun [(prepend "tv" (tpVarName x), x)] dive tpString rangeNull)) starTVs
+      tvBinds     = map (\(x, tp) -> mkBindt x tp drng) tvArgs
+      fullTp      = tpForall (tpParams ++ [dive]) $ TpFun ((selfArg,dataTp):tvArgs) dive tpString rangeNull
+      showExpr    = Ann (Lam (mkBindt selfArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
+      branches    = concatMap makeBranch (dataInfoConstrs info)
+      caseExpr    = Case (Var selfArg False drng) branches False drng
+      makeBranch :: ConInfo -> [Branch UserType]
+      makeBranch con
+        = let
+              crng                  = conInfoRange con
+              getTV :: UserType -> Maybe Name
+              getTV ty =
+                case ty of
+                  TpVar x _ ->
+                    do tvar <- find (\(TpVar xx _) -> x == xx) starTVs
+                       return (tVarName tvar)
+                  _ -> Nothing
+              tyShowName :: UserType -> Expr UserType
+              tyShowName ty =
+                  case getTV ty of
+                    Just x -> Var (fst $ splitImplicitParamName x) False crng
+                    Nothing -> Var nameShow False crng
+              showTp :: Expr UserType -> UserType -> Expr UserType
+              showTp exp ty =
+                -- Use fully qualified defName if the type is the same as the data type
+                if ty == dataTp then App (Var defName False crng) [(Nothing, exp)] crng
+                else App (tyShowName ty) [(Nothing, exp)] crng
+              lString s             = Lit (LitString s crng)
+              start                 = lString (nameStem (conInfoName con) ++ "(")
+              fields                = map (\(nm, tp) -> (not (isFun tp), (nm, userTp nice tp))) (conInfoParams con)
+              pVar fld rng          = if fst fld then PatVar (ValueBinder (fst (snd fld)) Nothing (PatWild rng) rng rng)
+                                      else PatWild rng
+              patterns              = [(Nothing,pVar fld crng) | fld <- fields]
+              showField2(fldN,fldTp)= [lString (nameStem fldN ++ ": "), showTp (Var fldN False crng) fldTp]
+              varExprs              = map showField2 (nonFunctionFields fields)
+              varExprs2             = intercalate [lString ", "] varExprs
+              toString              = appendStr start (foldr appendStr (lString ")") varExprs2)
+              conMatch              = PatCon (conInfoName con) patterns crng crng
+              branchExpr            = [Branch conMatch [Guard guardTrue toString]]
+              branchExprNoFields    = [Branch conMatch [Guard guardTrue (lString (nameStem (conInfoName con)))]]
+            in if null fields then branchExprNoFields else branchExpr
+  return def
+
+hasSingleCon :: DataInfo -> Bool
+hasSingleCon info = length (dataInfoConstrs info) == 1
+
+synEquality :: Name -> DataInfo -> Core.CorePhase b (Def UserType)
+synEquality modName info = do
+  evar <- TV.freshTypeVar kindEffect Bound
+  let drng        = dataInfoRange info
+      dataName    = dataInfoName info
+      tyParams    = dataInfoParams info
+      nice        = niceTypeExtendVars (evar:tyParams) niceEmpty
+      showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
+      tpParams    = map (\tv -> TpVar (showTV tv) rangeNull) tyParams
+      starTVs     = map (\tv -> TpVar (showTV tv) rangeNull) (filter isStarTypeVar tyParams)
+      ediv        = TpVar (showTV evar) rangeNull
+      selfArg     = newName "this"
+      otherArg    = newName "other"
+      dataTp      = TpApp (TpCon dataName drng) tpParams drng
+      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ prepend "eq" (tpVarName tv)) "==")
+      tvArgs      = map (\x -> (tVarName x, TpFun
+                          [(prepend "this" (tpVarName x), x),
+                           (prepend "other" (tpVarName x), x)] ediv tpBool rangeNull))
+                      starTVs
+      tvBinds     = map (\(x, t) -> mkBindt x t drng) tvArgs
+      fullTp      = tpForall (tpParams ++ [ediv]) $ TpFun ((selfArg,dataTp):(otherArg,dataTp):tvArgs) ediv tpBool rangeNull
+      branches    = concatMap makeBranch (dataInfoConstrs info)
+      litBool b rng = if b then Var nameTrue False rng else Var nameFalse False rng
+      caseArg     = [(Nothing, Var selfArg False drng), (Nothing, Var otherArg False drng)]
+      caseExpr    = Case (App (Var (nameTuple 2) False drng) caseArg drng) (branches ++ defaultBranch) False drng
+      defExpr     = Ann (Lam (mkBindt selfArg dataTp drng:mkBindt otherArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
+      visibility  = dataInfoVis info
+      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
+      doc         = "// Automatically generated.\n// Equality comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
+      defName     = newLocallyQualified "" (nameStem dataName) "=="
+      def         = Def (ValueBinder defName () defExpr drng drng) drng visibility (DefFun [Borrow] (NoFip False)) InlineAlways doc
+      tupleBranch :: Pattern UserType -> Pattern UserType -> Expr UserType -> Range -> Branch UserType
+      tupleBranch p1 p2 res r = Branch (PatCon (nameTuple 2) [(Nothing, p1), (Nothing, p2)] r r) [Guard guardTrue res]
+      defaultBranch :: [Branch UserType]
+      defaultBranch = ([tupleBranch (PatWild drng) (PatWild drng) (litBool False drng) drng | not (hasSingleCon  info)])
+      makeBranch :: ConInfo -> [Branch UserType]
+      makeBranch con
+        = let crng = conInfoRange con
+              getTV :: UserType -> Maybe Name
+              getTV ty =
+                case ty of
+                  TpVar x _ ->
+                    do tvar <- find (\(TpVar xx _) -> x == xx) starTVs
+                       return (tVarName tvar)
+                  _ -> Nothing
+              tpEqName :: UserType -> Expr UserType
+              tpEqName ty =
+                case getTV ty of
+                  Just x -> Var (fst $ splitImplicitParamName x) True crng
+                  Nothing -> Var nameEq True crng
+              eqTp :: Expr UserType -> Expr UserType -> UserType -> Expr UserType
+              eqTp expL expR ty   =
+                -- Use fully qualified defName if the type is the same as the data type
+                if ty == dataTp then App (Var defName True crng) [(Nothing, expL), (Nothing, expR)] crng
+                else App (tpEqName ty) [(Nothing, expL), (Nothing, expR)] crng
+              fields = map (\(nm, tp) -> (not (isFun tp), (nm, userTp nice tp))) (conInfoParams con)
+              pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
+              pVar fld postfix     = if fst fld then PatVar (ValueBinder (postpend postfix (fst (snd fld))) Nothing (PatWild crng) crng crng)
+                                    else PatWild crng
+              patternsL           = [(Nothing,pVar fld "") | fld <- fields]
+              patternsR           = [(Nothing,pVar fld "'") | fld <- fields]
+              andOp               = Var (newName "&&") True crng
+              andExpr expr1 expr2 = App andOp [(Nothing, expr1), (Nothing, expr2)] crng
+              nonFunctionFields   = map snd (filter fst fields)
+              eqField(fldN, fldT) = eqTp (Var fldN False crng) (Var (postpend "'" fldN) False crng) fldT
+              varExprs            = map eqField nonFunctionFields
+              branchExpr = case varExprs of
+                [] -> litBool True crng
+                _ -> foldr1 andExpr varExprs
+              branch              = tupleBranch (PatCon (conInfoName con) patternsL crng crng) (PatCon (conInfoName con) patternsR crng crng)
+            in [branch branchExpr crng]
+  return def
+
+nameCmpEq = newName "Eq"
+tpOrder = TpCon (newName "order") rangeNull
+
+synOrd :: Name -> DataInfo -> Core.CorePhase b (Def UserType)
+synOrd modName info = do
+  evar <- TV.freshTypeVar kindEffect Bound
+  let drng        = dataInfoRange info
+      dataName    = dataInfoName info
+      tyParams    = dataInfoParams info
+      nice        = niceTypeExtendVars (evar:tyParams) niceEmpty
+      showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
+      tpParams    = map (\tv -> TpVar (showTV tv) rangeNull) tyParams
+      starTVs     = map (\tv -> TpVar (showTV tv) rangeNull) (filter isStarTypeVar tyParams)
+      ediv        = TpVar (showTV evar) rangeNull
+      selfArg     = newName "this"
+      otherArg    = newName "other"
+      dataTp      = TpApp (TpCon dataName drng) tpParams drng
+      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ tpVarName tv) "cmp")
+      tvArgs      = map (\x -> (tVarName x, TpFun
+                          [(prepend "this" (tpVarName x), x),
+                           (prepend "other" (tpVarName x), x)] ediv tpOrder rangeNull))
+                      starTVs
+      tvBinds     = map (\(x, t) -> mkBindt x t drng) tvArgs
+      fullTp      = tpForall (tpParams ++ [ediv]) $ TpFun ((selfArg,dataTp):(otherArg,dataTp):tvArgs) ediv tpOrder rangeNull
+      doMakeBranches [] = []
+      doMakeBranches [c] = [head (makeBranches c)] -- Last constructor only needs to check equality
+      doMakeBranches (c:cs) = makeBranches c ++ doMakeBranches cs
+      branches    = doMakeBranches (dataInfoConstrs info)
+      litLt       = Var (newName "Lt") False drng
+      litGt       = Var (newName "Gt") False drng
+      litEq       = Var nameCmpEq False drng
+      caseArg     = [(Nothing, Var selfArg False drng), (Nothing, Var otherArg False drng)]
+      caseExpr    = Case (App (Var (nameTuple 2) False drng) caseArg drng) branches False drng
+      defExpr     = Ann (Lam (mkBindt selfArg dataTp drng:mkBindt otherArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
+      visibility  = dataInfoVis info
+      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
+      doc         = "// Automatically generated.\n// Comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
+      defName     = newLocallyQualified "" (nameStem dataName) "cmp"
+      def         = Def (ValueBinder defName () defExpr drng drng) drng visibility (DefFun [Borrow] (NoFip False)) InlineAlways doc
+      tupleBranch :: Pattern UserType -> Pattern UserType -> Expr UserType -> Range -> Branch UserType
+      tupleBranch p1 p2 res r = Branch (PatCon (nameTuple 2) [(Nothing, p1), (Nothing, p2)] r r) [Guard guardTrue res]
+      makeBranches :: ConInfo -> [Branch UserType]
+      makeBranches con
+        = let crng = conInfoRange con
+              getTV :: UserType -> Maybe Name
+              getTV ty =
+                case ty of
+                  TpVar x _ ->
+                    do tvar <- find (\(TpVar xx _) -> x == xx) starTVs
+                       return (tVarName tvar)
+                  _ -> Nothing
+              tpCmpName :: UserType -> Expr UserType
+              tpCmpName ty =
+                case getTV ty of
+                  Just x -> Var (fst $ splitImplicitParamName x) False crng
+                  Nothing -> Var nameCmp False crng
+              cmpTp :: Expr UserType -> Expr UserType -> UserType -> Expr UserType
+              cmpTp expL expR ty   =
+                -- Use fully qualified defName if the type is the same as the data type
+                if ty == dataTp then App (Var defName False crng) [(Nothing, expL), (Nothing, expR)] crng
+                else App (tpCmpName ty) [(Nothing, expL), (Nothing, expR)] crng
+              fields = map (\(nm, tp) -> (not (isFun tp), (nm, userTp nice tp))) (conInfoParams con)
+              pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
+              pVar fld postfix     = if fst fld then PatVar (ValueBinder (postpend postfix (fst (snd fld))) Nothing (PatWild crng) crng crng)
+                                    else PatWild crng
+              patternsL           = [(Nothing,pVar fld "") | fld <- fields]
+              patternsR           = [(Nothing,pVar fld "'") | fld <- fields]
+              nonFunctionFields   = map snd (filter fst fields)
+              cmpField(fldN, fldT) = cmpTp (Var fldN False crng) (Var (postpend "'" fldN) False crng) fldT
+              binderNeqName nm       = (prepend (nameStem nm) $ newName "_order")
+              binderNeqPat nm        = ValueBinder (binderNeqName nm)  Nothing (PatWild crng) crng crng
+              branchExpr' [field]                = cmpField field
+              branchExpr' (field@(nm,tp):fields) = Case (cmpField field) [
+                                                      Branch (PatCon nameCmpEq [] crng crng) [Guard guardTrue (branchExpr' fields)],
+                                                      Branch (PatVar (binderNeqPat nm)) [Guard guardTrue (Var (binderNeqName nm) False crng)]
+                                                    ] False crng
+              branchExpr = case nonFunctionFields of
+                [] -> litEq
+                _ -> branchExpr' nonFunctionFields
+              branch              = tupleBranch (PatCon (conInfoName con) patternsL crng crng) (PatCon (conInfoName con) patternsR crng crng)
+              ltbranch            = tupleBranch (PatCon (conInfoName con) [] crng crng) (PatWild crng) litLt crng
+              gtbranch            = tupleBranch (PatWild crng) (PatCon (conInfoName con) [] crng crng) litGt crng
+            in [branch branchExpr crng, ltbranch, gtbranch]
+  return def
+
+nameOrd2Eq = newName "Eq2"
+nameOrd2Lt = newName "Lt2"
+nameOrd2Gt = newName "Gt2"
+nameOrd2 = newName "order2"
+
+synOrder2 :: Name -> DataInfo -> Core.CorePhase b (Def UserType) -- TODO: Make this actually fip
+synOrder2 modName info = do
+  evar <- TV.freshTypeVar kindEffect Bound
+  let drng        = dataInfoRange info
+      dataName    = dataInfoName info
+      tyParams    = dataInfoParams info
+      nice        = niceTypeExtendVars (evar:tyParams) niceEmpty
+      showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
+      tpParams    = map (\tv -> TpVar (showTV tv) rangeNull) tyParams
+      starTVs     = map (\tv -> TpVar (showTV tv) rangeNull) (filter isStarTypeVar tyParams)
+      ediv        = TpVar (showTV evar) rangeNull
+      selfArg     = newName "this"
+      otherArg    = newName "other"
+      dataTp      = TpApp (TpCon dataName drng) tpParams drng
+      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ tpVarName tv) "order2")
+      tpOrder2    = TpApp (TpCon nameOrd2 drng) [dataTp] drng
+      tvArgs      = map (\x -> (tVarName x, TpFun
+                          [(prepend "this" (tpVarName x), x),
+                           (prepend "other" (tpVarName x), x)] ediv tpOrder2 rangeNull))
+                      starTVs
+      tvBinds     = map (\(x, t) -> mkBindt x t drng) tvArgs
+      fullTp      = tpForall (tpParams ++ [ediv]) $ TpFun ((selfArg,dataTp):(otherArg,dataTp):tvArgs) ediv tpOrder2 rangeNull
+      doMakeBranches [] = []
+      doMakeBranches [c] = [head (makeBranches c)] -- Last constructor only needs to check equality
+      doMakeBranches (c:cs) = makeBranches c ++ doMakeBranches cs
+      branches    = doMakeBranches (dataInfoConstrs info)
+      litLt       = Var nameOrd2Lt False drng
+      litGt       = Var nameOrd2Gt False drng
+      litEq       = Var nameOrd2Eq False drng
+      caseArg     = [(Nothing, Var selfArg False drng), (Nothing, Var otherArg False drng)]
+      caseExpr    = Case (App (Var (nameTuple 2) False drng) caseArg drng) branches False drng
+      defExpr     = Ann (Lam (mkBindt selfArg dataTp drng:mkBindt otherArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
+      visibility  = dataInfoVis info
+      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
+      doc         = "// Automatically generated.\n// Fip comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
+      defName     = newLocallyQualified "" (nameStem dataName) "order2"
+      def         = Def (ValueBinder defName () defExpr drng drng) drng visibility (DefFun [Borrow] (NoFip False)) InlineAlways doc
+      tupleBranch :: Pattern UserType -> Pattern UserType -> Expr UserType -> Range -> Branch UserType
+      tupleBranch p1 p2 res r = Branch (PatCon (nameTuple 2) [(Nothing, p1), (Nothing, p2)] r r) [Guard guardTrue res]
+      makeBranches :: ConInfo -> [Branch UserType]
+      makeBranches con
+        = let crng = conInfoRange con
+              getTV :: UserType -> Maybe Name
+              getTV ty =
+                case ty of
+                  TpVar x _ ->
+                    do tvar <- find (\(TpVar xx _) -> x == xx) starTVs
+                       return (tVarName tvar)
+                  _ -> Nothing
+              tpOrder2Name :: UserType -> Expr UserType
+              tpOrder2Name ty =
+                case getTV ty of
+                  Just x -> Var (fst $ splitImplicitParamName x) False crng
+                  Nothing -> Var nameOrder2 False crng
+              order2Tp :: Expr UserType -> Expr UserType -> UserType -> Expr UserType
+              order2Tp expL expR ty   =
+                -- Use fully qualified defName if the type is the same as the data type
+                if ty == dataTp then App (Var defName False crng) [(Nothing, expL), (Nothing, expR)] crng
+                else App (tpOrder2Name ty) [(Nothing, expL), (Nothing, expR)] crng
+              fields = map (\(nm, tp) -> (not (isFun tp), (nm, userTp nice tp))) (conInfoParams con)
+              pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
+              pVar fld postfix     = if fst fld then PatVar (ValueBinder (postpend postfix (fst (snd fld))) Nothing (PatWild crng) crng crng)
+                                    else PatWild crng
+              patternsL           = [(Nothing,pVar fld "") | fld <- fields]
+              patternsR           = [(Nothing,pVar fld "'") | fld <- fields]
+              nonFunctionFields   = map snd (filter fst fields)
+              order2Field(fldN, fldT) = order2Tp (Var fldN False crng) (Var (postpend "'" fldN) False crng) fldT
+              patEqName nm       = (prepend (nameStem nm) $ newName "_eq")
+              patLtLName nm       = (prepend (nameStem nm) $ newName "_lt")
+              patLtRName nm       = (prepend (nameStem nm) $ newName "_gt")
+              patGtLName nm       = (prepend (nameStem nm) $ newName "_lt")
+              patGtRName nm       = (prepend (nameStem nm) $ newName "_gt")
+              patEq nm            = PatCon nameOrd2Eq [(Just (patEqName nm, crng), PatWild crng)] crng crng
+              patLt nm            = PatCon nameOrd2Lt [(Just (patLtLName nm, crng), PatWild crng), (Just (patLtRName nm, crng), PatWild crng)] crng crng
+              patGt nm            = PatCon nameOrd2Gt [(Just (patGtLName nm, crng), PatWild crng), (Just (patGtRName nm, crng), PatWild crng)] crng crng
+              branchExpr' []                = App litEq [(Nothing, Var selfArg False crng)] crng
+              branchExpr' (field@(nm,tp):fields) = Case (order2Field field) [
+                                                      Branch (patEq nm) [Guard guardTrue (branchExpr' fields)],
+                                                      Branch (patLt nm) [Guard guardTrue (App litLt [(Nothing, Var selfArg False crng), (Nothing, Var otherArg False crng)] crng)],
+                                                      Branch (patGt nm) [Guard guardTrue (App litGt [(Nothing, Var otherArg False crng), (Nothing, Var selfArg False crng)] crng)]
+                                                    ] False crng
+              branchExpr = branchExpr' nonFunctionFields
+              branch              = tupleBranch (PatCon (conInfoName con) patternsL crng crng) (PatCon (conInfoName con) patternsR crng crng)
+              ltbranch            = tupleBranch (PatCon (conInfoName con) [] crng crng) (PatWild crng)
+                                                    (App litLt [(Nothing, Var selfArg False crng), (Nothing, Var otherArg False crng)] crng) crng
+              gtbranch            = tupleBranch (PatWild crng) (PatCon (conInfoName con) [] crng crng)
+                                                    (App litGt [(Nothing, Var otherArg False crng), (Nothing, Var selfArg False crng)] crng) crng
+            in [branch branchExpr crng, ltbranch, gtbranch]
+  return def
+

--- a/src/Main/langserver/LanguageServer/Handler/CodeAction.hs
+++ b/src/Main/langserver/LanguageServer/Handler/CodeAction.hs
@@ -64,7 +64,8 @@ codeActionHandler
           case findType defs rng of
             Just info -> do
               let actions = [("show", synShowString modname info), ("==", synEquality modname info),
-                             ("cmp", synOrd modname info), ("order2", synOrder2 modname info)]
+                             ("cmp", synOrd modname info), ("order2", synOrder2 modname info),
+                             ("recursive method", synPlaceholder modname "method" info), ("general method", synPlaceholder2 modname "method" info)]
               let results = map (\(nm, action) -> (nm, Core.runCorePhase 0 action)) actions
               env <- getPrettyEnvFor modname
               responder $ Right $ J.InL (mapMaybe (\(nm, res) -> J.InR <$> toCodeAction env origuri (dataInfoRange info) nm res) results)
@@ -86,6 +87,8 @@ toCodeAction env uri rng kind err =
           "==" -> "Generate (==) function"
           "cmp" -> "Generate cmp (comparison) function"
           "order2" -> "Generate order2 (fip comparison) function"
+          "general method" -> "Generate a method that is recursive only on the fields of the data type"
+          "recursive method" -> "Generate a recursive method that calls the method for each field"
         )
         (Just J.CodeActionKind_QuickFix) Nothing Nothing Nothing
         (Just (J.WorkspaceEdit (Just (M.singleton uri [
@@ -169,31 +172,28 @@ appendStr (Lit (LitString s1 _)) (App (Var op _ _) [(_, Lit (LitString s2 _)), (
                 appendStr (Lit (LitString (s1 ++ s2) rangeNull)) s3
 appendStr expr1 expr2 = App appendOp [(Nothing, expr1), (Nothing, expr2)] rangeNull
 
-synShowString :: Name -> DataInfo -> Core.CorePhase b (Def UserType)
-synShowString modName info = do
-  evar <- TV.freshTypeVar kindEffect Bound
-  let drng        = dataInfoRange info
+type SynUnaryBranch = UserType -> ConInfo -> (Expr UserType -> UserType -> Expr UserType) -> [(Bool, (Name, UserType))] -> [Branch UserType]
+
+synGeneralUnary :: Name -> Name -> String -> DataInfo -> (TypeVar, UserType) -> UserType -> SynUnaryBranch -> (Def UserType)
+synGeneralUnary modName generalName doc info (evar, effectTp) resultTp mkBranches =
+  let DataInfo{dataInfoRange = drng }   = info
       dataName    = dataInfoName info
-      defName     = newLocallyQualified "" (nameStem dataName) "show"
-      visibility  = dataInfoVis info
-      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
-      doc         = "// Automatically generated.\n// Shows a string representation of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
-      def         = Def (ValueBinder defName () showExpr drng drng) drng visibility (DefFun [Borrow] (NoFip False)) InlineAlways doc
       tyParams    = dataInfoParams info
       nice        = niceTypeExtendVars (evar:tyParams) niceEmpty
       showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
       tpParams    = map (\tv -> TpVar (showTV tv) drng) tyParams
-      dive        = TpVar (showTV evar) drng
       dataTp      = TpApp (TpCon dataName drng) tpParams drng
       selfArg     = if all isAlphaNum (show dataName) then dataName else newName "this"
-      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ tpVarName tv) "show")
+      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ tpVarName tv) (nameStem generalName))
       starTVs     = map (\tv -> TpVar (showTV tv) drng) $ filter isStarTypeVar tyParams
-      tvArgs      = map (\x -> (tVarName x, TpFun [(prepend "tv" (tpVarName x), x)] dive tpString rangeNull)) starTVs
+      tvArgs      = map (\x -> (tVarName x, TpFun [(prepend "tv" (tpVarName x), x)] effectTp resultTp rangeNull)) starTVs
       tvBinds     = map (\(x, tp) -> mkBindt x tp drng) tvArgs
-      fullTp      = tpForall (tpParams ++ [dive]) $ TpFun ((selfArg,dataTp):tvArgs) dive tpString rangeNull
+      fullTp      = tpForall (tpParams ++ [effectTp]) $ TpFun ((selfArg,dataTp):tvArgs) effectTp resultTp rangeNull
       showExpr    = Ann (Lam (mkBindt selfArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
       branches    = concatMap makeBranch (dataInfoConstrs info)
       caseExpr    = Case (Var selfArg False drng) branches False drng
+      defName     = newLocallyQualified "" (nameStem dataName) (nameStem generalName)
+      def         = Def (ValueBinder defName () showExpr drng drng) drng (dataInfoVis info) (DefFun [Borrow] (NoFip False)) InlineAlways doc
       makeBranch :: ConInfo -> [Branch UserType]
       makeBranch con
         = let
@@ -205,38 +205,87 @@ synShowString modName info = do
                     do tvar <- find (\(TpVar xx _) -> x == xx) starTVs
                        return (tVarName tvar)
                   _ -> Nothing
-              tyShowName :: UserType -> Expr UserType
-              tyShowName ty =
+              tyAppName :: UserType -> Expr UserType
+              tyAppName ty =
                   case getTV ty of
                     Just x -> Var (fst $ splitImplicitParamName x) False crng
-                    Nothing -> Var nameShow False crng
-              showTp :: Expr UserType -> UserType -> Expr UserType
-              showTp exp ty =
+                    Nothing -> Var generalName False crng
+              recur :: Expr UserType -> UserType -> Expr UserType
+              recur exp ty =
                 -- Use fully qualified defName if the type is the same as the data type
                 if ty == dataTp then App (Var defName False crng) [(Nothing, exp)] crng
-                else App (tyShowName ty) [(Nothing, exp)] crng
-              lString s             = Lit (LitString s crng)
-              start                 = lString (nameStem (conInfoName con) ++ "(")
+                else App (tyAppName ty) [(Nothing, exp)] crng
               fields                = map (\(nm, tp) -> (not (isFun tp), (nm, userTp nice tp))) (conInfoParams con)
-              pVar fld rng          = if fst fld then PatVar (ValueBinder (fst (snd fld)) Nothing (PatWild rng) rng rng)
-                                      else PatWild rng
-              patterns              = [(Nothing,pVar fld crng) | fld <- fields]
-              showField2(fldN,fldTp)= [lString (nameStem fldN ++ ": "), showTp (Var fldN False crng) fldTp]
-              varExprs              = map showField2 (nonFunctionFields fields)
-              varExprs2             = intercalate [lString ", "] varExprs
-              toString              = appendStr start (foldr appendStr (lString ")") varExprs2)
-              conMatch              = PatCon (conInfoName con) patterns crng crng
-              branchExpr            = [Branch conMatch [Guard guardTrue toString]]
-              branchExprNoFields    = [Branch conMatch [Guard guardTrue (lString (nameStem (conInfoName con)))]]
-            in if null fields then branchExprNoFields else branchExpr
-  return def
+            in mkBranches dataTp con recur fields
+  in def
+
+synPlaceholder :: Name -> String -> DataInfo -> Core.CorePhase b (Def UserType)
+synPlaceholder modName generalName info = do
+  evar <- TV.freshTypeVar kindEffect Bound
+  let doc  = "// " ++ generalName ++ " method for `" ++ (nameStem dataName) ++ "` type.\n"
+  return $ synGeneralUnary modName (newName generalName) doc info (evar, TpVar (newName "e") rangeNull) (TpVar (newName "a") rangeNull) $ \_ con recur fields ->
+    let crng = conInfoRange con
+        patterns              = [(Nothing,pVar fld crng) | fld <- fields]
+        defs                  = map (\f@(isFunc,(fldNm,fldTp)) ->
+                                    Def (ValueBinder (prepend "rec" fldNm) () (recur (Var fldNm False crng) fldTp) crng crng) crng Private DefVal InlineAlways ""
+                                  ) fields
+        pVar fld rng          = PatVar (ValueBinder (fst (snd fld)) Nothing (PatWild rng) rng rng)
+        conMatch              = PatCon (conInfoName con) patterns crng crng
+        branchExpr            = [Branch conMatch [Guard guardTrue (Let (DefRec defs) (Var nameUnit False crng) crng)]]
+      in branchExpr
+  where dataName = dataInfoName info
+
+synPlaceholder2 :: Name -> String -> DataInfo -> Core.CorePhase b (Def UserType)
+synPlaceholder2 modName generalName info = do
+  evar <- TV.freshTypeVar kindEffect Bound
+  let doc  = "// " ++ generalName ++ " method for `" ++ (nameStem dataName) ++ "` type.\n"
+  return $ synGeneralUnary modName (newName generalName) doc info (evar, TpVar (newName "e") rangeNull) (TpVar (newName "a") rangeNull) $ \dataTp con recur fields ->
+    let crng = conInfoRange con
+        patterns              = [(Nothing,pVar fld crng) | fld <- fields]
+        defs                  = mapMaybe (\f@(isFunc,(fldNm,fldTp)) ->
+                                    if fldTp == dataTp then
+                                      Just $ Def (ValueBinder (prepend "rec" fldNm) () (recur (Var fldNm False crng) fldTp) crng crng) crng Private DefVal InlineAlways ""
+                                    else
+                                      Nothing
+                                  ) fields
+        pVar fld rng          = PatVar (ValueBinder (fst (snd fld)) Nothing (PatWild rng) rng rng)
+        conMatch              = PatCon (conInfoName con) patterns crng crng
+        branchExpr            = [Branch conMatch [Guard guardTrue (Let (DefRec defs) (Var nameUnit False crng) crng)]]
+      in branchExpr
+  where dataName = dataInfoName info
+
+
+synShowString :: Name -> DataInfo -> Core.CorePhase b (Def UserType)
+synShowString modName info = do
+  evar <- TV.freshTypeVar kindEffect Bound
+  let anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
+      doc         = "// Automatically generated.\n// Shows a string representation of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
+  return $ synGeneralUnary modName nameShow doc info (evar, TpVar (newName "e") rangeNull) tpString $ \_ con recur fields ->
+    let crng = conInfoRange con
+        lString s             = Lit (LitString s crng)
+        patterns              = [(Nothing,pVar fld crng) | fld <- fields]
+        showField2(fldN,fldTp)= [lString (nameStem fldN ++ ": "), recur (Var fldN False crng) fldTp]
+        pVar fld rng          = if fst fld then PatVar (ValueBinder (fst (snd fld)) Nothing (PatWild rng) rng rng)
+                                else PatWild rng
+        start                 = lString (nameStem (conInfoName con) ++ "(")
+        varExprs              = map showField2 (nonFunctionFields fields)
+        varExprs2             = intercalate [lString ", "] varExprs
+        toString              = appendStr start (foldr appendStr (lString ")") varExprs2)
+        conMatch              = PatCon (conInfoName con) patterns crng crng
+        branchExpr            = [Branch conMatch [Guard guardTrue toString]]
+        branchExprNoFields    = [Branch conMatch [Guard guardTrue (lString (nameStem (conInfoName con)))]]
+      in if null fields then branchExprNoFields else branchExpr
 
 hasSingleCon :: DataInfo -> Bool
 hasSingleCon info = length (dataInfoConstrs info) == 1
 
-synEquality :: Name -> DataInfo -> Core.CorePhase b (Def UserType)
-synEquality modName info = do
-  evar <- TV.freshTypeVar kindEffect Bound
+type SynBinaryBranch = Int -> UserType -> ConInfo -> (Expr UserType -> Expr UserType -> UserType -> Expr UserType) -> [(Bool, (Name, UserType))] -> [Branch UserType]
+
+tupleBranch :: Pattern UserType -> Pattern UserType -> Expr UserType -> Range -> Branch UserType
+tupleBranch p1 p2 res r = Branch (PatCon (nameTuple 2) [(Nothing, p1), (Nothing, p2)] r r) [Guard guardTrue res]
+
+synBinaryOp :: Name -> Name -> Bool -> String -> DataInfo -> (TypeVar, UserType) -> UserType -> [Branch UserType] -> SynBinaryBranch -> Def UserType
+synBinaryOp modName generalName isOp doc info (evar, effectTp) resultTp defaultBranch mkBranch =
   let drng        = dataInfoRange info
       dataName    = dataInfoName info
       tyParams    = dataInfoParams info
@@ -244,33 +293,25 @@ synEquality modName info = do
       showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
       tpParams    = map (\tv -> TpVar (showTV tv) rangeNull) tyParams
       starTVs     = map (\tv -> TpVar (showTV tv) rangeNull) (filter isStarTypeVar tyParams)
-      ediv        = TpVar (showTV evar) rangeNull
       selfArg     = newName "this"
       otherArg    = newName "other"
       dataTp      = TpApp (TpCon dataName drng) tpParams drng
-      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ prepend "eq" (tpVarName tv)) "==")
+      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem (tpVarName tv)) (nameStem generalName))
       tvArgs      = map (\x -> (tVarName x, TpFun
                           [(prepend "this" (tpVarName x), x),
-                           (prepend "other" (tpVarName x), x)] ediv tpBool rangeNull))
+                           (prepend "other" (tpVarName x), x)] effectTp resultTp rangeNull))
                       starTVs
       tvBinds     = map (\(x, t) -> mkBindt x t drng) tvArgs
-      fullTp      = tpForall (tpParams ++ [ediv]) $ TpFun ((selfArg,dataTp):(otherArg,dataTp):tvArgs) ediv tpBool rangeNull
-      branches    = concatMap makeBranch (dataInfoConstrs info)
+      fullTp      = tpForall (tpParams ++ [effectTp]) $ TpFun ((selfArg,dataTp):(otherArg,dataTp):tvArgs) effectTp resultTp rangeNull
+      branches    = concat $ zipWith makeBranch (dataInfoConstrs info) [0..] 
       litBool b rng = if b then Var nameTrue False rng else Var nameFalse False rng
       caseArg     = [(Nothing, Var selfArg False drng), (Nothing, Var otherArg False drng)]
       caseExpr    = Case (App (Var (nameTuple 2) False drng) caseArg drng) (branches ++ defaultBranch) False drng
       defExpr     = Ann (Lam (mkBindt selfArg dataTp drng:mkBindt otherArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
-      visibility  = dataInfoVis info
-      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
-      doc         = "// Automatically generated.\n// Equality comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
-      defName     = newLocallyQualified "" (nameStem dataName) "=="
-      def         = Def (ValueBinder defName () defExpr drng drng) drng visibility (DefFun [Borrow] (NoFip False)) InlineAlways doc
-      tupleBranch :: Pattern UserType -> Pattern UserType -> Expr UserType -> Range -> Branch UserType
-      tupleBranch p1 p2 res r = Branch (PatCon (nameTuple 2) [(Nothing, p1), (Nothing, p2)] r r) [Guard guardTrue res]
-      defaultBranch :: [Branch UserType]
-      defaultBranch = ([tupleBranch (PatWild drng) (PatWild drng) (litBool False drng) drng | not (hasSingleCon  info)])
-      makeBranch :: ConInfo -> [Branch UserType]
-      makeBranch con
+      defName     = newLocallyQualified "" (nameStem dataName) (nameStem generalName)
+      def         = Def (ValueBinder defName () defExpr drng drng) drng (dataInfoVis info) (DefFun [Borrow] (NoFip False)) InlineAlways doc
+      makeBranch :: ConInfo -> Int -> [Branch UserType]
+      makeBranch con i
         = let crng = conInfoRange con
               getTV :: UserType -> Maybe Name
               getTV ty =
@@ -279,33 +320,46 @@ synEquality modName info = do
                     do tvar <- find (\(TpVar xx _) -> x == xx) starTVs
                        return (tVarName tvar)
                   _ -> Nothing
-              tpEqName :: UserType -> Expr UserType
-              tpEqName ty =
+              tpAppName :: UserType -> Expr UserType
+              tpAppName ty =
                 case getTV ty of
-                  Just x -> Var (fst $ splitImplicitParamName x) True crng
-                  Nothing -> Var nameEq True crng
-              eqTp :: Expr UserType -> Expr UserType -> UserType -> Expr UserType
-              eqTp expL expR ty   =
+                  Just x -> Var (fst $ splitImplicitParamName x) isOp crng
+                  Nothing -> Var generalName isOp crng
+              recur :: Expr UserType -> Expr UserType -> UserType -> Expr UserType
+              recur expL expR ty   =
                 -- Use fully qualified defName if the type is the same as the data type
-                if ty == dataTp then App (Var defName True crng) [(Nothing, expL), (Nothing, expR)] crng
-                else App (tpEqName ty) [(Nothing, expL), (Nothing, expR)] crng
+                if ty == dataTp then App (Var defName isOp crng) [(Nothing, expL), (Nothing, expR)] crng
+                else App (tpAppName ty) [(Nothing, expL), (Nothing, expR)] crng
               fields = map (\(nm, tp) -> (not (isFun tp), (nm, userTp nice tp))) (conInfoParams con)
-              pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
-              pVar fld postfix     = if fst fld then PatVar (ValueBinder (postpend postfix (fst (snd fld))) Nothing (PatWild crng) crng crng)
-                                    else PatWild crng
-              patternsL           = [(Nothing,pVar fld "") | fld <- fields]
-              patternsR           = [(Nothing,pVar fld "'") | fld <- fields]
-              andOp               = Var (newName "&&") True crng
-              andExpr expr1 expr2 = App andOp [(Nothing, expr1), (Nothing, expr2)] crng
-              nonFunctionFields   = map snd (filter fst fields)
-              eqField(fldN, fldT) = eqTp (Var fldN False crng) (Var (postpend "'" fldN) False crng) fldT
-              varExprs            = map eqField nonFunctionFields
-              branchExpr = case varExprs of
-                [] -> litBool True crng
-                _ -> foldr1 andExpr varExprs
-              branch              = tupleBranch (PatCon (conInfoName con) patternsL crng crng) (PatCon (conInfoName con) patternsR crng crng)
-            in [branch branchExpr crng]
-  return def
+          in mkBranch i dataTp con recur fields
+  in def
+
+synEquality :: Name -> DataInfo -> Core.CorePhase b (Def UserType)
+synEquality modName info = do
+  evar <- TV.freshTypeVar kindEffect Bound
+  let drng = dataInfoRange info
+      litBool b rng = if b then Var nameTrue False rng else Var nameFalse False rng
+      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
+      doc         = "// Automatically generated.\n// Equality comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
+      defaultBranch :: [Branch UserType]
+      defaultBranch = ([tupleBranch (PatWild drng) (PatWild drng) (litBool False drng) drng | not (hasSingleCon info)])
+  return $ synBinaryOp modName nameEq True doc info (evar, TpVar (newName "e") rangeNull) tpBool defaultBranch $ \_ _ con recur fields ->
+      let crng = conInfoRange con
+          pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
+          pVar fld postfix     = if fst fld then PatVar (ValueBinder (postpend postfix (fst (snd fld))) Nothing (PatWild crng) crng crng)
+                                else PatWild crng
+          patternsL           = [(Nothing,pVar fld "") | fld <- fields]
+          patternsR           = [(Nothing,pVar fld "'") | fld <- fields]
+          andOp               = Var (newName "&&") True crng
+          andExpr expr1 expr2 = App andOp [(Nothing, expr1), (Nothing, expr2)] crng
+          nonFunctionFields   = map snd (filter fst fields)
+          eqField(fldN, fldT) = recur (Var fldN False crng) (Var (postpend "'" fldN) False crng) fldT
+          varExprs            = map eqField nonFunctionFields
+          branchExpr = case varExprs of
+            [] -> litBool True crng
+            _ -> foldr1 andExpr varExprs
+          branch              = tupleBranch (PatCon (conInfoName con) patternsL crng crng) (PatCon (conInfoName con) patternsR crng crng)
+        in [branch branchExpr crng]
 
 nameCmpEq = newName "Eq"
 tpOrder = TpCon (newName "order") rangeNull
@@ -313,84 +367,36 @@ tpOrder = TpCon (newName "order") rangeNull
 synOrd :: Name -> DataInfo -> Core.CorePhase b (Def UserType)
 synOrd modName info = do
   evar <- TV.freshTypeVar kindEffect Bound
-  let drng        = dataInfoRange info
-      dataName    = dataInfoName info
-      tyParams    = dataInfoParams info
-      nice        = niceTypeExtendVars (evar:tyParams) niceEmpty
-      showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
-      tpParams    = map (\tv -> TpVar (showTV tv) rangeNull) tyParams
-      starTVs     = map (\tv -> TpVar (showTV tv) rangeNull) (filter isStarTypeVar tyParams)
-      ediv        = TpVar (showTV evar) rangeNull
-      selfArg     = newName "this"
-      otherArg    = newName "other"
-      dataTp      = TpApp (TpCon dataName drng) tpParams drng
-      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ tpVarName tv) "cmp")
-      tvArgs      = map (\x -> (tVarName x, TpFun
-                          [(prepend "this" (tpVarName x), x),
-                           (prepend "other" (tpVarName x), x)] ediv tpOrder rangeNull))
-                      starTVs
-      tvBinds     = map (\(x, t) -> mkBindt x t drng) tvArgs
-      fullTp      = tpForall (tpParams ++ [ediv]) $ TpFun ((selfArg,dataTp):(otherArg,dataTp):tvArgs) ediv tpOrder rangeNull
-      doMakeBranches [] = []
-      doMakeBranches [c] = [head (makeBranches c)] -- Last constructor only needs to check equality
-      doMakeBranches (c:cs) = makeBranches c ++ doMakeBranches cs
-      branches    = doMakeBranches (dataInfoConstrs info)
+  let
+      drng = dataInfoRange info
+      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
+      doc         = "// Automatically generated.\n// Comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
       litLt       = Var (newName "Lt") False drng
       litGt       = Var (newName "Gt") False drng
       litEq       = Var nameCmpEq False drng
-      caseArg     = [(Nothing, Var selfArg False drng), (Nothing, Var otherArg False drng)]
-      caseExpr    = Case (App (Var (nameTuple 2) False drng) caseArg drng) branches False drng
-      defExpr     = Ann (Lam (mkBindt selfArg dataTp drng:mkBindt otherArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
-      visibility  = dataInfoVis info
-      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
-      doc         = "// Automatically generated.\n// Comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
-      defName     = newLocallyQualified "" (nameStem dataName) "cmp"
-      def         = Def (ValueBinder defName () defExpr drng drng) drng visibility (DefFun [Borrow] (NoFip False)) InlineAlways doc
-      tupleBranch :: Pattern UserType -> Pattern UserType -> Expr UserType -> Range -> Branch UserType
-      tupleBranch p1 p2 res r = Branch (PatCon (nameTuple 2) [(Nothing, p1), (Nothing, p2)] r r) [Guard guardTrue res]
-      makeBranches :: ConInfo -> [Branch UserType]
-      makeBranches con
-        = let crng = conInfoRange con
-              getTV :: UserType -> Maybe Name
-              getTV ty =
-                case ty of
-                  TpVar x _ ->
-                    do tvar <- find (\(TpVar xx _) -> x == xx) starTVs
-                       return (tVarName tvar)
-                  _ -> Nothing
-              tpCmpName :: UserType -> Expr UserType
-              tpCmpName ty =
-                case getTV ty of
-                  Just x -> Var (fst $ splitImplicitParamName x) False crng
-                  Nothing -> Var nameCmp False crng
-              cmpTp :: Expr UserType -> Expr UserType -> UserType -> Expr UserType
-              cmpTp expL expR ty   =
-                -- Use fully qualified defName if the type is the same as the data type
-                if ty == dataTp then App (Var defName False crng) [(Nothing, expL), (Nothing, expR)] crng
-                else App (tpCmpName ty) [(Nothing, expL), (Nothing, expR)] crng
-              fields = map (\(nm, tp) -> (not (isFun tp), (nm, userTp nice tp))) (conInfoParams con)
-              pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
-              pVar fld postfix     = if fst fld then PatVar (ValueBinder (postpend postfix (fst (snd fld))) Nothing (PatWild crng) crng crng)
-                                    else PatWild crng
-              patternsL           = [(Nothing,pVar fld "") | fld <- fields]
-              patternsR           = [(Nothing,pVar fld "'") | fld <- fields]
-              nonFunctionFields   = map snd (filter fst fields)
-              cmpField(fldN, fldT) = cmpTp (Var fldN False crng) (Var (postpend "'" fldN) False crng) fldT
-              binderNeqName nm       = (prepend (nameStem nm) $ newName "_order")
-              binderNeqPat nm        = ValueBinder (binderNeqName nm)  Nothing (PatWild crng) crng crng
-              branchExpr' [field]                = cmpField field
-              branchExpr' (field@(nm,tp):fields) = Case (cmpField field) [
-                                                      Branch (PatCon nameCmpEq [] crng crng) [Guard guardTrue (branchExpr' fields)],
-                                                      Branch (PatVar (binderNeqPat nm)) [Guard guardTrue (Var (binderNeqName nm) False crng)]
-                                                    ] False crng
-              branchExpr = case nonFunctionFields of
-                [] -> litEq
-                _ -> branchExpr' nonFunctionFields
-              branch              = tupleBranch (PatCon (conInfoName con) patternsL crng crng) (PatCon (conInfoName con) patternsR crng crng)
-              ltbranch            = tupleBranch (PatCon (conInfoName con) [] crng crng) (PatWild crng) litLt crng
-              gtbranch            = tupleBranch (PatWild crng) (PatCon (conInfoName con) [] crng crng) litGt crng
-            in [branch branchExpr crng, ltbranch, gtbranch]
-  return def
+  return $ synBinaryOp modName nameCmp False doc info (evar, TpVar (newName "e") rangeNull) tpOrder [] $ \idx _ con recur fields ->
+      let crng = conInfoRange con
+          pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
+          pVar fld postfix     = if fst fld then PatVar (ValueBinder (postpend postfix (fst (snd fld))) Nothing (PatWild crng) crng crng)
+                                else PatWild crng
+          patternsL           = [(Nothing,pVar fld "") | fld <- fields]
+          patternsR           = [(Nothing,pVar fld "'") | fld <- fields]
+          nonFunctionFields   = map snd (filter fst fields)
+          cmpField(fldN, fldT) = recur (Var fldN False crng) (Var (postpend "'" fldN) False crng) fldT
+          binderNeqName nm       = (prepend (nameStem nm) $ newName "_order")
+          binderNeqPat nm        = ValueBinder (binderNeqName nm)  Nothing (PatWild crng) crng crng
+          branchExpr' [field]                = cmpField field
+          branchExpr' (field@(nm,tp):fields) = Case (cmpField field) [
+                                                  Branch (PatCon nameCmpEq [] crng crng) [Guard guardTrue (branchExpr' fields)],
+                                                  Branch (PatVar (binderNeqPat nm)) [Guard guardTrue (Var (binderNeqName nm) False crng)]
+                                                ] False crng
+          branchExpr = case nonFunctionFields of
+            [] -> litEq
+            _ -> branchExpr' nonFunctionFields
+          branch              = tupleBranch (PatCon (conInfoName con) patternsL crng crng) (PatCon (conInfoName con) patternsR crng crng)
+          ltbranch            = tupleBranch (PatCon (conInfoName con) [] crng crng) (PatWild crng) litLt crng
+          gtbranch            = tupleBranch (PatWild crng) (PatCon (conInfoName con) [] crng crng) litGt crng
+        in if idx == length (dataInfoConstrs info) - 1 then [branch branchExpr crng] else [branch branchExpr crng, ltbranch, gtbranch]
 
 nameOrd2Eq = newName "Eq2"
 nameOrd2Lt = newName "Lt2"
@@ -400,96 +406,53 @@ nameOrd2 = newName "order2"
 synOrder2 :: Name -> DataInfo -> Core.CorePhase b (Def UserType) -- TODO: Make this actually fip
 synOrder2 modName info = do
   evar <- TV.freshTypeVar kindEffect Bound
-  let drng        = dataInfoRange info
-      dataName    = dataInfoName info
+  let dataName = dataInfoName info
+      drng = dataInfoRange info
+      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
+      doc         = "// Automatically generated.\n// Fip comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")      
+      litLt       = Var nameOrd2Lt False drng
+      litGt       = Var nameOrd2Gt False drng
+      litEq       = Var nameOrd2Eq False drng
       tyParams    = dataInfoParams info
       nice        = niceTypeExtendVars (evar:tyParams) niceEmpty
       showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
       tpParams    = map (\tv -> TpVar (showTV tv) rangeNull) tyParams
-      starTVs     = map (\tv -> TpVar (showTV tv) rangeNull) (filter isStarTypeVar tyParams)
-      ediv        = TpVar (showTV evar) rangeNull
-      selfArg     = newName "this"
-      otherArg    = newName "other"
       dataTp      = TpApp (TpCon dataName drng) tpParams drng
-      tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ tpVarName tv) "order2")
       tpOrder2    = TpApp (TpCon nameOrd2 drng) [dataTp] drng
-      tvArgs      = map (\x -> (tVarName x, TpFun
-                          [(prepend "this" (tpVarName x), x),
-                           (prepend "other" (tpVarName x), x)] ediv (TpApp (TpCon nameOrd2 drng) [x] rangeNull) rangeNull))
-                      starTVs
-      tvBinds     = map (\(x, t) -> mkBindt x t drng) tvArgs
-      fullTp      = tpForall (tpParams ++ [ediv]) $ TpFun ((selfArg,dataTp):(otherArg,dataTp):tvArgs) ediv tpOrder2 rangeNull
-      doMakeBranches [] = []
-      doMakeBranches [c] = [head (makeBranches c)] -- Last constructor only needs to check equality
-      doMakeBranches (c:cs) = makeBranches c ++ doMakeBranches cs
-      branches    = doMakeBranches (dataInfoConstrs info)
-      litLt       = Var nameOrd2Lt False drng
-      litGt       = Var nameOrd2Gt False drng
-      litEq       = Var nameOrd2Eq False drng
-      caseArg     = [(Nothing, Var selfArg False drng), (Nothing, Var otherArg False drng)]
-      caseExpr    = Case (App (Var (nameTuple 2) False drng) caseArg drng) branches False drng
-      defExpr     = Ann (Lam (mkBindt selfArg dataTp drng:mkBindt otherArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
-      visibility  = dataInfoVis info
-      anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
-      doc         = "// Automatically generated.\n// Fip comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
-      defName     = newLocallyQualified "" (nameStem dataName) "order2"
-      def         = Def (ValueBinder defName () defExpr drng drng) drng visibility (DefFun [Borrow] (NoFip False)) InlineAlways doc
-      tupleBranch :: Pattern UserType -> Pattern UserType -> Expr UserType -> Range -> Branch UserType
-      tupleBranch p1 p2 res r = Branch (PatCon (nameTuple 2) [(Nothing, p1), (Nothing, p2)] r r) [Guard guardTrue res]
-      makeBranches :: ConInfo -> [Branch UserType]
-      makeBranches con
-        = let crng = conInfoRange con
-              getTV :: UserType -> Maybe Name
-              getTV ty =
-                case ty of
-                  TpVar x _ ->
-                    do tvar <- find (\(TpVar xx _) -> x == xx) starTVs
-                       return (tVarName tvar)
-                  _ -> Nothing
-              tpOrder2Name :: UserType -> Expr UserType
-              tpOrder2Name ty =
-                case getTV ty of
-                  Just x -> Var (fst $ splitImplicitParamName x) False crng
-                  Nothing -> Var nameOrder2 False crng
-              order2Tp :: Expr UserType -> Expr UserType -> UserType -> Expr UserType
-              order2Tp expL expR ty   =
-                -- Use fully qualified defName if the type is the same as the data type
-                if ty == dataTp then App (Var defName False crng) [(Nothing, expL), (Nothing, expR)] crng
-                else App (tpOrder2Name ty) [(Nothing, expL), (Nothing, expR)] crng
-              fields = map (\(nm, tp) -> (not (isFun tp), (nm, userTp nice tp))) (conInfoParams con)
-              varN fld postfix     = postpend postfix (fst (snd fld))
-              pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
-              pVar fld postfix     = if fst fld then PatVar (ValueBinder (varN fld postfix) Nothing (PatWild crng) crng crng)
-                                    else PatWild crng
-              patternsL           = [(Nothing,pVar fld "") | fld <- fields]
-              patternsR           = [(Nothing,pVar fld "'") | fld <- fields]
-              nonFunctionFields   = map snd (filter fst fields)
-              order2Field(fldN, fldT) = order2Tp (Var fldN False crng) (Var (postpend "'" fldN) False crng) fldT
-              patEqName nm       = (prepend (nameStem nm) $ newName "_eq")
-              patLtLName nm       = (prepend (nameStem nm) $ newName "_lt")
-              patLtRName nm       = (prepend (nameStem nm) $ newName "_gt")
-              patGtLName nm       = (prepend (nameStem nm) $ newName "_lt")
-              patGtRName nm       = (prepend (nameStem nm) $ newName "_gt")
-              constr args         = App (Var (conInfoName con) False crng) (map (\nm -> (Nothing, Var nm False crng)) args) crng
-              patEq nm            = PatCon nameOrd2Eq [(Just (patEqName nm, crng), PatWild crng)] crng crng
-              patLt nm            = PatCon nameOrd2Lt [(Just (patLtLName nm, crng), PatWild crng), (Just (patLtRName nm, crng), PatWild crng)] crng crng
-              patGt nm            = PatCon nameOrd2Gt [(Just (patGtLName nm, crng), PatWild crng), (Just (patGtRName nm, crng), PatWild crng)] crng crng
-              patOther' = PatVar (ValueBinder (newName "other'") Nothing (PatWild crng) crng crng)
-              patThis' = PatVar (ValueBinder (newName "this'") Nothing (PatWild crng) crng crng)
-              varNThis fld         = fst fld
-              varNOther fld         = postpend "'" (fst fld)
-              branchExpr' [] eqFields                = App litEq [(Nothing, constr (reverse eqFields))] crng
-              branchExpr' (field@(nm,tp):fields) eqFields = Case (order2Field field) [
-                                                      Branch (patEq nm) [Guard guardTrue (branchExpr' fields (patEqName nm:eqFields))],
-                                                      Branch (patLt nm) [Guard guardTrue (App litLt [(Nothing, constr (reverse eqFields ++ [patLtLName nm] ++ map varNThis fields)), (Nothing, constr (reverse eqFields ++ [patLtRName nm] ++ map varNOther fields))] crng)],
-                                                      Branch (patGt nm) [Guard guardTrue (App litGt [(Nothing, constr (reverse eqFields ++ [patGtLName nm] ++ map varNOther fields)), (Nothing, constr (reverse eqFields ++ [patGtRName nm] ++map varNThis fields))] crng)]
-                                                    ] False crng
-              branchExpr = branchExpr' nonFunctionFields []
-              branch              = tupleBranch (PatCon (conInfoName con) patternsL crng crng) (PatCon (conInfoName con) patternsR crng crng)
-              ltbranch            = tupleBranch (PatCon (conInfoName con) patternsL crng crng) patOther'
-                                                    (App litLt [(Nothing, constr (map (varNThis . snd) fields)), (Nothing, Var (newName "other'") False crng)] crng) crng
-              gtbranch            = tupleBranch patThis' (PatCon (conInfoName con) patternsR crng crng)
-                                                    (App litGt [(Nothing, constr (map (varNOther . snd) fields)), (Nothing, Var (newName "this'") False crng)] crng) crng
-            in [branch branchExpr crng, ltbranch, gtbranch]
-  return def
+  return $ synBinaryOp modName nameOrder2 False doc info (evar, TpVar (newName "e") rangeNull) tpOrder2 [] $ \idx dataTp con recur fields ->
+      let crng = conInfoRange con
+          varN fld postfix     = postpend postfix (fst (snd fld))
+          pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
+          pVar fld postfix     = if fst fld then PatVar (ValueBinder (varN fld postfix) Nothing (PatWild crng) crng crng)
+                                else PatWild crng
+          patternsL           = [(Nothing,pVar fld "") | fld <- fields]
+          patternsR           = [(Nothing,pVar fld "'") | fld <- fields]
+          nonFunctionFields   = map snd (filter fst fields)
+          order2Field(fldN, fldT) = recur (Var fldN False crng) (Var (postpend "'" fldN) False crng) fldT
+          patEqName nm       = (prepend (nameStem nm) $ newName "_eq")
+          patLtLName nm       = (prepend (nameStem nm) $ newName "_lt")
+          patLtRName nm       = (prepend (nameStem nm) $ newName "_gt")
+          patGtLName nm       = (prepend (nameStem nm) $ newName "_lt")
+          patGtRName nm       = (prepend (nameStem nm) $ newName "_gt")
+          constr args         = App (Var (conInfoName con) False crng) (map (\nm -> (Nothing, Var nm False crng)) args) crng
+          patEq nm            = PatCon nameOrd2Eq [(Just (patEqName nm, crng), PatWild crng)] crng crng
+          patLt nm            = PatCon nameOrd2Lt [(Just (patLtLName nm, crng), PatWild crng), (Just (patLtRName nm, crng), PatWild crng)] crng crng
+          patGt nm            = PatCon nameOrd2Gt [(Just (patGtLName nm, crng), PatWild crng), (Just (patGtRName nm, crng), PatWild crng)] crng crng
+          patOther' = PatVar (ValueBinder (newName "other'") Nothing (PatWild crng) crng crng)
+          patThis' = PatVar (ValueBinder (newName "this'") Nothing (PatWild crng) crng crng)
+          varNThis fld         = fst fld
+          varNOther fld         = postpend "'" (fst fld)
+          branchExpr' [] eqFields                = App litEq [(Nothing, constr (reverse eqFields))] crng
+          branchExpr' (field@(nm,tp):fields) eqFields = Case (order2Field field) [
+                                                  Branch (patEq nm) [Guard guardTrue (branchExpr' fields (patEqName nm:eqFields))],
+                                                  Branch (patLt nm) [Guard guardTrue (App litLt [(Nothing, constr (reverse eqFields ++ [patLtLName nm] ++ map varNThis fields)), (Nothing, constr (reverse eqFields ++ [patLtRName nm] ++ map varNOther fields))] crng)],
+                                                  Branch (patGt nm) [Guard guardTrue (App litGt [(Nothing, constr (reverse eqFields ++ [patGtLName nm] ++ map varNOther fields)), (Nothing, constr (reverse eqFields ++ [patGtRName nm] ++map varNThis fields))] crng)]
+                                                ] False crng
+          branchExpr = branchExpr' nonFunctionFields []
+          branch              = tupleBranch (PatCon (conInfoName con) patternsL crng crng) (PatCon (conInfoName con) patternsR crng crng)
+          ltbranch            = tupleBranch (PatCon (conInfoName con) patternsL crng crng) patOther'
+                                                (App litLt [(Nothing, constr (map (varNThis . snd) fields)), (Nothing, Var (newName "other'") False crng)] crng) crng
+          gtbranch            = tupleBranch patThis' (PatCon (conInfoName con) patternsR crng crng)
+                                                (App litGt [(Nothing, constr (map (varNOther . snd) fields)), (Nothing, Var (newName "this'") False crng)] crng) crng
+        in if idx == length (dataInfoConstrs info) - 1 then [branch branchExpr crng] else [branch branchExpr crng, ltbranch, gtbranch]
 

--- a/src/Main/langserver/LanguageServer/Handler/CodeAction.hs
+++ b/src/Main/langserver/LanguageServer/Handler/CodeAction.hs
@@ -65,7 +65,8 @@ codeActionHandler
             Just info -> do
               let actions = [("show", synShowString modname info), ("==", synEquality modname info),
                              ("cmp", synOrd modname info), ("order2", synOrder2 modname info),
-                             ("recursive method", synPlaceholder modname "method" info), ("general method", synPlaceholder2 modname "method" info)]
+                             ("function", synOverloaded modname "overloaded" info), 
+                             ("map", synMap modname "map" info)]
               let results = map (\(nm, action) -> (nm, Core.runCorePhase 0 action)) actions
               env <- getPrettyEnvFor modname
               responder $ Right $ J.InL (mapMaybe (\(nm, res) -> J.InR <$> toCodeAction env origuri (dataInfoRange info) nm res) results)
@@ -87,8 +88,8 @@ toCodeAction env uri rng kind err =
           "==" -> "Generate (==) function"
           "cmp" -> "Generate cmp (comparison) function"
           "order2" -> "Generate order2 (fip comparison) function"
-          "general method" -> "Generate a method that is recursive only on the fields of the data type"
-          "recursive method" -> "Generate a recursive method that calls the method for each field"
+          "map" -> "Generate a map function"
+          "function" -> "Generate an overloaded function"
         )
         (Just J.CodeActionKind_QuickFix) Nothing Nothing Nothing
         (Just (J.WorkspaceEdit (Just (M.singleton uri [
@@ -154,7 +155,7 @@ instance Eq UserQuantifier where
 instance Eq (TypeBinder k) where
   TypeBinder x _ _ _ == TypeBinder y _ _ _ = x == y
 
-instance Eq UserType where
+instance Eq (KUserType k) where
   TpVar x _ == TpVar y _ = x == y
   TpCon x _ == TpCon y _ = x == y
   TpApp x xs _ == TpApp y ys _ = x == y && xs == ys
@@ -172,13 +173,11 @@ appendStr (Lit (LitString s1 _)) (App (Var op _ _) [(_, Lit (LitString s2 _)), (
                 appendStr (Lit (LitString (s1 ++ s2) rangeNull)) s3
 appendStr expr1 expr2 = App appendOp [(Nothing, expr1), (Nothing, expr2)] rangeNull
 
-type SynUnaryBranch = UserType -> ConInfo -> (Expr UserType -> UserType -> Expr UserType) -> [(Bool, (Name, UserType))] -> [Branch UserType]
+type SynUnaryBranch = UserType -> ConInfo -> (Expr UserType -> UserType -> Expr UserType) -> (UserType -> Bool) -> [(Bool, (Name, UserType))] -> [Branch UserType]
 
-synGeneralUnary :: Name -> Name -> String -> DataInfo -> (TypeVar, UserType) -> UserType -> SynUnaryBranch -> (Def UserType)
+synGeneralUnary :: Name -> Name -> String -> DataInfo -> (TypeVar, UserType) -> ((Bool, UserType, Int) -> UserType) -> SynUnaryBranch -> (Def UserType)
 synGeneralUnary modName generalName doc info (evar, effectTp) resultTp mkBranches =
-  let DataInfo{dataInfoRange = drng }   = info
-      dataName    = dataInfoName info
-      tyParams    = dataInfoParams info
+  let DataInfo{dataInfoRange = drng, dataInfoParams = tyParams, dataInfoConstrs = constrs, dataInfoVis = vis, dataInfoName = dataName }   = info
       nice        = niceTypeExtendVars (evar:tyParams) niceEmpty
       showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
       tpParams    = map (\tv -> TpVar (showTV tv) drng) tyParams
@@ -186,14 +185,14 @@ synGeneralUnary modName generalName doc info (evar, effectTp) resultTp mkBranche
       selfArg     = if all isAlphaNum (show dataName) then dataName else newName "this"
       tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem $ tpVarName tv) (nameStem generalName))
       starTVs     = map (\tv -> TpVar (showTV tv) drng) $ filter isStarTypeVar tyParams
-      tvArgs      = map (\x -> (tVarName x, TpFun [(prepend "tv" (tpVarName x), x)] effectTp resultTp rangeNull)) starTVs
+      tvArgs      = zipWith (\i x -> (tVarName x, TpFun [(prepend "tv" (tpVarName x), x)] effectTp (resultTp (False, x, i)) rangeNull)) [0..] starTVs
       tvBinds     = map (\(x, tp) -> mkBindt x tp drng) tvArgs
-      fullTp      = tpForall (tpParams ++ [effectTp]) $ TpFun ((selfArg,dataTp):tvArgs) effectTp resultTp rangeNull
-      showExpr    = Ann (Lam (mkBindt selfArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
-      branches    = concatMap makeBranch (dataInfoConstrs info)
+      fullTp      = tpForall (tpParams ++ [effectTp]) $ TpFun ((selfArg,dataTp):tvArgs) effectTp (resultTp (True, dataTp, 0)) rangeNull
+      showExpr    = Ann (Lam (mkBindt selfArg dataTp drng:tvBinds) caseExpr True drng) fullTp drng
+      branches    = concatMap makeBranch constrs
       caseExpr    = Case (Var selfArg False drng) branches False drng
       defName     = newLocallyQualified "" (nameStem dataName) (nameStem generalName)
-      def         = Def (ValueBinder defName () showExpr drng drng) drng (dataInfoVis info) (DefFun [Borrow] (NoFip False)) InlineAlways doc
+      def         = Def (ValueBinder defName () showExpr drng drng) drng vis (DefFun [Borrow] (NoFip False)) InlineAlways doc
       makeBranch :: ConInfo -> [Branch UserType]
       makeBranch con
         = let
@@ -215,15 +214,19 @@ synGeneralUnary modName generalName doc info (evar, effectTp) resultTp mkBranche
                 -- Use fully qualified defName if the type is the same as the data type
                 if ty == dataTp then App (Var defName False crng) [(Nothing, exp)] crng
                 else App (tyAppName ty) [(Nothing, exp)] crng
+              isTV :: UserType -> Bool
+              isTV (TpVar _ _) = True
+              isTV _ = False
               fields                = map (\(nm, tp) -> (not (isFun tp), (nm, userTp nice tp))) (conInfoParams con)
-            in mkBranches dataTp con recur fields
+            in mkBranches dataTp con recur isTV fields
   in def
 
-synPlaceholder :: Name -> String -> DataInfo -> Core.CorePhase b (Def UserType)
-synPlaceholder modName generalName info = do
+synOverloaded :: Name -> String -> DataInfo -> Core.CorePhase b (Def UserType)
+synOverloaded modName generalName info = do
   evar <- TV.freshTypeVar kindEffect Bound
-  let doc  = "// " ++ generalName ++ " method for `" ++ (nameStem dataName) ++ "` type.\n"
-  return $ synGeneralUnary modName (newName generalName) doc info (evar, TpVar (newName "e") rangeNull) (TpVar (newName "a") rangeNull) $ \_ con recur fields ->
+  let doc  = "// " ++ generalName ++ " function for `" ++ (nameStem dataName) ++ "` type.\n"
+      dataName = dataInfoName info
+  return $ synGeneralUnary modName (newName generalName) doc info (evar, TpVar (newName "e") rangeNull) (const (TpVar (newName "a") rangeNull)) $ \_ con recur _ fields ->
     let crng = conInfoRange con
         patterns              = [(Nothing,pVar fld crng) | fld <- fields]
         defs                  = map (\f@(isFunc,(fldNm,fldTp)) ->
@@ -233,34 +236,40 @@ synPlaceholder modName generalName info = do
         conMatch              = PatCon (conInfoName con) patterns crng crng
         branchExpr            = [Branch conMatch [Guard guardTrue (Let (DefRec defs) (Var nameUnit False crng) crng)]]
       in branchExpr
-  where dataName = dataInfoName info
 
-synPlaceholder2 :: Name -> String -> DataInfo -> Core.CorePhase b (Def UserType)
-synPlaceholder2 modName generalName info = do
+synMap :: Name -> String -> DataInfo -> Core.CorePhase b (Def UserType)
+synMap modName generalName info = do
   evar <- TV.freshTypeVar kindEffect Bound
-  let doc  = "// " ++ generalName ++ " method for `" ++ (nameStem dataName) ++ "` type.\n"
-  return $ synGeneralUnary modName (newName generalName) doc info (evar, TpVar (newName "e") rangeNull) (TpVar (newName "a") rangeNull) $ \dataTp con recur fields ->
+  let dataName = dataInfoName info 
+      doc  = "// " ++ generalName ++ " function for `" ++ (nameStem dataName) ++ "` type.\n"
+      DataInfo{dataInfoRange = drng, dataInfoParams = tyParams, dataInfoConstrs = constrs, dataInfoVis = vis }   = info
+  tvarsnew <- mapM (\x -> if isStarTypeVar x then Left <$> (TV.freshTypeVar kindStar Bound) else return $ Right x) tyParams
+  let newstarvars = concatMap (\x -> case x of {Right _ -> []; Left x -> [x]}) tvarsnew
+      nice        = niceTypeExtendVars (evar:tyParams ++ newstarvars) niceEmpty
+      showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
+      tpParamsNew    = map (\tv -> case tv of {Right tv -> TpVar (showTV tv) drng; Left tv -> TpVar (showTV tv) drng}) tvarsnew
+      returnTp (isDataTp, tp, i) = if isDataTp then TpApp (TpCon dataName drng) tpParamsNew drng -- final return type 
+                                   else TpVar (showTV (newstarvars !! i)) rangeNull -- return type for polymorphic starTVs
+  return $ synGeneralUnary modName (newName generalName) doc info (evar, TpVar (newName "e") rangeNull) returnTp $ \dataTp con recur isTV fields ->
     let crng = conInfoRange con
-        patterns              = [(Nothing,pVar fld crng) | fld <- fields]
-        defs                  = mapMaybe (\f@(isFunc,(fldNm,fldTp)) ->
-                                    if fldTp == dataTp then
-                                      Just $ Def (ValueBinder (prepend "rec" fldNm) () (recur (Var fldNm False crng) fldTp) crng crng) crng Private DefVal InlineAlways ""
-                                    else
-                                      Nothing
-                                  ) fields
         pVar fld rng          = PatVar (ValueBinder (fst (snd fld)) Nothing (PatWild rng) rng rng)
+        patterns              = [(Nothing,pVar fld crng) | fld <- fields]
+        newfields             = map (\f@(isFunc,(fldNm,fldTp)) ->
+                                    if fldTp == dataTp || isTV fldTp then
+                                      recur (Var fldNm False crng) fldTp
+                                    else
+                                      Var fldNm False crng
+                                  ) fields
         conMatch              = PatCon (conInfoName con) patterns crng crng
-        branchExpr            = [Branch conMatch [Guard guardTrue (Let (DefRec defs) (Var nameUnit False crng) crng)]]
+        branchExpr            = [Branch conMatch [Guard guardTrue (App (Var (conInfoName con) False crng) (map (\e -> (Nothing, e)) newfields) crng)]]
       in branchExpr
-  where dataName = dataInfoName info
-
 
 synShowString :: Name -> DataInfo -> Core.CorePhase b (Def UserType)
 synShowString modName info = do
   evar <- TV.freshTypeVar kindEffect Bound
   let anyFunctionFields = any (any (isFun . snd) . conInfoParams) (dataInfoConstrs info)
       doc         = "// Automatically generated.\n// Shows a string representation of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
-  return $ synGeneralUnary modName nameShow doc info (evar, TpVar (newName "e") rangeNull) tpString $ \_ con recur fields ->
+  return $ synGeneralUnary modName nameShow doc info (evar, TpVar (newName "e") rangeNull) (const tpString) $ \_ con recur _ fields ->
     let crng = conInfoRange con
         lString s             = Lit (LitString s crng)
         patterns              = [(Nothing,pVar fld crng) | fld <- fields]
@@ -284,7 +293,7 @@ type SynBinaryBranch = Int -> UserType -> ConInfo -> (Expr UserType -> Expr User
 tupleBranch :: Pattern UserType -> Pattern UserType -> Expr UserType -> Range -> Branch UserType
 tupleBranch p1 p2 res r = Branch (PatCon (nameTuple 2) [(Nothing, p1), (Nothing, p2)] r r) [Guard guardTrue res]
 
-synBinaryOp :: Name -> Name -> Bool -> String -> DataInfo -> (TypeVar, UserType) -> UserType -> [Branch UserType] -> SynBinaryBranch -> Def UserType
+synBinaryOp :: Name -> Name -> Bool -> String -> DataInfo -> (TypeVar, UserType) -> (UserType -> UserType) -> [Branch UserType] -> SynBinaryBranch -> Def UserType
 synBinaryOp modName generalName isOp doc info (evar, effectTp) resultTp defaultBranch mkBranch =
   let drng        = dataInfoRange info
       dataName    = dataInfoName info
@@ -299,15 +308,15 @@ synBinaryOp modName generalName isOp doc info (evar, effectTp) resultTp defaultB
       tVarName tv = toImplicitParamName (newLocallyQualified "" (nameStem (tpVarName tv)) (nameStem generalName))
       tvArgs      = map (\x -> (tVarName x, TpFun
                           [(prepend "this" (tpVarName x), x),
-                           (prepend "other" (tpVarName x), x)] effectTp resultTp rangeNull))
+                           (prepend "other" (tpVarName x), x)] effectTp (resultTp x) rangeNull))
                       starTVs
       tvBinds     = map (\(x, t) -> mkBindt x t drng) tvArgs
-      fullTp      = tpForall (tpParams ++ [effectTp]) $ TpFun ((selfArg,dataTp):(otherArg,dataTp):tvArgs) effectTp resultTp rangeNull
+      fullTp      = tpForall (tpParams ++ [effectTp]) $ TpFun ((selfArg,dataTp):(otherArg,dataTp):tvArgs) effectTp (resultTp dataTp) rangeNull
       branches    = concat $ zipWith makeBranch (dataInfoConstrs info) [0..] 
       litBool b rng = if b then Var nameTrue False rng else Var nameFalse False rng
       caseArg     = [(Nothing, Var selfArg False drng), (Nothing, Var otherArg False drng)]
       caseExpr    = Case (App (Var (nameTuple 2) False drng) caseArg drng) (branches ++ defaultBranch) False drng
-      defExpr     = Ann (Lam (mkBindt selfArg dataTp drng:mkBindt otherArg dataTp drng:tvBinds) caseExpr drng) fullTp drng
+      defExpr     = Ann (Lam (mkBindt selfArg dataTp drng:mkBindt otherArg dataTp drng:tvBinds) caseExpr True drng) fullTp drng
       defName     = newLocallyQualified "" (nameStem dataName) (nameStem generalName)
       def         = Def (ValueBinder defName () defExpr drng drng) drng (dataInfoVis info) (DefFun [Borrow] (NoFip False)) InlineAlways doc
       makeBranch :: ConInfo -> Int -> [Branch UserType]
@@ -343,7 +352,7 @@ synEquality modName info = do
       doc         = "// Automatically generated.\n// Equality comparison of the `" ++ nameStem (dataInfoName info) ++ "` type" ++ (if anyFunctionFields then " (ignores function fields).\n" else ".\n")
       defaultBranch :: [Branch UserType]
       defaultBranch = ([tupleBranch (PatWild drng) (PatWild drng) (litBool False drng) drng | not (hasSingleCon info)])
-  return $ synBinaryOp modName nameEq True doc info (evar, TpVar (newName "e") rangeNull) tpBool defaultBranch $ \_ _ con recur fields ->
+  return $ synBinaryOp modName nameEq True doc info (evar, TpVar (newName "e") rangeNull) (const tpBool) defaultBranch $ \_ _ con recur fields ->
       let crng = conInfoRange con
           pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
           pVar fld postfix     = if fst fld then PatVar (ValueBinder (postpend postfix (fst (snd fld))) Nothing (PatWild crng) crng crng)
@@ -374,7 +383,7 @@ synOrd modName info = do
       litLt       = Var (newName "Lt") False drng
       litGt       = Var (newName "Gt") False drng
       litEq       = Var nameCmpEq False drng
-  return $ synBinaryOp modName nameCmp False doc info (evar, TpVar (newName "e") rangeNull) tpOrder [] $ \idx _ con recur fields ->
+  return $ synBinaryOp modName nameCmp False doc info (evar, TpVar (newName "e") rangeNull) (const tpOrder) [] $ \idx _ con recur fields ->
       let crng = conInfoRange con
           pVar :: (Bool, (Name, UserType)) -> String -> Pattern UserType
           pVar fld postfix     = if fst fld then PatVar (ValueBinder (postpend postfix (fst (snd fld))) Nothing (PatWild crng) crng crng)
@@ -418,7 +427,7 @@ synOrder2 modName info = do
       showTV tv   = newName $ show $ ppTypeVar defaultEnv{nice=nice} tv
       tpParams    = map (\tv -> TpVar (showTV tv) rangeNull) tyParams
       dataTp      = TpApp (TpCon dataName drng) tpParams drng
-      tpOrder2    = TpApp (TpCon nameOrd2 drng) [dataTp] drng
+      tpOrder2 tp = TpApp (TpCon nameOrd2 drng) [tp] drng
   return $ synBinaryOp modName nameOrder2 False doc info (evar, TpVar (newName "e") rangeNull) tpOrder2 [] $ \idx dataTp con recur fields ->
       let crng = conInfoRange con
           varN fld postfix     = postpend postfix (fst (snd fld))

--- a/src/Main/langserver/LanguageServer/Handlers.hs
+++ b/src/Main/langserver/LanguageServer/Handlers.hs
@@ -59,6 +59,7 @@ import LanguageServer.Handler.TextDocument (didChangeHandler, didCloseHandler, d
 import LanguageServer.Handler.SignatureHelp (signatureHelpHandler)
 import LanguageServer.Monad
 import GHC.IO (catchAny)
+import LanguageServer.Handler.CodeAction (codeActionHandler)
 
 newtype ReactorInput = ReactorAction (IO ())
 
@@ -78,6 +79,7 @@ handlers =
       cancelHandler,
       commandHandler,
       inlayHintsHandler,
+      codeActionHandler,
       foldingHandler,
       configurationChangeHandler,
       signatureHelpHandler

--- a/src/Main/langserver/LanguageServer/Monad.hs
+++ b/src/Main/langserver/LanguageServer/Monad.hs
@@ -15,7 +15,7 @@ module LanguageServer.Monad
   ( LSState (..),
     InlayHintOptions(..),
     SignatureContext(..), clearSignatureContext, updateSignatureContext, getSignatureContext,
-    Colors(..), updateColorScheme, getColorScheme,
+    Colors(..), updateColorScheme, getColorScheme, toJSON, fromJSON,
     defaultLSState,
     newLSStateVar,
     LSM,

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -1,0 +1,198 @@
+
+------------------------------------------------------------------------------
+-- Copyright 2023, Tim Whiting
+--
+-- This is free software; you can redistribute it and/or modify it under the
+-- terms of the Apache License, Version 2.0. A copy of the License can be
+-- found in the LICENSE file at the root of this distribution.
+-----------------------------------------------------------------------------
+{-
+    Pretty print user syntax
+-}
+-----------------------------------------------------------------------------
+module Syntax.Pretty where
+import Type.Pretty
+import Type.Type
+import Core.Pretty
+import Lib.PPrint
+import Syntax.Syntax
+import Common.Syntax
+import Common.ColorScheme
+import Common.NamePrim
+import qualified Syntax.Syntax as S
+import Common.Range
+import Data.List
+
+class PrettyEnv t where
+  prettyEnv :: Env -> t -> Doc
+
+instance PrettyEnv t => PrettyEnv (Maybe t) where
+  prettyEnv env (Just x) = prettyEnv env x
+  prettyEnv env Nothing = empty
+
+instance PrettyEnv Type where
+  prettyEnv env tp = ppType env tp
+
+instance PrettyEnv (KUserType k) where
+  prettyEnv env tp =
+    case tp of
+      TpAnn tp _ -> prettyEnv env tp
+      TpVar n _ -> ppName env n
+      TpCon n _ -> ppName env n
+      TpQuan QForall tb tp rng -> text "forall<" <.> ppName env (tbinderName tb) <.> text ">" <+> prettyEnv env tp
+      TpQuan QExists tb tp rng -> text "exists<" <.> ppName env (tbinderName tb) <.> text ">" <+> prettyEnv env tp
+      TpQuan QSome tb tp rng -> text "some<" <.> ppName env (tbinderName tb) <.> text ">" <+> prettyEnv env tp
+      TpApp tp args _ -> prettyEnv env tp <.> angled (map (prettyEnv env) args)
+      TpFun args e res _ -> tupled (map (\(n, tp) -> prettyEnv env tp) args) <+> text "->" <+> prettyEnv env e <+> prettyEnv env res
+      TpParens tp _ -> tupled [prettyEnv env tp]
+      TpQual _ _ -> text "unhandled tp"
+
+allDefs :: S.DefGroup t -> [S.Def t]
+allDefs defs =
+  case defs of
+    S.DefNonRec d -> [d]
+    S.DefRec ds   -> ds
+
+ppLit :: S.Lit -> String
+ppLit (S.LitInt i range) = show i
+ppLit (S.LitFloat f range) = show f
+ppLit (S.LitChar c range) = show c
+ppLit (S.LitString s range) = show s
+
+ppVis :: Env -> Visibility -> Doc
+ppVis env vis
+  = case vis of
+      Private -> empty
+      Public -> keyword env "pub "
+
+ppSyntaxDef :: PrettyEnv t => Env -> S.Def t -> Doc
+ppSyntaxDef env (S.Def binder range vis sort inline doc)
+  = prettyComment env doc $
+    ppVis env vis <.> text (defSortShowFull sort) <+> ppValBinder env binder
+
+ppSyntaxDefUserType :: Env -> S.Def UserType -> Doc
+ppSyntaxDefUserType env (S.Def binder range vis sort inline doc)
+  = prettyComment env doc $
+    ppVis env vis <.> text (defSortShowFull sort) <+> (
+    case sort of
+      DefFun _ _ -> ppFunDef env binder
+      _ -> ppValBinder env binder
+      )
+
+ppSyntaxExtern :: Env -> S.External -> Doc
+ppSyntaxExtern env e = text "extern" <+> ppName env (extName e)
+
+returnType :: UserType -> Maybe (UserType, UserType)
+returnType (TpFun _ eff tp _) = Just (eff, tp)
+returnType (TpQuan _ _ tp _) = returnType tp
+returnType (TpQual _ tp) = returnType tp
+returnType _ = Nothing
+
+ppFunDef :: Env -> ValueBinder () (S.Expr UserType) -> Doc
+ppFunDef env (ValueBinder name _ (Lam vbs body _) _ _)
+  = ppName env name <.> tupled (map (ppMValBinder env) vbs) <--> indent 2 (ppSyntaxExpr env body)
+ppFunDef env (ValueBinder name _ (Ann (Lam vbs body _) tp _) _ _)
+  = case returnType tp of
+      Just (eff, ret) ->
+          ppName env name <.> tupled (map (ppMValBinder env) vbs) <+> colon <+> prettyEnv env eff <+> prettyEnv env ret <-->
+                                    indent 2 (ppSyntaxExpr env body)
+      Nothing -> ppName env name <.> tupled (map (ppMValBinder env) vbs) <--> indent 2 (ppSyntaxExpr env body)
+
+ppValBinder :: PrettyEnv t => Env -> ValueBinder () (S.Expr t) -> Doc
+ppValBinder env (ValueBinder name _ expr nameRange range)
+  = ppName env name <+> text "=" <+> ppSyntaxExpr env expr
+
+ppMValBinder :: PrettyEnv t => Env -> ValueBinder (Maybe t) (Maybe (S.Expr t)) -> Doc
+ppMValBinder env (ValueBinder name (Just tp) (Just expr) nameRange range)
+  = ppName env name <+> text "=" <+> ppSyntaxExpr env expr
+ppMValBinder env (ValueBinder name Nothing (Just expr) nameRange range)
+  = ppName env name <+> text "=" <+> ppSyntaxExpr env expr
+ppMValBinder env (ValueBinder name (Just tp) Nothing nameRange range)
+  = ppName env name <+> text ":" <+> prettyEnv env tp
+ppMValBinder env (ValueBinder name Nothing Nothing nameRange range)
+  = ppName env name
+
+ppValEmptyBinder ::  PrettyEnv t => Env -> ValueBinder (Maybe t) () -> Doc
+ppValEmptyBinder env (ValueBinder name _ () nameRange range)
+  = ppName env name
+
+ppPatBinder ::  PrettyEnv t => Env -> ValueBinder (Maybe t) (S.Pattern t) -> Doc
+ppPatBinder env (ValueBinder name _ (S.PatWild rng) nameRange range)
+  = ppName env name
+ppPatBinder env (ValueBinder name _ pat nameRange range)
+  = ppName env name <+> text "as" <+> ppSyntaxPattern env pat
+
+ppArg ::  PrettyEnv t => Env -> (Maybe (Name,Range),S.Expr t) -> Doc
+ppArg env (Nothing,expr) = ppSyntaxExpr env expr
+ppArg env (Just (name,_),expr) = ppName env name <+> text "=" <+> ppSyntaxExpr env expr
+
+ppSyntaxExpr ::  PrettyEnv t => Env -> S.Expr t -> Doc
+ppSyntaxExpr env e =
+  case e of
+    S.Lam pars expr range ->
+      text "fn" <.> tupled (map (ppMValBinder env) pars) <--> indent 2 (ppSyntaxExpr env expr)
+    S.Let defs expr range ->
+      vcat (map (ppSyntaxDef env) (allDefs defs) ++ [ppSyntaxExpr env expr])
+    Bind def expr range ->
+      vcat [ppSyntaxDef env def, ppSyntaxExpr env expr]
+    App (Var na True _) [(Nothing, x0), (Nothing, x1)] _ | not (isQualified na || isLocallyQualified na) -> -- Unqualified infix operations
+      ppSyntaxExpr env x0 <+> text (nameStem na) <+> ppSyntaxExpr env x1 
+    App (Var na True _) [(Nothing, x0)] _ -> -- Postfix operations?
+      ppSyntaxExpr env x0 <.> ppName env na
+    App (Var na _ _) args _ | isNameTuple na -> -- Tuple
+      tupled (map (ppArg env) args)
+    S.App (S.Var name _ _) args range | name == nameOpExpr ->
+      hcat (intersperse (text " ") (map (ppArg env) args))
+    S.App hnd@Handler{} [(_, a)] range ->
+      tupled [ppSyntaxExpr env hnd] <.> tupled [ppSyntaxExpr env a]
+    S.App fun args range ->
+      ppSyntaxExpr env fun <.> tupled (map (ppArg env) args)
+    S.Var name isop range -> ppName env name
+    S.Lit lit -> text $ ppLit lit
+    Ann expr tp range -> ppSyntaxExpr env expr
+    S.Case expr branches lazy range ->
+      text "match" <+> ppSyntaxExpr env expr <--> indent 2 (vcat (map (ppSyntaxBranch env) branches))
+    Parens expr name _ range -> ppSyntaxExpr env expr
+    Inject tp expr behind range ->
+      text "mask<" <.> prettyEnv env tp <.> text ">{" <--> indent 2 (ppSyntaxExpr env expr) <--> text "}"
+    Handler sort scope override allowmask eff pars reinit ret final branches drange range ->
+      text "handler" <--> indent 2 (vcat (ppMaybeExpr env ret: ppMaybeExpr env reinit : ppMaybeExpr env final : map (ppHandlerBranch env) branches))
+
+ppHandlerBranch ::  PrettyEnv t => Env -> S.HandlerBranch t -> Doc
+ppHandlerBranch env (HandlerBranch nm pars expr sort nmRng patRng) =
+  pretty (show sort) <+> text (show nm) <.> tupled (map (ppValEmptyBinder env) pars) <--> indent 2 (ppSyntaxExpr env expr)
+
+ppMaybeExpr ::  PrettyEnv t => Env -> Maybe (Expr t) -> Doc
+ppMaybeExpr env (Just expr) = ppSyntaxExpr env expr
+ppMaybeExpr env Nothing = empty
+
+ppSyntaxBranch :: PrettyEnv t => Env -> S.Branch t -> Doc
+ppSyntaxBranch env (S.Branch pat [S.Guard (S.Var n _ _) body]) | nameTrue == n
+  = ppSyntaxPattern env pat <+> text "->" <--> indent 2 (ppSyntaxExpr env body)
+ppSyntaxBranch env (S.Branch pat [guard])
+  = ppSyntaxPattern env pat <+> text "|" <+> ppSyntaxGuard env guard
+ppSyntaxBranch env b = text "Unhandled branch"
+
+ppSyntaxPattern :: PrettyEnv t => Env -> S.Pattern t -> Doc
+ppSyntaxPattern env (S.PatWild range) = text "_"
+ppSyntaxPattern env (S.PatVar binder) = ppPatBinder env binder
+ppSyntaxPattern env (PatAnn pat tp range) = ppSyntaxPattern env pat
+ppSyntaxPattern env (S.PatCon name args nameRng range)
+  | isNameTuple name = tupled (map (ppPatternArg env) args)
+  | null args = ppName env name
+  | otherwise = ppName env name <.> tupled (map (ppPatternArg env) args)
+ppSyntaxPattern env (PatParens pat range) = tupled [ppSyntaxPattern env pat]
+ppSyntaxPattern env (S.PatLit lit) = text $ ppLit lit
+
+ppPatternArg :: PrettyEnv t => Env -> (Maybe (Name,Range), S.Pattern t) -> Doc
+ppPatternArg env (Nothing,pat) = ppSyntaxPattern env pat
+ppPatternArg env (Just (name,_),S.PatWild rng) = ppName env name
+ppPatternArg env (Just (name,_),pat) = ppName env name <+> text "=" <+> ppSyntaxPattern env pat
+
+alwaysTrue :: Expr t -> Bool
+alwaysTrue (Var n _ _) | n == nameTrue = True
+alwaysTrue _ = False
+
+ppSyntaxGuard :: PrettyEnv t => Env -> S.Guard t -> Doc
+ppSyntaxGuard env (S.Guard guard body)
+  = if alwaysTrue guard then text "->" <+> ppSyntaxExpr env body else ppSyntaxExpr env guard <+> text "->" <--> indent 2 (ppSyntaxExpr env body)

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -150,6 +150,7 @@ ppSyntaxExpr env e =
       tupled [ppSyntaxExpr env hnd] <.> tupled [ppSyntaxExpr env a]
     S.App fun args range ->
       ppSyntaxExpr env fun <.> tupled (map (ppArg env) args)
+    S.Var nm isop range | nm == nameUnit -> text "()"
     S.Var name isop range -> ppName env name
     S.Lit lit -> text $ ppLit lit
     Ann expr tp range -> ppSyntaxExpr env expr

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -42,6 +42,7 @@ instance PrettyEnv (KUserType k) where
       TpQuan QForall tb tp rng -> text "forall<" <.> ppName env (tbinderName tb) <.> text ">" <+> prettyEnv env tp
       TpQuan QExists tb tp rng -> text "exists<" <.> ppName env (tbinderName tb) <.> text ">" <+> prettyEnv env tp
       TpQuan QSome tb tp rng -> text "some<" <.> ppName env (tbinderName tb) <.> text ">" <+> prettyEnv env tp
+      TpApp tp [] _ -> prettyEnv env tp
       TpApp tp args _ -> prettyEnv env tp <.> angled (map (prettyEnv env) args)
       TpFun args e res _ -> tupled (map (\(n, tp) -> prettyEnv env tp) args) <+> text "->" <+> prettyEnv env e <+> prettyEnv env res
       TpParens tp _ -> tupled [prettyEnv env tp]

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -135,6 +135,8 @@ ppSyntaxExpr env e =
       vcat (map (ppSyntaxDef env) (allDefs defs) ++ [ppSyntaxExpr env expr])
     Bind def expr range ->
       vcat [ppSyntaxDef env def, ppSyntaxExpr env expr]
+    App (Var na _ _) [] _ | isConstructorName na -> -- Singleton constructor
+      ppName env na
     App (Var na True _) [(Nothing, x0), (Nothing, x1)] _ | not (isQualified na || isLocallyQualified na) -> -- Unqualified infix operations
       ppSyntaxExpr env x0 <+> text (nameStem na) <+> ppSyntaxExpr env x1 
     App (Var na True _) [(Nothing, x0)] _ -> -- Postfix operations?

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -22,6 +22,7 @@ import Common.NamePrim
 import qualified Syntax.Syntax as S
 import Common.Range
 import Data.List
+import Data.Maybe (fromMaybe, isJust)
 
 class PrettyEnv t where
   prettyEnv :: Env -> t -> Doc
@@ -127,6 +128,10 @@ ppArg ::  PrettyEnv t => Env -> (Maybe (Name,Range),S.Expr t) -> Doc
 ppArg env (Nothing,expr) = ppSyntaxExpr env expr
 ppArg env (Just (name,_),expr) = ppName env name <+> text "=" <+> ppSyntaxExpr env expr
 
+isConstructorApp :: S.Expr t -> Bool
+isConstructorApp (S.Var n _ _) = isConstructorName n
+isConstructorApp _ = False
+
 ppSyntaxExpr ::  PrettyEnv t => Env -> S.Expr t -> Doc
 ppSyntaxExpr env e =
   case e of
@@ -139,7 +144,7 @@ ppSyntaxExpr env e =
     App (Var na _ _) [] _ | isConstructorName na -> -- Singleton constructor
       ppName env na
     App (Var na True _) [(Nothing, x0), (Nothing, x1)] _ | not (isQualified na || isLocallyQualified na) -> -- Unqualified infix operations
-      ppSyntaxExpr env x0 <+> text (nameStem na) <+> ppSyntaxExpr env x1 
+      ppSyntaxExpr env x0 <+> text (nameStem na) <+> ppSyntaxExpr env x1
     App (Var na True _) [(Nothing, x0)] _ -> -- Postfix operations?
       ppSyntaxExpr env x0 <.> ppName env na
     App (Var na _ _) args _ | isNameTuple na -> -- Tuple
@@ -148,7 +153,11 @@ ppSyntaxExpr env e =
       hcat (intersperse (text " ") (map (ppArg env) args))
     S.App hnd@Handler{} [(_, a)] range ->
       tupled [ppSyntaxExpr env hnd] <.> tupled [ppSyntaxExpr env a]
-    S.App fun args range ->
+    S.App fun [(Nothing, a)] range | not (isConstructorApp fun) -> -- prefer: arg.function 
+      ppSyntaxExpr env a <.> text "." <.> ppSyntaxExpr env fun
+    S.App fun ((Nothing, a):args) range | not (isConstructorApp fun) -> -- prefer: arg.function(args,...)
+      ppSyntaxExpr env a <.> text "." <.> ppSyntaxExpr env fun <.> tupled (map (ppArg env) args)
+    S.App fun args range -> -- named or no arguments prefer: function(named: arg, ...) or function()
       ppSyntaxExpr env fun <.> tupled (map (ppArg env) args)
     S.Var nm isop range | nm == nameUnit -> text "()"
     S.Var name isop range -> ppName env name
@@ -170,9 +179,16 @@ ppMaybeExpr ::  PrettyEnv t => Env -> Maybe (Expr t) -> Doc
 ppMaybeExpr env (Just expr) = ppSyntaxExpr env expr
 ppMaybeExpr env Nothing = empty
 
+contains :: Eq a => [a] -> [a] -> Bool
+contains search str = any (isPrefixOf search) (tails str)
+
 ppSyntaxBranch :: PrettyEnv t => Env -> S.Branch t -> Doc
 ppSyntaxBranch env (S.Branch pat [S.Guard (S.Var n _ _) body]) | nameTrue == n
-  = ppSyntaxPattern env pat <+> text "->" <--> indent 2 (ppSyntaxExpr env body)
+  = let bod = ppSyntaxExpr env body
+    in if contains "\n" (show bod) then
+        ppSyntaxPattern env pat <+> text "->" <--> indent 2 bod
+       else
+        ppSyntaxPattern env pat <+> text "->" <+> bod
 ppSyntaxBranch env (S.Branch pat [guard])
   = ppSyntaxPattern env pat <+> text "|" <+> ppSyntaxGuard env guard
 ppSyntaxBranch env b = text "Unhandled branch"

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -90,9 +90,9 @@ returnType (TpQual _ tp) = returnType tp
 returnType _ = Nothing
 
 ppFunDef :: Env -> ValueBinder () (S.Expr UserType) -> Doc
-ppFunDef env (ValueBinder name _ (Lam vbs body _) _ _)
+ppFunDef env (ValueBinder name _ (Lam vbs body _ _) _ _)
   = ppName env name <.> tupled (map (ppMValBinder env) vbs) <--> indent 2 (ppSyntaxExpr env body)
-ppFunDef env (ValueBinder name _ (Ann (Lam vbs body _) tp _) _ _)
+ppFunDef env (ValueBinder name _ (Ann (Lam vbs body _ _) tp _) _ _)
   = case returnType tp of
       Just (eff, ret) ->
           ppName env name <.> tupled (map (ppMValBinder env) vbs) <+> colon <+> prettyEnv env eff <+> prettyEnv env ret <-->
@@ -130,7 +130,7 @@ ppArg env (Just (name,_),expr) = ppName env name <+> text "=" <+> ppSyntaxExpr e
 ppSyntaxExpr ::  PrettyEnv t => Env -> S.Expr t -> Doc
 ppSyntaxExpr env e =
   case e of
-    S.Lam pars expr range ->
+    S.Lam pars expr _ range ->
       text "fn" <.> tupled (map (ppMValBinder env) pars) <--> indent 2 (ppSyntaxExpr env expr)
     S.Let defs expr range ->
       vcat (map (ppSyntaxDef env) (allDefs defs) ++ [ppSyntaxExpr env expr])

--- a/support/vscode/koka.language-koka/package.json
+++ b/support/vscode/koka.language-koka/package.json
@@ -310,12 +310,12 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@vscode/debugadapter": "^1.61.0",
-    "@vscode/debugprotocol": "^1.61.0",
+    "@vscode/debugadapter": "^1.68.0",
+    "@vscode/debugprotocol": "^1.68.0",
+    "semver": "^7.6.3",
     "await-notify": "1.0.1",
-    "semver": "^7.5.4",
+    "vscode-languageclient": "^9.0.1",
     "ts-loader": "^9.5.2",
-    "vscode-languageclient": "^8.1.0",
     "webpack": "^5.97.1",
     "webpack-cli": "^6.0.1"
   }

--- a/support/vscode/koka.language-koka/src/lang-server.ts
+++ b/support/vscode/koka.language-koka/src/lang-server.ts
@@ -162,7 +162,7 @@ export class KokaLanguageServer {
             console.log("Asking VSCode to trigger parameter hints")
             vscode.commands.executeCommand("editor.action.triggerParameterHints")
           } else {
-            next(command, args)
+            return next(command, args)
           }
         }
       }


### PR DESCRIPTION
Generates functions for `(==)` `cmp` `show` and `order2` from datatype definition. However, unlike #335 this does it from the language server code action rather than automatically. This allows for more flexibility in working with effects for now, and also allows for greater customization of `show` after generation, while handling most of the boilerplate. We could also add a generic empty template for "adding a function" which would just create a function of one parameter of that type that immediately matches on the datatype, using the correct names of the fields. This would save a lot of typing and make the language server even more useful, while keeping consistent methods using the right / full names of fields.