### PR TITLE
Add `prepend` to the `exn` module

### DIFF
--- a/lib/std/core/exn.kk
+++ b/lib/std/core/exn.kk
@@ -119,3 +119,7 @@ pub fun exn-error-range() : exn a
 // pub fun unsafe-no-exn( action : () -> <exn|e> a ) : e a
 //   unsafe-total( action )
 
+// Prepend `exn`'s message with `pre`.
+pub fun prepend( exn : exception, pre : string ) : exception
+  Exception(pre ++ ": " ++ exn.message, exn.info)
+

--- a/lib/std/os/dir.kk
+++ b/lib/std/os/dir.kk
@@ -63,9 +63,6 @@ pub fun copy-file( from : path, to : path, preserve-mtime : bool = True ) : <fsy
     _ -> ()
 
 
-fun prepend( exn : exception, pre : string ) : exception
-  Exception(pre ++ ": " ++ exn.message, exn.info)
-
 extern ensure-dir-err( path : string, mode : int ) : fsys error<()>
   c "kk_os_ensure_dir_error"
 

--- a/lib/std/os/file.kk
+++ b/lib/std/os/file.kk
@@ -32,10 +32,6 @@ pub fun write-text-file( path : path, content : string, create-dir : bool = True
     _ -> ()
 
 
-fun prepend( exn : exception, pre : string ) : exception
-  Exception(pre ++ ": " ++ exn.message, exn.info)
-
-
 extern read-text-file-err( path : string ) : fsys error<string>
   c "kk_os_read_text_file_error"
   js "_read_text_file_error"

--- a/lib/std/os/readline.kk
+++ b/lib/std/os/readline.kk
@@ -25,10 +25,6 @@ pub fun readline() : <console,exn> string
     Ok(line)    -> line
 
 
-fun prepend( exn : exception, pre : string ) : exception
-  Exception(pre ++ ": " ++ exn.message, exn.info)
-
-
 extern readline-err() : console error<string>
   c "kk_os_read_line_error"  
   js "sync_readline_err"


### PR DESCRIPTION
I find myself using `prepend` a lot when writing system call bindings. It's currently defined in three different places in the standard library, I think it makes sense to export it from `exn` instead.