### PR TITLE
fix macos default triplet for vcpkg

### DIFF
--- a/src/Compile/Options.hs
+++ b/src/Compile/Options.hs
@@ -1329,6 +1329,7 @@ tripletOsName osName
       "linux-android" -> "android"
       "mingw32"       -> "mingw-static"
       "darwin"        -> "osx"
+      "macos"         -> "osx"
       os              -> os
 
 hostOsName


### PR DESCRIPTION
This PR correct the default vcpkg triplet, in MacOS Koka try to install `pcre2` when loading `std/text/regex` with `vcpkg install pcre2:arm64-macos --disable-metrics`. 

The correct triplet supported is `arm64-osx` and `x64-osx` for MacOS.