### PR TITLE
Properly render `n - 1` in API reference docs

### DIFF
--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -133,7 +133,7 @@ pub fun range/for( ^start: int, end : int, action : (int) -> e () ) : e ()
       rep(pretend-decreasing(i.inc))
   rep(start)
 
-// Executes `action` `n` times for each integer from `0` to `n-1`.
+// Executes `action` `n` times for each integer from `0` to `n - 1`.
 // If `n <= 0`  the function returns without any call to `action` .
 pub fun for( ^n : int, action : (int) -> e () ) : e ()
   range/for(0, n - 1, action)

--- a/lib/std/num/int32.kk
+++ b/lib/std/num/int32.kk
@@ -527,7 +527,7 @@ pub fip fun range/fold-int32( start : int32, end : int32, init : a, ^f : (int32,
     val x = f(start,init)
     range/fold-int32(pretend-decreasing(start.inc), end, x, f)
 
-// Fold over the 32-bit integers `0` to `n-1`.
+// Fold over the 32-bit integers `0` to `n - 1`.
 pub fip fun fold-int32( n : int32, init : a, ^f : (int32,a) -> e a ) : e a
   range/fold-int32(zero, n.dec, init, f)
 
@@ -539,7 +539,7 @@ pub fun range/fold-while-int32( start : int32, end : int32, init : a, f : (int32
       Just(x) -> range/fold-while-int32(pretend-decreasing(start.inc), end, x, f)
       Nothing -> init
 
-// Iterate over the 32-bit integers `0` to `n-1`.
+// Iterate over the 32-bit integers `0` to `n - 1`.
 pub fun fold-while-int32( n : int32, init : a, f : (int32,a) -> e maybe<a> ) : e a
   range/fold-while-int32(zero, n.dec, init, f)
 


### PR DESCRIPTION
Koka's standard library API reference docs were not quite rendering `n-1` properly. I think the fix is to add spaces, i.e. `n - 1`.

![image](https://github.com/user-attachments/assets/4f0963c8-d380-4fb3-90a4-4c23083f4125)
