### PR TITLE
Fix regex-inline for replace-all

### DIFF
--- a/lib/std/text/regex-inline.js
+++ b/lib/std/text/regex-inline.js
@@ -107,7 +107,7 @@ function $regexExecAll( r,  s, start, atmost )
   // and push the post string
   var post = $std_core_sslice._new_sslice( s, start, s.length - start );
   result.push( $std_core_types.Cons(post,$std_core_types.Nil) ); // singleton post list
-  return $std_core_types._vlist(result,null);
+  return $std_core_vector._vlist(result,null);
 }
 
 


### PR DESCRIPTION
A reproducer for the issue:
```
import std/text/regex

fun main()
  trace("some text with o".replace-all(regex("[o]"), "a", 1))
```
```
koka --target=js test-regex-all.kk
```
It will fail with
![image](https://github.com/user-attachments/assets/e36e52d3-4c28-44c2-9a3a-4a43c1a0eed5)
in browser because `_vlist` is defined in a vector:
* https://github.com/koka-lang/koka/blob/561a11cc1944f2cd974562b329c0a31b63365b9e/lib/std/core/inline/vector.js#L10

