### PR TITLE
Adjust finalization

### DIFF
--- a/lib/std/core/hnd.kk
+++ b/lib/std/core/hnd.kk
@@ -551,8 +551,7 @@ pub fun resume-shallow( r : resume-context<b,e,e0,r>, x : b ) : e0 r
 // But because we are manually finalizing out of context, we are returning in a new context
 // where only `()` makes sense, because we do not want to require a dummy value to finalize
 extern unsafe-cast-unit-context(r: resume-context<b,e,e0,r>): resume-context<b,e,e0,()>
-  c inline "#1"
-  js inline "#1"
+  inline "#1"
 
 pub fun finalize( r : resume-context<b,e,e0,r> ) : e ()
   // finalize(r.k,x)

--- a/lib/std/core/hnd.kk
+++ b/lib/std/core/hnd.kk
@@ -547,9 +547,16 @@ pub fun resume-shallow( r : resume-context<b,e,e0,r>, x : b ) : e0 r
   cast-ev1(r.k)(Shallow(x))
 
 
-pub fun finalize( r : resume-context<b,e,e0,r>, x : r ) : e r
-  //finalize(r.k,x)
-  (r.k)(Finalize(x))
+// Applying the continuation with an immediate throw restores the handler which expects a return type `r`
+// But because we are manually finalizing out of context, we are returning in a new context
+// where only `()` makes sense, because we do not want to require a dummy value to finalize
+extern unsafe-cast-unit-context(r: resume-context<b,e,e0,r>): resume-context<b,e,e0,()>
+  c inline "#1"
+  js inline "#1"
+
+pub fun finalize( r : resume-context<b,e,e0,r> ) : e ()
+  // finalize(r.k,x)
+  (unsafe-cast-unit-context(r).k)(Finalize(()))
 
 // -------------------------------------------
 // Clauses


### PR DESCRIPTION
#780 brought this up. 

The parameter/return value for `rcontext.finalize` does not make much sense in practice. `raw ctl`'s `rcontext` is intended to escape the handler's return context, and the required parameter makes it awkward to implement cooperative asymmetric coroutines. 

The other place `Finalize` is used is to ensure finalization if `ctl` clauses do not resume, in which case the return value is important to keep. Instead of creating a new variant of `FinalizeRaw : resume-context`, this PR just casts the return type to `()`. 

Obviously there are other potential approaches, this probably needs to be discussed more, and a test would need to be added.