### PR TITLE
Remove local masks

### DIFF
--- a/lib/std/core/list.kk
+++ b/lib/std/core/list.kk
@@ -396,7 +396,7 @@ pub fun foreach-indexed( xs : list<a>, action : (int,a) -> e () ) : e ()
   var i := 0
   xs.foreach fn(x)
     val j = i // don't dereference `i` inside the inject
-    mask<local>{ action(j,x) }
+    action(j,x)
     i := i+1
 
 // Insert a separator `sep`  between all elements of a list `xs` .

--- a/lib/std/core/sslice.kk
+++ b/lib/std/core/sslice.kk
@@ -254,7 +254,7 @@ pub fun head-char( s : string ) : maybe<char>
 pub fun pred/count( s : string, pred : (char) -> e bool ) : e int
   var cnt := 0
   s.foreach fn(c)
-    if (mask<local>{pred(c)}) then cnt := cnt+1
+    if pred(c) then cnt := cnt+1
   cnt
 
 

--- a/test/algeff/perf1e.kk
+++ b/test/algeff/perf1e.kk
@@ -24,9 +24,9 @@ linear effect count {
 
 fun countH( action ) {
   var cnt := 0
-  with return(x) cnt
   with fun increment() { cnt := cnt+1 }
-  mask<local>{action()}
+  action()
+  cnt
 }
 
 noinline fun fold-counterC( xs : list<int>, m : int) : count int {

--- a/test/parc/hcounter.kk
+++ b/test/parc/hcounter.kk
@@ -24,7 +24,7 @@ fun count() {
 
 fun test-normal(i0,action) {
   var i := i0
-  handle({mask<local>(action)}) {
+  handle(action) {
     fun get()  { i }
     fun put(j) { i := j; () }
   }


### PR DESCRIPTION
Remove some local masks in the standard library and tests 

I did not change:
- some instances in the v1 std library
- the `misc/` tests (which are not run, and have invalid syntax?)
 - the `type/masklocal*` tests which make sure that you can still have an explicit mask