### PR TITLE
fix label compare

### DIFF
--- a/src/Common/Name.hs
+++ b/src/Common/Name.hs
@@ -187,17 +187,11 @@ instance Ord Name where
 
 -- Effects compare by name first, then by module name for efficiency at runtime
 labelNameCompare (Name m1 hm1 l1 hl1 n1 hn1) (Name m2 hm2 l2 hl2 n2 hn2)
-  = case compare hn1 hn2 of
-      EQ -> case lowerCompareS n1 n2 of
-              EQ -> case compare hl1 hl2 of
-                      EQ -> case compare l1 l2 of
-                              EQ -> case compare hm1 hm2 of
-                                      EQ -> compare m1 m2
-                                      lg -> lg
-                              lg -> lg
+  = case lowerCompareS (n1 ++ "@") (n2 ++ "@") of -- Labels are name@module, so if a name looks like name-x@module and name@module, we need to compare @ and - (which is what the runtime does)
+          EQ -> case compare l1 l2 of
+                      EQ -> compare m1 m2
                       lg -> lg
-              lg -> lg
-      lg -> lg
+          lg -> lg
 
 
 stemIsEqual :: Name -> Name -> Bool

--- a/test/cgen/eff-name.kk
+++ b/test/cgen/eff-name.kk
@@ -1,0 +1,24 @@
+// https://github.com/koka-lang/koka/issues/684
+
+pub effect test
+  fun register-test(name: string): ()
+
+pub effect test-report
+  fun report-end(test: string, failures: int): ()
+
+pub fun plain-reporter(action: () -> <test-report,io> ()): io ()
+  handle<test-report>(action)
+    fun report-end(test, failures: int)
+      println("end")
+
+pub fun log-names(f: () -> <test,io> ()): <test-report,io> ()
+  handle<test> (f)
+    fun register-test(name)
+      println("Test name: " ++ name)
+
+pub fun main()
+  with plain-reporter
+  println("1")
+  log-names
+    println("2")
+    register-test("Assertion")

--- a/test/cgen/eff-name.kk.out
+++ b/test/cgen/eff-name.kk.out
@@ -1,0 +1,3 @@
+1
+2
+Test name: Assertion


### PR DESCRIPTION
Fixes #684

Label names look like `name@module` in the runtime if a name has a similar prefix, the comparison of shortened names `name` versus `name-x` didn't consider the order in comparison of `name-` and `name@`. This caused the expected indices from the compiler to be different than the actual lexicographic ordering of inserted names in the runtime.