### PR TITLE
Make JS regex unicode

### DIFF
--- a/lib/std/text/regex-inline.js
+++ b/lib/std/text/regex-inline.js
@@ -12,7 +12,7 @@ function $regexCreate( s, ignoreCase, multiLine )
 {
   // we always use "g" flag.
   // to re-use safely, we always need to explicitly set 'lastIndex' on each use!
-  var flags = (ignoreCase!==0 ? "i" : "") + (multiLine!==0 ? "m" : "");
+  var flags = "u" + (ignoreCase!==0 ? "i" : "") + (multiLine!==0 ? "m" : "");
   var key = s+flags;
   if ($regexCache[key]) return $regexCache[key];
   var regx = null;


### PR DESCRIPTION
By default, JavaScript regex are not unicode.

However, C and C# regex are unicode.

To test this, you can run
```koka
import std/text/regex

fun main()
  println("Добар Дан".split(regex("[^\\p{L}]+")).show)
```
With C and C# you'll get 2 words. With JS target
```
koka -e --target=js test-regex2.kk 
```
you'll get
```
["",""]
```

This PR adds unicode flag to JS regex, so the behavior is consistent.

Related:
* https://github.com/koka-lang/koka/issues/659