### PR TITLE
Stop re-allocating static strings for every local string definition

### DIFF
--- a/src/Backend/C/FromCore.hs
+++ b/src/Backend/C/FromCore.hs
@@ -1759,7 +1759,7 @@ genExprPrim expr
              if (s=="")
               then return ([],text "kk_string_empty()")
               else do let (cstr,clen) = cstring s
-                      return ([text "kk_define_string_literal" <.> arguments [empty,ppName name,pretty clen,cstr]]
+                      return ([text "kk_define_string_literal" <.> arguments [text "static",ppName name,pretty clen,cstr]]
                              ,text "kk_string_dup" <.> arguments [ppName name]);
 
      Var vname (InfoExternal formats)


### PR DESCRIPTION
Tracing currently allocates memory that isn't freed:

```koka
fun main()
  while { True }
    trace("ping")
```

This fix was suggested by @TimWhiting.