### PR TITLE
Add maybe utils

### DIFF
--- a/lib/std/core/maybe.kk
+++ b/lib/std/core/maybe.kk
@@ -26,10 +26,16 @@ pub fun default( m : maybe<a>, nothing : a ) : a
     Just(x) -> x
 
 // Get the value of the `Just` constructor or raise an exception
-pub fun unjust( m : maybe<a> ) : exn a
+pub fun unjust( m : maybe<a>, ?kk-file-line: string) : exn a
   match m
     Just(x) -> x
-    Nothing -> throw("unexpected Nothing in std/core/maybe/unjust")
+    Nothing -> throw("unexpected Nothing in " ++ ?kk-file-line)
+
+// Get the value of the `Just` constructor or raise an exception with `error-msg`
+pub fun expect( m : maybe<a>, error-msg: string) : exn a
+  match m
+    Just(x) -> x
+    Nothing -> throw(error-msg)
 
 pub fun map( m : maybe<a>, f : a -> e b ) : e maybe<b>
   match m

--- a/lib/std/core/maybe2.kk
+++ b/lib/std/core/maybe2.kk
@@ -26,10 +26,16 @@ pub fun default( m : maybe2<a,b>, nothing : (a,b) ) : (a,b)
     Just2(x,y) -> (x,y)
 
 // Get the value of the `Just` constructor or raise an exception
-pub fun unjust2( m : maybe2<a,b> ) : exn (a,b)
+pub fun unjust( m : maybe2<a,b>, ?kk-file-line: string) : exn (a,b)
   match m
     Just2(x,y) -> (x,y)
-    Nothing2   -> throw("unexpected Nothing2 in std/core/maybe/unjust2")
+    Nothing2   -> throw("unexpected Nothing2 in " ++ ?kk-file-line)
+
+// Get the value of the `Just` constructor or raise an exception
+pub fun expect( m : maybe2<a,b>, error-msg: string) : exn (a,b)
+  match m
+    Just2(x,y) -> (x,y)
+    Nothing2   -> throw(error-msg)
 
 pub fun map( m : maybe2<a,b>, f : (a,b) -> e (c,d) ) : e maybe2<c,d>
   match m


### PR DESCRIPTION
A few updates to the standard library for `maybe`. Open to feedback / suggestions.

I've improved the error location for the `unjust` function. I also renamed `unjust2` to `unjust`, since none of the other functions in `core/maybe2` use the `2` qualifier, and we have static overloading which can resolve this most of the time.

I then also added an `expect` function which expects an explicit error message as a second parameter. 
This mimics the naming of this function in Rust's Option type, but I'm open to other names. 

If we go with Rust's naming for this it might be good to look at also changing `unjust` to `unwrap` - maybe with a deprecation notice on the old definition due to it's wide use. Haskell uses `fromMaybe`, Swift uses a postfix `!` and `unsafelyUnwrap` for no runtime checks in non-debug builds.