### PR TITLE
Fix open constructor tags #711

### DIFF
--- a/src/Kind/Infer.hs
+++ b/src/Kind/Infer.hs
@@ -312,7 +312,8 @@ synConstrTag (con)
   = let name = toOpenTagName (unqualify (conInfoName con))
         rc   = rangeHide (conInfoRange con)
         expr = Lit (LitString (show (conInfoName con)) rc)
-    in DefNonRec (Def (ValueBinder name () expr rc rc) rc (conInfoVis con) DefVal InlineNever "")
+        -- Tags must be public, since they may extend a type outside of the current module
+    in DefNonRec (Def (ValueBinder name () expr rc rc) rc Public DefVal InlineNever "") 
 
 {- ------------------------------------------------------------------------------------------------------------
    Lazy types and constructors


### PR DESCRIPTION
Fixes #711. 

The real fix would be to move all private constructor related functions out of the C header files, but currently we have them as `static inline` functions in the headers. I attempted to move all of those functions depend on the visibility of constructor, but ran into an issue where we would have to rewrite a ton of the standard library .c/.h files which use this pattern in their headers. Also moving them to C files prevents the C compiler from doing as much cross-compilation-unit optimization - which is likely crucial for some private constructors like `Cctx`, and `Ev`.