### PR TITLE
Add $KOKA_PATH, and pkg-config lookup for C libraries

### DIFF
--- a/src/Common/File.hs
+++ b/src/Common/File.hs
@@ -15,7 +15,7 @@ module Common.File(
                   , searchPaths, searchPathsSuffixes, searchPathsEx, searchPathsCanonical
                   , getMaximalPrefixPath
                   , searchProgram
-                  , runSystem, runSystemRaw, runCmd, runCmdRead, runCmdEnv
+                  , runSystem, runSystemRaw, runCmd, runCmdRead, runCmdReadExit, runCmdEnv
                   , getProgramPath
 
                   -- * Strings
@@ -63,7 +63,7 @@ import Platform.FileIO  ( doesFileExist, doesDirectoryExist, createDirectoryIfMi
                         , removeFileIfExists
                         , getCwd, realPath
                         , getEnvVar, getEnvPaths, getProgramPath
-                        , runSystem, runSystemRaw, runCmd, runCmdRead, runCmdEnv
+                        , runSystem, runSystemRaw, runCmd, runCmdRead, runCmdReadExit, runCmdEnv
                         , getFileSize )
 import Platform.Filetime
 import qualified Platform.Runtime as B (copyBinaryFileWithMetaData)

--- a/src/Compile/CodeGen.hs
+++ b/src/Compile/CodeGen.hs
@@ -34,6 +34,7 @@ import Type.Pretty( Env(colorizing,coreIface,coreShowDef,context,importsMap) )
 import Syntax.Syntax
 import Syntax.Colorize( colorize )
 import Syntax.GenDoc( genDoc )
+import System.Exit( ExitCode(..) )
 
 import qualified Core.Core as Core
 import qualified Core.Pretty
@@ -454,7 +455,9 @@ copyCLibrary term flags sequential cc outDir eimport
   = case Core.eimportLookup (buildType flags) "library" eimport of
       Nothing -> return []
       Just clib
-        -> do mb  <- do mbSearch <- search [] [ searchCLibrary flags cc clib (ccompLibDirs flags)
+        -> do mb  <- do mbSearch <- search [] [ searchCLibrary term flags cc clib (ccompLibDirs flags)
+                                              , pkgConfigCLibrary term flags cc clib $
+                                                  fromMaybe ("lib" ++ clib) (lookup "pkg-config" eimport)
                                               , case lookup "vcpkg" eimport of
                                                   Just pkg
                                                     -> vcpkgCLibrary term flags sequential cc eimport clib pkg
@@ -479,7 +482,7 @@ copyCLibrary term flags sequential cc outDir eimport
                   -> -- TODO: suggest conan and/or vcpkg install?
                      do termWarning term flags $
                           text "unable to find C library:" <+> color (colorSource (colorScheme flags)) (text clib) <->
-                          text "   hint: provide \"--cclibdir\" as an option, or use \"syslib\" in an extern import?"
+                          text "   hint: provide \"--cclibdir\" as an option, ensure \"pkg-config\" can find the library, or use \"syslib\" in an extern import?"
                         raiseIO ("unable to find C library " ++ clib ++
                                  "\nlibrary search paths: " ++ show (ccompLibDirs flags))
   where
@@ -491,14 +494,22 @@ copyCLibrary term flags sequential cc outDir eimport
              Right res   -> return (Right res)
              Left warns' -> search (warns ++ warns') ios
 
-searchCLibrary :: Flags -> CC -> FilePath -> [FilePath] -> IO (Either [Doc] (FilePath {-libPath-},[FilePath] {-include paths-}))
-searchCLibrary flags cc clib searchPaths
-  = do mbPath <- -- looking for specific suffixes is not ideal but it differs among plaforms (e.g. pcre2-8 is only pcre2-8d on Windows)
-                 -- and the actual name of the library is not easy to extract from vcpkg (we could read
-                 -- the lib/config/<lib>.pc information and parse the Libs field but that seems fragile as well)
-                 do let suffixes = (if (buildType flags <= Debug) then ["d","_d","-d","-debug","_debug","-dbg","_dbg"] else [])
-                    -- trace ("search in: " ++ show searchPaths) $
-                    searchPathsSuffixes searchPaths [] suffixes (ccLibFile cc clib)
+searchCLibPath :: Terminal -> Flags -> CC -> FilePath -> [FilePath] -> IO (Maybe FilePath)
+searchCLibPath term flags cc clib searchPaths
+  = -- looking for specific suffixes is not ideal but it differs among plaforms (e.g. pcre2-8 is only pcre2-8d on Windows)
+    -- and the actual name of the library is not easy to extract from vcpkg (we could read
+    -- the lib/config/<lib>.pc information and parse the Libs field but that seems fragile as well)
+    do let suffixes = (if (buildType flags <= Debug) then ["d","_d","-d","-debug","_debug","-dbg","_dbg"] else [])
+       let libFilename = ccLibFile cc clib
+       -- trace ("search in: " ++ show searchPaths) $
+       result <- searchPathsSuffixes searchPaths [] suffixes libFilename
+       phaseVerboseIO term flags 3 "libPath" $
+         \penv -> text (fromMaybe (libFilename ++ " not found in " ++ show searchPaths) result)
+       return result
+
+searchCLibrary :: Terminal -> Flags -> CC -> FilePath -> [FilePath] -> IO (Either [Doc] (FilePath {-libPath-},[FilePath] {-include paths-}))
+searchCLibrary term flags cc clib searchPaths
+  = do mbPath <- searchCLibPath term flags cc clib searchPaths
        case mbPath of
         Just fname
           -> case reverse (splitPath fname) of
@@ -510,8 +521,33 @@ searchCLibrary flags cc clib searchPaths
 
 
 {---------------------------------------------------------------
-  Package managers: Conan and VCPkg
+  Dependency management: pkg-config, Conan and VCPkg
 ---------------------------------------------------------------}
+
+-- This currently only inspects the given package,
+-- it could be improved to handle transitive dependencies.
+pkgConfigCLibrary :: Terminal -> Flags -> CC -> FilePath -> FilePath -> IO (Either [Doc] (FilePath {-libPath-},[FilePath] {-include paths-}))
+pkgConfigCLibrary term flags cc clib pkgname
+  = do pkgConfigExe <- searchProgram "pkg-config"
+       case pkgConfigExe of
+         Nothing -> return $ Left []
+         Just pkgConfigExe
+           -> do libDir <- getPath "libdir"
+                 libPath <- searchCLibPath term flags cc clib (maybeToList libDir)
+                 includePath <- maybe (return Nothing) (\_ -> getPath "includedir") libPath
+                 return $ case (libPath, includePath) of
+                   (Just libPath, Just includePath) -> Right (libPath, [includePath])
+                   _ -> Left [text $ "No pkg-config definition found for " ++ clib]
+              where
+                getPath variable
+                  = do (status, outFull, err) <- runCommandReadAllExit term flags [] [pkgConfigExe, "--variable=" ++ variable, pkgname]
+                       let out = trim outFull
+                       case status of
+                         ExitFailure _ -> do phaseVerboseIO term flags 3 "shell" $ \penv -> text ("failed: " ++ (trim err))
+                                             return Nothing
+                         ExitSuccess   -> do phaseVerboseIO term flags 3 "out" $ \penv -> text out
+                                             return (Just out)
+
 
 conanCLibrary :: Terminal -> Flags -> (IO () -> IO ()) -> CC -> [(String,String)] -> FilePath -> String -> IO (Either [Doc] (FilePath,[FilePath]))
 conanCLibrary term flags sequential cc eimport clib pkg
@@ -537,7 +573,7 @@ conanCLibrary term flags sequential cc eimport clib pkg
                     -> do termPhase term $ color (colorInterpreter (colorScheme flags)) $
                             text "package : conan" <+> clrSource (text pkgName) -- <.> colon <+> clrSource (text pkgDir)
                           let libDir = pkgDir ++ "/lib"
-                          searchCLibrary flags cc clib [libDir]
+                          searchCLibrary term flags cc clib [libDir]
 
   where
     pkgBase
@@ -617,7 +653,7 @@ vcpkgCLibrary term flags sequential cc eimport clib pkg
                                 ++ (if buildType flags <= Debug then "/debug/lib" else "/lib")
                  termPhase term $ color (colorInterpreter (colorScheme flags)) $
                     text "package : vcpkg" <+> clrSource (text pkg)
-                 mbInstalled <- searchCLibrary flags cc clib [libDir]
+                 mbInstalled <- searchCLibrary term flags cc clib [libDir]
                  case mbInstalled of
                    Right _ -> return mbInstalled
                    Left _  -> install root libDir vcpkg
@@ -644,7 +680,7 @@ vcpkgCLibrary term flags sequential cc eimport clib pkg
                       return (Left [])
               else do termPhase term (color (colorInterpreter (colorScheme flags)) (text "install: vcpkg package:") <+> clrSource (text pkg))
                       sequential $ runCommand term flags installCmd
-                      searchCLibrary flags cc clib [libDir] -- try to find again after install
+                      searchCLibrary term flags cc clib [libDir] -- try to find again after install
 
 clibsFromCore flags core    = externalImportKeyFromCore (target flags) (buildType flags) core "library"
 csyslibsFromCore flags core = externalImportKeyFromCore (target flags) (buildType flags) core "syslib"
@@ -731,6 +767,12 @@ runCommandReadAll term flags env cargs@(cmd:args)
        phaseVerboseIO term flags 3 "command" $ \penv -> text command -- cmd ++ " [" ++ concat (intersperse "," args) ++ "]")
        runCmdRead env cmd (filter (not . null) args)
          `catchIO` (\msg -> raiseIO ("error  : " ++ msg ++ "\ncommand: " ++ command))
+
+runCommandReadAllExit :: Terminal -> Flags -> [(String,String)] -> [String] -> IO (ExitCode,String,String)
+runCommandReadAllExit term flags env cargs@(cmd:args)
+  = do let command = unwords (shellQuote cmd : map shellQuote args)
+       phaseVerboseIO term flags 3 "command" $ \penv -> text command -- cmd ++ " [" ++ concat (intersperse "," args) ++ "]")
+       runCmdReadExit env cmd (filter (not . null) args)
 
 runCommandEnv :: Terminal -> Flags -> [(String,String)] -> [String] -> IO ()
 runCommandEnv term flags env cargs@(cmd:args)

--- a/src/Compile/Options.hs
+++ b/src/Compile/Options.hs
@@ -862,7 +862,10 @@ processInitialOptions flags0 opts
               (localDir,localLibDir,localShareDir,localBinDir)
                   <- getKokaDirs (localLibDir flags) (localShareDir flags) buildDir
 
-              normalizedIncludes <- mapM realPath ("." : (localShareDir ++ "/lib") : includePath flags)
+              pathsFromEnv <- fmap undelimPaths (getEnvVar "KOKA_PATH")
+              let allIncludes = nub $ filter (not . null) ("." : (localShareDir ++ "/lib") : includePath flags ++ pathsFromEnv)
+              normalizedIncludes <- mapM realPath allIncludes
+              -- _ <- trace ("Normalized includes: " ++ show normalizedIncludes) $ return ()
 
               -- cc
               ccmd <- if (ccompPath flags == "") then detectCC (target flags)

--- a/src/Platform/cpp/Platform/FileIO.hs
+++ b/src/Platform/cpp/Platform/FileIO.hs
@@ -37,7 +37,7 @@ module Platform.FileIO(
   , getHomeDirectory
   , getTemporaryDirectory
     -- * Process execution
-  , runSystem, runSystemRaw, runCmd, runCmdRead, runCmdEnv
+  , runSystem, runSystemRaw, runCmd, runCmdRead, runCmdReadExit, runCmdEnv
   ) where
 
 import System.IO
@@ -198,17 +198,21 @@ runCmd cmd args
 
 runCmdRead :: [(String,String)] -> String -> [String] -> IO (String,String)
 runCmdRead extraEnv cmd args
+  = do (exitCode,out,err) <- runCmdReadExit extraEnv cmd args
+       case exitCode of
+          ExitFailure i -> raiseIO ("command failed (exit code " ++ show i ++ ")") -- \n  " ++ concat (intersperse " " (cmd:args)))
+          ExitSuccess   -> return (out,err)
+
+runCmdReadExit :: [(String,String)] -> String -> [String] -> IO (ExitCode,String,String)
+runCmdReadExit extraEnv cmd args
   = do mbEnv <- buildEnv extraEnv
        (_, Just hout, Just herr, process) <- createProcess (proc cmd args){ env = mbEnv, std_out = CreatePipe, std_err = CreatePipe }
        exitCode <- waitForProcess process
-       case exitCode of
-          ExitFailure i -> do -- hClose hout
-                              raiseIO ("command failed (exit code " ++ show i ++ ")") -- \n  " ++ concat (intersperse " " (cmd:args)))
-          ExitSuccess   -> do out <- hGetContents hout
-                              err <- hGetContents herr
-                              -- hClose hout
-                              return (out,err)
-
+       out <- hGetContents hout
+       err <- hGetContents herr
+       -- hClose hout
+       -- hClose herr
+       return (exitCode,out,err)
 
 runCmdEnv :: [(String,String)] -> String -> [String] -> IO ()
 runCmdEnv extraEnv cmd args

--- a/src/Platform/wasm/Platform/FileIO.hs
+++ b/src/Platform/wasm/Platform/FileIO.hs
@@ -42,6 +42,7 @@ import System.IO
 import System.Directory( doesFileExist, doesDirectoryExist, createDirectoryIfMissing
                        , getCurrentDirectory, canonicalizePath, removeFile
                        , getFileSize )
+import System.Exit( ExitCode(..) )
 import Data.Char( toLower )
 
 import Common.Failure( raiseIO, catchIO )
@@ -126,6 +127,9 @@ runCmd :: String -> [String] -> IO ()
 runCmd _ _ = raiseIO "command execution not available in WASM/WASI"
 
 runCmdRead :: [(String,String)] -> String -> [String] -> IO (String,String)
+runCmdRead _ _ _ = raiseIO "command execution not available in WASM/WASI"
+
+runCmdReadExit :: [(String,String)] -> String -> [String] -> IO (ExitCode,String,String)
 runCmdRead _ _ _ = raiseIO "command execution not available in WASM/WASI"
 
 runCmdEnv :: [(String,String)] -> String -> [String] -> IO ()


### PR DESCRIPTION
This PR implements the two ideas I mentioned [in discord](https://discord.com/channels/1231710450152902716/1231777420072194068/1410226410529755267):

 - use `$KOKA_PATH` as an additional list of include directories, similar to many other languages
 - add support for resolving C libraries via [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/). This is a standard which is supported by a number of build tools (including many conan / vcpkg packages). This may make the existing two integrations redundant one day, but for now I've just added it as an additional source.

Sample output finding `libuv` with `--verbose=4` (the library is provided by `nix`, thus the long paths):

```
codegen : uv/utils
generated c: .koka/v3.2.2/clang-debug-5f0454/uv_utils
libPath : libuv.a not found in ["/usr/local/lib","/usr/lib","/lib","/opt/homebrew/lib"]
command : /nix/store/hj7iydwvhkslzsvw82iilv8say0xv5n7-pkg-config-wrapper-0.29.2/bin/pkg-config --variable=libdir libuv
out     : /nix/store/nwck8lyydw82yvxc8gz9h5b92yhwdcy6-libuv-1.50.0/lib
libPath : /nix/store/nwck8lyydw82yvxc8gz9h5b92yhwdcy6-libuv-1.50.0/lib/libuv.a
command : /nix/store/hj7iydwvhkslzsvw82iilv8say0xv5n7-pkg-config-wrapper-0.29.2/bin/pkg-config --variable=includedir libuv
out     : /nix/store/sqbwc4gyayj983i6qkw3bmikxbf86v2c-libuv-1.50.0-dev/include
library : /nix/store/nwck8lyydw82yvxc8gz9h5b92yhwdcy6-libuv-1.50.0/lib/libuv.a
codegen done: uv/utils
link    : uv/utils
command : /nix/store/xpja3ad45p55aryvgng6g9grp8yivvsd-clang-wrapper-19.1.7/bin/clang -Wall -Wextra -Wpointer-arith -Wshadow -Wstrict-aliasing -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-variable -Wno-unused-value -Wno-unused-but-set-variable -Wno-cast-qual -Wno-undef -Wno-reserved-id-macro -Wno-unused-macros -Wno-cast-align -Wno-unknown-warning-option -g -Og -c -I /Users/tcuthbertson/.local/share/koka/v3.2.2/kklib/include -I /nix/store/sqbwc4gyayj983i6qkw3bmikxbf86v2c-libuv-1.50.0-dev/include -DKK_MIMALLOC=8 -o .koka/v3.2.2/clang-debug-5f0454/uv_utils.o .koka/v3.2.2/clang-debug-5f0454/uv_utils.c
building: 0.822507s
```
