### PR TITLE
fix exit status

### DIFF
--- a/kklib/src/os.c
+++ b/kklib/src/os.c
@@ -648,7 +648,15 @@ kk_decl_export int kk_os_run_system(kk_string_t cmd, kk_context_t* ctx) {
   }
   #else
   kk_with_string_as_qutf8_borrow(cmd, ccmd, ctx) {
-    exitcode = system(ccmd);
+    int status = system(ccmd);
+    if (WIFEXITED(status)) {
+      exitcode = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) { 
+      exitcode = -WTERMSIG(status); // Like Haskell, return negative code for signal termination
+    } else {
+      // Technically WIFSTOPPED(status) can happen, but only if the process is being traced, or the call was done with WUNTRACED.
+      kk_fatal_error(EINVAL, "kk_os_run_system: unexpected termination");
+    }
   }
   #endif
   kk_string_drop(cmd, ctx);


### PR DESCRIPTION
Fix exit status on unix for `system` call. The returned integer is not directly interpretable as an exit status.

Fixes: #797 

Unfortunately, unix does this to require the user to check for other abnormal termination (due to signal / stopped process). 

Not sure how you want to report that?
- Add a tagged C union in kklib, and convert it to a Koka Error type in std/os/process? 
- Assignable parameters in kklib, ditto for std/os/proccess?
- Something else?

My opinion is to do the simple fix now (below), with the plan of re-addressing this when we get to real process integration with libuv.

@daanx 