### PR TITLE
fix escaping command line arguments

### DIFF
--- a/src/Compile/Options.hs
+++ b/src/Compile/Options.hs
@@ -860,7 +860,7 @@ parseOptions flags0 opts
   = let (preOpts,postOpts) = span (/="--") opts
         flags1 = case postOpts of
                    [] -> flags0
-                   (_:rest) -> flags0{ execOpts = concat (map (++" ") rest) }
+                   (_:rest) -> flags0{ execOpts = unwords $ intersperse " " (map (show) rest) }
         (options,files,errs0) = getOpt Permute optionsAll preOpts
         errs = errs0 ++ extractErrors options
     in if null errs


### PR DESCRIPTION
In attempting to fix the second observation in this issue that the arguments are not properly escaped I ran into some issues #727. 

The following fix fixes the example in the issue, but fails with more complex arguments such as:

`koka -e print-args.kk -- 'a b c'  d  "a \" b"`

I tracked it down to the fact that `runSystem` normalizes anything that looks like a path separator which in this case changes the escaped quote to a forward slash :(.