### PR TITLE
Add list.contains method

### DIFF
--- a/lib/std/core/list.kk
+++ b/lib/std/core/list.kk
@@ -529,6 +529,9 @@ pub fun any( xs : list<a>, predicate : a -> e bool ) : e bool
     Cons(x,xx) -> if predicate(x) then True else xx.any(predicate)
     Nil -> False
 
+pub fun contains( xs : list<a>, item: a, ^?(==): (x: a, y: a) -> bool) : bool
+  xs.any(_ == item)
+
 // Return the sum of a list of integers
 pub fun sum( xs : list<int> ) : int
   xs.foldl( 0, fn(x,y) { x + y } )


### PR DESCRIPTION
It felt so weird that this method is missing from the std lib, even if it's a one-liner.