### PR TITLE
replace deprecated `catch` with a version with arguments swapped

### DIFF
--- a/lib/std/core/exn.kk
+++ b/lib/std/core/exn.kk
@@ -55,9 +55,10 @@ pub fun handle/try( action : () -> <exn|e> a, hndl: exception -> e a ) : e a
   with final ctl throw-exn(exn) hndl(exn)
   action()
 
-// _Deprecated_; use `try` instead. Catch an exception raised by `throw` and handle it.
-// Use `on-exit` when appropriate.
-pub fun catch( action : () -> <exn|e> a, hndl: exception -> e a) : e a
+// Catch an exception raised by `throw` and handle it.
+// This is `try` but with the arguments reversed, and is
+// often convenient to use as `with catch fn(e) ...`
+pub inline fun catch(hndl: exception -> e a, action : () -> <exn|e> a) : e a
   try(action,hndl)
 
 // An `:error` type represents a first-class exception result.


### PR DESCRIPTION
I [floated this idea on discord](https://discord.com/channels/1231710450152902716/1231777443052781578/1418205892318334996) and folks seemed keen:

I often find myself wishing there was a backwards version of try, with the exception handler as the first argument. Perhaps the already-deprecated catch could be repurposed for this one day? It also matches how finally is used:

```
with catch fn(e)
  println("It failed!")
do-something-dangerous()
```
