### PR TITLE
fix unique names inside (-) functions in core parsing

### DIFF
--- a/src/Core/Parse.hs
+++ b/src/Core/Parse.hs
@@ -547,7 +547,7 @@ parseDefGroups0 env
 parseDefGroup :: Env -> LexParser (Env,DefGroup)
 parseDefGroup env
   = do (sort,inl,isRec,doc) <- pdefSort
-       (name,_)   <- funid False <|> do{ wildcard; return (nameNil,rangeNull) }
+       (name,_)   <- funid True <|> do{ wildcard; return (nameNil,rangeNull) } -- Allow locally qualified identifiers in Core
        range      <- prange env
        -- inl        <- parseInline
        tp         <- typeAnnot env

--- a/src/Syntax/Lexer.x
+++ b/src/Syntax/Lexer.x
@@ -410,10 +410,13 @@ xdigitToInt :: Char -> Int
 xdigitToInt c
   = if (isHexDigit c) then fromIntegral (digitToInt c) else trace ("lexer hex digit: " ++ [c]) (0)
 
+isAt :: Char -> Bool
+isAt c = c == '@'
+
 isMalformed :: String -> Bool
 isMalformed s
   = case s of
-      '-':c:cs   | not (isLetter c) -> True
+      '-':c:cs   | not (isLetter c || isAt c) -> True -- @ signs are added postpend to unique names (e.g. "x-@1") for variable x monadic lifted in a function (-).
       c:'-':cs   | not (isLetter c || isDigit c) -> True
       c:cs       -> isMalformed cs
       []         -> False


### PR DESCRIPTION
```koka
fun (-)(l1: list<a>, l2: list<a>, ?(==): (a, a) -> e bool): e list<a>
  l1.filter(fn(x) !l2.any(fn(y) y == x))

fun main()
  [1, 2, 3] - [3, 4, 5]
```

Monadic lifting creates a unique name based on the top level identifier
```koka
// core identifier
fun @mlift-x-@10007[1,0,1,0] : forall<(e :: E)> (@y-x10004 : std/core/types/bool) -> (e :: E) std/core/types/bool;
```
However, `@` is not a valid follow character after `-`

We could change unique names, or change lexing to allow this as an identifier. I chose the latter in this PR.

Also, the implicits translation / open effects can add let identifiers such as the following below:
```koka
fun @lift-handle-cache@10567 // inline size: 3
  = tp... {
    val @implicit/(@uniq-x@10158==)[
```

I edited `Core/Parse.hs` to allow locally qualified identifiers inside function definitions.