### PR TITLE
Add a hint when a variable may be shadowing a function

### DIFF
--- a/src/Type/Infer.hs
+++ b/src/Type/Infer.hs
@@ -2440,17 +2440,25 @@ matchFunTypeArgs context fun tp fresolved fixed named
 
     reportNonCallable
       = do
+         hints <- shadowHints
          typeError context range (text "only functions or types with a copy constructor can be applied") tp hints
          return (zip [1..] (map (\x -> ArgExpr x True) (fixed ++ map snd named)), [], typeTotal, typeUnit, Core.App)
       where
-        hints
+        shadowHints
           = case fun of
-              Var name _ nameRange | not (isQualified name) ->
-                [(
-                  text "hint",
-                  text ("`" ++ showPlain name ++ "` at " ++ showRange "." False nameRange ++ " might be shadowing another function")
-                )]
-              _ -> []
+              Var name _ nameRange -> do
+                vals <- lookupLocalName isInfoVal name
+                ppEnv <- getPrettyEnv
+                case vals of 
+                  Right (nm, nameInfo) -> 
+                    return $ shadowHint ppEnv (nm, nameInfo)
+                  Left results -> return (concatMap (shadowHint ppEnv) results) -- Multiple locals with the same name?
+              _ -> return []
+        shadowHint ppEnv (nm, nameInfo) = 
+          [(
+            text "hint",
+            ppName ppEnv nm <+> text "at position" <+> text (show (infoRange nameInfo)) <+> text "might be shadowing another function"
+          )]
 
 
 

--- a/src/Type/Infer.hs
+++ b/src/Type/Infer.hs
@@ -2325,8 +2325,7 @@ matchFunTypeArgs context fun tp fresolved fixed named
                                 = let coreVar = coreExprFromNameInfo qname info
                                   in (Core.App (coreInst coreVar) (seqqList coreArgs))
                           return (iargs,pars,eff,res,coreAddCopy)
-                  _ -> do typeError context range (text "only functions or types with a copy constructor can be applied") tp []
-                          return (zip [1..] (map (\x -> ArgExpr x True) (fixed ++ map snd named)), [], typeTotal, typeUnit, Core.App)
+                  _ -> reportNonCallable
   where
     range = getRange fun
 
@@ -2438,6 +2437,20 @@ matchFunTypeArgs context fun tp fresolved fixed named
       = case tp of
           TSyn syn [_,_] _ -> (typesynName syn == nameTpDelay)
           _ -> False
+
+    reportNonCallable
+      = do
+         typeError context range (text "only functions or types with a copy constructor can be applied") tp hints
+         return (zip [1..] (map (\x -> ArgExpr x True) (fixed ++ map snd named)), [], typeTotal, typeUnit, Core.App)
+      where
+        hints
+          = case fun of
+              Var name _ nameRange | not (isQualified name) ->
+                [(
+                  text "hint",
+                  text ("`" ++ showPlain name ++ "` is a local variable which may be shadowing a function")
+                )]
+              _ -> []
 
 
 

--- a/src/Type/Infer.hs
+++ b/src/Type/Infer.hs
@@ -2448,7 +2448,7 @@ matchFunTypeArgs context fun tp fresolved fixed named
               Var name _ nameRange | not (isQualified name) ->
                 [(
                   text "hint",
-                  text ("`" ++ showPlain name ++ "` is a local variable which may be shadowing a function")
+                  text ("`" ++ showPlain name ++ "` at " ++ showRange "." False nameRange ++ " might be shadowing another function")
                 )]
               _ -> []
 

--- a/src/Type/InferMonad.hs
+++ b/src/Type/InferMonad.hs
@@ -30,6 +30,7 @@ module Type.InferMonad( Inf, InfGamma
 
                       , lookupAppName
                       , lookupFunName
+                      , lookupLocalName
                       , lookupNameCtx
                       , lookupInfName
                       , NameContext(..), maybeToContext

--- a/test/type/wrong/local-shadow.kk
+++ b/test/type/wrong/local-shadow.kk
@@ -1,0 +1,7 @@
+struct address
+  hostname: string
+  port: int
+
+fun log-connect(address: address)
+  val port = 80 // shadow of `port` accessor
+  println("connecting to port " ++ address.port.show)

--- a/test/type/wrong/local-shadow.kk.out
+++ b/test/type/wrong/local-shadow.kk.out
@@ -2,4 +2,4 @@ test/type/wrong/local-shadow@kk(7,44): type error: only functions or types with 
  context : address@port
  term : port
  inferred type: int
- hint : `port` is a local variable which may be shadowing a function
+ hint : `port` at @@@/test/type/wrong/local-shadow@kk(7,44) might be shadowing another function

--- a/test/type/wrong/local-shadow.kk.out
+++ b/test/type/wrong/local-shadow.kk.out
@@ -2,4 +2,4 @@ test/type/wrong/local-shadow@kk(7,44): type error: only functions or types with 
  context : address@port
  term : port
  inferred type: int
- hint : `port` at @@@/test/type/wrong/local-shadow@kk(7,44) might be shadowing another function
+ hint : port at position (6, 7) might be shadowing another function

--- a/test/type/wrong/local-shadow.kk.out
+++ b/test/type/wrong/local-shadow.kk.out
@@ -1,0 +1,5 @@
+test/type/wrong/local-shadow@kk(7,44): type error: only functions or types with a copy constructor can be applied
+ context : address@port
+ term : port
+ inferred type: int
+ hint : `port` is a local variable which may be shadowing a function


### PR DESCRIPTION
Adds a hint when a non-callable local variable is used as a function, suggesting that it may be shadowing another function.

I got very confused the first time I encountered the case in the attached test, where a struct accessor (or other "method") gets shadowed by a local variable with the same name. The type error points you in the wrong direction if you don't realise that this shadowing is happening.

I'm _assuming_ that a `Var` whose name is `nonQualified` means "local variable" (or at least global variable in the same file), so is the message accurate here?

## Improvements

I couldn't figure out how to do any of these, but I think they would make this even better:

 - Include the location (filename + range) for where the name (`port` in this test) is defined
 - Print out all the bindings with the same name which the local var is shadowing (i.e. similar to the "ambiguous overload" function listing)
 - (Maybe) only have this hint when you're using dot syntax, i.e. `foo.bar` and not `bar(foo)` since that's the case where this error is the most surprising.