### PR TITLE
list: fix typo in docs

### DIFF
--- a/lib/std/core/list.kk
+++ b/lib/std/core/list.kk
@@ -233,7 +233,7 @@ pub fip fun reverse(xs : list<a>) : list<a>
   reverse-append( xs, Nil )
 
 // Efficiently reverse a list `xs` and append it to `tl`:
-// `reverse-append(xs,tl) == reserve(xs) ++ tl
+// `reverse-append(xs,tl) == reverse(xs) ++ tl
 pub fip fun reverse-append( xs : list<a>, tl : list<a> ) : list<a>
   reverse-acc(tl,xs)
 


### PR DESCRIPTION
Noticed a minor typo in the docs which use `reserve(...)` instead of `reverse(...)`