### PR TITLE
colorscheme tweaks to use red sparingly

### DIFF
--- a/src/Common/ColorScheme.hs
+++ b/src/Common/ColorScheme.hs
@@ -67,8 +67,8 @@ defaultColorScheme
   = darkColorScheme
 
 darkColorScheme
-  = let c = emptyColorScheme{ colorInterpreter = DarkRed
-                            , colorCommand     = Red
+  = let c = emptyColorScheme{ colorInterpreter = DarkCyan
+                            , colorCommand     = Magenta
                             , colorError       = Red
                             , colorComment     = DarkGreen
                             , colorReserved    = DarkYellow
@@ -80,9 +80,9 @@ darkColorScheme
                             , colorNumber      = ColorDefault
                             , colorSource      = ColorDefault
                             , colorParameter   = DarkGray
-                            , colorRange       = colorInterpreter c
-                            , colorMarker      = colorInterpreter c
-                            , colorWarning     = colorError c
+                            , colorRange       = Cyan
+                            , colorMarker      = colorError c
+                            , colorWarning     = Yellow
                             , colorType        = DarkCyan -- colorSource c
                             , colorEffect      = colorType c
                             , colorTypeVar     = colorType c
@@ -102,13 +102,13 @@ lightColorScheme
                 colorNumber      = DarkGray
               , colorSource      = DarkGray
               , colorCommand     = Black
-              , colorInterpreter = DarkRed
-              , colorError       = DarkRed
-              , colorWarning     = colorError c
+              , colorInterpreter = Black
+              , colorError       = Red
+              , colorWarning     = DarkYellow
               , colorNameQual    = DarkGray
               , colorRange       = colorInterpreter c
               , colorMarker      = colorInterpreter c
-              , colorString      = Red
+              , colorString      = DarkRed
             }
     in defaultTo c Black
 


### PR DESCRIPTION
Very minor issue, but I find the compiler output can be tough to scan as there's a lot of red, and I'm typically trying to focus on errors so ideally they'd be the main red part.

I played around a bit and came to something that I quite like.

Here's a comparison output with both a warning and an error, to illustrate the difference:

Current scheme:
![Screenshot 2025-04-26 at 12 41 32 pm](https://github.com/user-attachments/assets/94b8e310-757c-45a6-893a-68dfebafd10c)

Less reds:
![Screenshot 2025-04-26 at 12 38 54 pm](https://github.com/user-attachments/assets/a224ce93-131e-4203-9243-466935dc4c73)

