### PR TITLE
Make `struct` constructors PascalCase

### DIFF
--- a/lib/std/core/hnd.kk
+++ b/lib/std/core/hnd.kk
@@ -595,7 +595,7 @@ noinline fun under1x( ev : ev<h>, op : a -> e b, x : a ) : e b
   y
 
 pub fun clause-control-raw1( op : (x:a, r: resume-context<b,e,e0,r>) -> e r ) : clause1<a,b,h,e,r>
-  Clause1(fn(m,_ev,x){ yield-to(m, fn(k){ op(x,Resume-context(k)) } ) } )
+  Clause1(fn(m,_ev,x){ yield-to(m, fn(k){ op(x,ResumeContext(k)) } ) } )
 
 fun get( ref: ref<h,a>) : <read<h>,div> a
   !ref
@@ -677,7 +677,7 @@ inline fun under0( ev : ev<i>, op : () -> e b) : e b
   y
 
 pub fun clause-control-raw0( op : resume-context<b,e,e0,r> -> e r ) : clause0<b,h,e,r>
-  Clause0(fn(m,_ev){ yield-to(m, fn(k){ op(Resume-context(k)) } ) })
+  Clause0(fn(m,_ev){ yield-to(m, fn(k){ op(ResumeContext(k)) } ) })
 
 /*
 pub fun clause-control0( op : (b -> e r) -> e r ) : clause0<b,e,r>
@@ -727,7 +727,7 @@ pub fun clause-control2( clause : (x1:a1, x2:a2, k: b -> e r) -> e r ) : clause2
 
 
 pub fun clause-control-raw2( op : (x1:a1, x2:a2, r: resume-context<b,e,e0,r>) -> e r ) : clause2<a1,a2,b,h,e,r>
-  Clause2(fn(m,_ev,x1,x2){ yield-to(m, fn(k){ op(x1,x2,Resume-context(k)) } ) })
+  Clause2(fn(m,_ev,x1,x2){ yield-to(m, fn(k){ op(x1,x2,ResumeContext(k)) } ) })
 
 pub fun clause-tail2<e,r,h,a1,a2,b>(op : (a1,a2) -> e b) : clause2<a1,a2,b,h,e,r>
   Clause2(fn(m,ev,x1,x2){ under2(ev,op,x1,x2) })

--- a/lib/std/num/random.kk
+++ b/lib/std/num/random.kk
@@ -47,7 +47,7 @@ pub fun sfc-step( sfc : sfc ) : sfc-result
   match sfc
     Sfc(x,y,z,cnt) ->
       val res = x + y + cnt
-      Sfc-result( res, Sfc( y ^ shr(y,9),
+      SfcResult( res, Sfc( y ^ shr(y,9),
                             z + shl(z,3),
                             rotl(z,21) + res,
                             cnt + 1.int32 ))

--- a/lib/std/time/locale.kk
+++ b/lib/std/time/locale.kk
@@ -31,7 +31,7 @@ pub struct time-locale
 
 
 // English time locale (`en`)
-pub val time-locale-en : time-locale = Time-locale( "en",
+pub val time-locale-en : time-locale = TimeLocale( "en",
   ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"],
   ["January","February","March","April","May","June","July","August","September","October","November","December"],
   format-t    = "h:mmaa",
@@ -42,7 +42,7 @@ pub val time-locale-en : time-locale = Time-locale( "en",
 
 // ISO English time locale (`en-iso`). Uses English names for
 // months and days but displays numeric dates and times using unambigious ISO format.
-pub val time-locale-en-iso : time-locale = Time-locale( "en-iso",
+pub val time-locale-en-iso : time-locale = TimeLocale( "en-iso",
   day-names   = time-locale-en.day-names,
   month-names = time-locale-en.month-names,
   format-lll  = "D MMMM YYYY, tt",
@@ -50,7 +50,7 @@ pub val time-locale-en-iso : time-locale = Time-locale( "en-iso",
 )
 
 // French time locale (`fr`)
-pub val time-locale-fr : time-locale = Time-locale( "fr",
+pub val time-locale-fr : time-locale = TimeLocale( "fr",
   ["lundi","mardi","mercredi","jeudi","vendredi","samedi","dimanche"],
   ["janvier","février","mars","avril","mai","juin","juillet","août","septembre","octobre","novembre","décembre"],
   ["janv.","févr.","mars","avr.","mai","juin","juil.","août","sept.","oct.","nov.","déc."],
@@ -60,7 +60,7 @@ pub val time-locale-fr : time-locale = Time-locale( "fr",
 )
 
 // German time locale (`de`)
-pub val time-locale-de : time-locale = Time-locale( "de",
+pub val time-locale-de : time-locale = TimeLocale( "de",
   ["Montag","Dienstag","Mittwoch","Donnerstag","Freitag","Samstag","Sonntag"],
   ["Januar","Februar","März","April","Mai","Juni","Juli","August","September","Oktober","November","Dezember"],
   ["Jan.","Febr.","Mrz.","Apr.","Mai","Jun.","Jul.","Aug.","Sept.","Okt.","Nov.","Dez."],
@@ -73,7 +73,7 @@ pub val time-locale-de : time-locale = Time-locale( "de",
 )
 
 // Spanish time locale (`es`)
-pub val time-locale-es : time-locale = Time-locale( "es",
+pub val time-locale-es : time-locale = TimeLocale( "es",
   ["lunes","martes","miércoles","jueves","viernes","sábado","domingo"],
   ["enero","febrero","marzo","abril","mayo","junio","julio","agosto","septiembre","octubre","noviembre","diciembre"],
   format-t    = "H:mm",
@@ -85,7 +85,7 @@ pub val time-locale-es : time-locale = Time-locale( "es",
 )
 
 // Dutch time locale (`nl`)
-pub val time-locale-nl : time-locale = Time-locale( "nl",
+pub val time-locale-nl : time-locale = TimeLocale( "nl",
   ["maandag","dinsdag","woensdag","donderdag","vrijdag","zaterdag","zondag"],
   ["januari","februari","maart","april","mei","juni","juli","augustus","september","oktober","november","december"],
   ["jan","feb","mrt","apr","mei","jun","jul","aug","sep","okt","nov","dec"],

--- a/lib/std/time/timezone.kk
+++ b/lib/std/time/timezone.kk
@@ -91,10 +91,10 @@ pub struct timezone-period(
 )
 
 // Zero time period
-val timezone-period0 = Timezone-period( Nothing, "UTC", zero )
+val timezone-period0 = TimezonePeriod( Nothing, "UTC", zero )
 
 // The time zone info for the UTC time zone.
-val tzi-utc : timezone-info = Timezone-info( "UTC", 0, fn(){ [] } )
+val tzi-utc : timezone-info = TimezoneInfo( "UTC", 0, fn(){ [] } )
 
 // Find the DST offset for a particular instant `i` given a list of time zone periods
 fun find-offset( i : instant, periods : list<timezone-period> ) : timezone-period
@@ -187,7 +187,7 @@ fun parse-packed-zone( s : string ) : exn timezone-info
   val population= parts[5].default("0").parse-base60
   // delay parsing the periods until needed
   val periods   = once{ parse-packed-periods(name, abbrs,offsets,indices,xdiffs) }
-  Timezone-info( name, population, periods, False )
+  TimezoneInfo( name, population, periods, False )
 
 fun parse-packed-periods( name : string, sabbrs : string, soffsets :string, sindices : string, sxdiffs :string ) : list<timezone-period>
 
@@ -211,7 +211,7 @@ fun parse-packed-periods( name : string, sabbrs : string, soffsets :string, sind
                   ).snd
     val ofsabrs  = indices.reverse.map( fn(i) { (offsets[i].default(0.0), abbrs[i].default("") ) } )
     val periods  = zipwith( endings ++ [Nothing], ofsabrs, fn(start,ofsabbr)
-                     Timezone-period(start,ofsabbr.snd, duration(ofsabbr.fst * ~60.0))
+                     TimezonePeriod(start,ofsabbr.snd, duration(ofsabbr.fst * ~60.0))
                    )
     periods
 

--- a/lib/std/time/ut1.kk
+++ b/lib/std/time/ut1.kk
@@ -227,7 +227,7 @@ fun parse-iersA( s : string ) : maybe<dut-table>
   //trace("finals2000A expire: " ++ expire.time.show)
   //trace("entries: " ++ entries.list.map(fn(d){ show(d) }).join("\n"))
   //trace("finals: " ++ entries.length.show ++ ", start: " ++ start.show ++ ", end: " ++ end.show )
-  Just(Dut-table(expire,start,end,entries))
+  Just(DutTable(expire,start,end,entries))
 
 val rx-finals-dut = regex(r"^.{57}[IP]([\-\+ ]\d+(?:\.\d+))", multiline=True)
 val rx-finals-start = regex(r"^(?:\d\d| \d).{4} (\d+(?:\.\d+)?)", multiline=True)
@@ -421,7 +421,7 @@ struct deltat-table(
   entries: vector<float64>
 )
 
-val deltat-table-empty = Deltat-table(0.0,0.0,vector(0,0.0))
+val deltat-table-empty = DeltatTable(0.0,0.0,vector(0,0.0))
 
 // Given a `deltat-table` and a fractional year, return the delta-t by
 // linear interpolation between two known delta-t instants. If the
@@ -456,7 +456,7 @@ fun parse-predicted( s : string ) : deltat-table
   if caps.is-nil return deltat-table-empty
   val start = caps.head.map(fn(cap){ cap.groups[1] }).default("").parse-float64.maybe(2000.0)
   val entries = caps.map(fn(cap){ cap.groups[2].parse-float64.maybe(0.0) }).vector
-  Deltat-table(start,4.0,entries)
+  DeltatTable(start,4.0,entries)
 
 val rx-predict = regex(r"^\s*\d+\.\d+\s*(\d+\.\d+)\s*(\d+(?:\.\d*)?)", multiline=True)
 
@@ -466,14 +466,14 @@ fun parse-determined( s : string ) : deltat-table
   val (y,m) = caps.head.map(fn(cap){ (cap.groups[1],cap.groups[2]) }).default(("",""))
   val start = y.parse-float64.maybe(2000.0) + ((m.parse-float64.maybe(1.0) - 1.0)/12.0)
   val entries = caps.map(fn(cap){ cap.groups[4].parse-float64.maybe(0.0) }).vector
-  Deltat-table(start,12.0,entries)
+  DeltatTable(start,12.0,entries)
 
 val rx-determined = regex(r"^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+(?:\.\d*)?)", multiline=True)
 
 fun parse-historic( start: float64, s : string ) : deltat-table
   val caps = s.replace-all(rxcomment,"").find-all(rxdouble)
   val entries = caps.map(fn(cap){ cap.matched.parse-float64.maybe(0.0) }).vector
-  Deltat-table(start,2.0,entries)
+  DeltatTable(start,2.0,entries)
 
 val rxdouble = regex(r"-?\d+(?:\.\d+)?")
 val rxcomment = regex(r"//.*")

--- a/lib/std/time/utc.kk
+++ b/lib/std/time/utc.kk
@@ -325,8 +325,8 @@ abstract struct leap-adjust(
 )
 
 
-val leaps-table0 = Leaps-table(epoch,[])
-val zero : leap-adjust = Leap-adjust(timestamp0,timespan0,timestamp0,zero)
+val leaps-table0 = LeapsTable(epoch,[])
+val zero : leap-adjust = LeapAdjust(timestamp0,timespan0,timestamp0,zero)
 
 fun is-zero( la : leap-adjust ) : bool
   la.offset.is-zero && la.drift.is-zero
@@ -735,7 +735,7 @@ pub fun get-leap-steps( table : leaps-table = leaps-table-ti ) : list<(utc-times
 pub fun parse-leap-seconds( leaps : string ) : leaps-table
   val adjusts = leaps.lines.flatmap-maybe(parse-leap).reverse
   val expire = parse-leap-expire(leaps,adjusts)
-  Leaps-table(expire,adjusts)
+  LeapsTable(expire,adjusts)
 
 fun parse-leap( line : string ) : maybe<leap-adjust>
   if (line.trim-left(" ").starts-with("#").is-just)
@@ -748,7 +748,7 @@ fun pleap() : parse leap-adjust
   whitespace()
   val adjust = pint()
   // trace("leap entry: " ++ adjust.show ++ " - " ++ ntpsecs.show )
-  Leap-adjust(timestamp(ntpsecs.timespan - ntp2000), adjust.timespan, timestamp0, timespan0)
+  LeapAdjust(timestamp(ntpsecs.timespan - ntp2000), adjust.timespan, timestamp0, timespan0)
 
 /*
 pub fun parse-leap-seconds( leaps : string ) : leaps-table
@@ -757,11 +757,11 @@ pub fun parse-leap-seconds( leaps : string ) : leaps-table
     val ntpsecs = cap.groups[1].parse-int-default(0)
     val adjust  = cap.groups[2].parse-int-default(0)
     // trace("leap entry: " ++ adjust.show ++ " - " ++ ntpsecs.show )
-    Leap-adjust(timestamp(ntpsecs.timespan - ntp2000), adjust.timespan, timestamp0, timespan0)
+    LeapAdjust(timestamp(ntpsecs.timespan - ntp2000), adjust.timespan, timestamp0, timespan0)
   }.reverse
 
   val expire = parse-leap-expire(leaps,adjusts)
-  val table = Leaps-table(expire,adjusts)
+  val table = LeapsTable(expire,adjusts)
   table
 
 val rxleap   = regex(r"^[ \t]*(\d+)[ \t]+(\d+)[ \t]*(?:#.*)?$",multiLine=True)
@@ -825,7 +825,7 @@ val mjd-epoch-shift    = 51544.timespan // 2000-01-01Z - 1858-11-17Z modified ju
 pub fun parse-leap-seconds-dat( leaps : string  ) : leaps-table
   val adjusts = leaps.lines.flatmap-maybe(parse-taiadjust).reverse
   val expire = parse-leap-expire(leaps,adjusts)
-  Leaps-table(expire,adjusts)
+  LeapsTable(expire,adjusts)
 
 fun parse-leap-expire( leaps : string, adjusts : list<leap-adjust>) : instant
   // get expiration date
@@ -871,7 +871,7 @@ fun ptaiadjust() : parse leap-adjust
   val start  = ((mjd - mjd-epoch-shift)*solar-secs-per-day).round.timestamp
   val dstart = ((dmjd - mjd-epoch-shift)*solar-secs-per-day).round.timestamp
   // trace("pre72 start=" ++ start.show ++ ", ofs: " ++ ofs.show ++ ", drift: " ++ drift.show )
-  Leap-adjust( start, ofs, dstart, drift )
+  LeapAdjust( start, ofs, dstart, drift )
 
 // TAI leap second adjustments for dates before 1972-01-01Z are linear interpolations.
 // TAI started in 1958-01-01Z. The initial official UTC time step in 1961-01-01Z was 1.422818s and before that there
@@ -944,10 +944,10 @@ pub fun parse-leap-seconds-dat( leaps : string  ) : leaps-table
     val start  = ((mjd - mjd-epoch-shift)*solar-secs-per-day).round.timestamp
     val dstart = ((dmjd - mjd-epoch-shift)*solar-secs-per-day).round.timestamp
     // trace("pre72 start=" ++ start.show ++ ", ofs: " ++ ofs.show ++ ", drift: " ++ drift.show )
-    Leap-adjust( start, ofs, dstart, drift )
+    LeapAdjust( start, ofs, dstart, drift )
   }).reverse
   val expire = parse-leap-expire(leaps,adjusts)
-  Leaps-table(expire,adjusts)
+  LeapsTable(expire,adjusts)
 
 val rxtaiadjust = regex(r"^ *\d[^=]*=JD (\d+\.\d+) *TAI-UTC= *(-?\d+(?:\.\d*)?)[^\d]+(\d+(?:\.\d*)?)[^\d]+(\d+\.\d+) *S *$", multiLine=True)
 */

--- a/src/Common/Name.hs
+++ b/src/Common/Name.hs
@@ -553,11 +553,10 @@ splitLocalQualName name
 
 toConstructorName :: Name -> Name
 toConstructorName name
-  = nameMapStem name $ \stem ->
-    case stem of
-      ('@':c:cs) -> '@':toUpper c : cs  -- keep hidden names hidden
-      (c:cs)     -> toUpper c : cs
-      ""         -> ""
+  = nameMapStem name (concat . map upper . splitOn (=='-'))
+  where upper ('@':c:cs) = '@':toUpper c:cs -- keep hidden names hidden
+        upper (c:cs) = toUpper c:cs
+        upper "" = ""
 
 toVarName :: Name -> Name
 toVarName name

--- a/test/misc/evidence/ev-examples1.kk
+++ b/test/misc/evidence/ev-examples1.kk
@@ -92,7 +92,7 @@ fun read() {
 }
 
 fun reader(init,action) {
-  read-handle( Reader-hnd( clause-control0(fn(k){ k(init) } )), id, action)
+  read-handle( ReaderHnd( clause-control0(fn(k){ k(init) } )), id, action)
 }
 
 // State

--- a/test/misc/evidence/ev4.kk
+++ b/test/misc/evidence/ev4.kk
@@ -381,7 +381,7 @@ fun read(i:int) {
 }
 
 fun reader(init,action) {
-  read-handle( Reader-hnd( op-control( fn(x,k){ k(init) } )), action)
+  read-handle( ReaderHnd( op-control( fn(x,k){ k(init) } )), action)
 }
 
 // State

--- a/test/misc/evidence/ev5.kk
+++ b/test/misc/evidence/ev5.kk
@@ -334,7 +334,7 @@ fun under1( w : evv<e>, op : a -> e b, x : a ) : e b {
 
 
 fun clause-control-raw( op : (x:a, r: resume-context<b,e,r>) -> e r ) : clause<a,b,e,r> {
-  Clause(fn(m,w,x){ yield-to(m, fn(k){ op(x,Resume-context(k)) } ) } )
+  Clause(fn(m,w,x){ yield-to(m, fn(k){ op(x,ResumeContext(k)) } ) } )
 }
 
 fun get( ref: ref<h,a>) : <read<h>,div|e> a {
@@ -402,7 +402,7 @@ fun under0( w : evv<e>, op : () -> e b) : e b {
 }
 
 fun clause-control0( op : resume-context<b,e,r> -> e r ) : clause<(),b,e,r> {
-  Clause(fn(m,w,_x){ yield-to(m, fn(k){ op(Resume-context(k)) } ) })
+  Clause(fn(m,w,_x){ yield-to(m, fn(k){ op(ResumeContext(k)) } ) })
 }
 
 fun clause-tail0(op : () -> e b) : clause<(),b,e,r> {
@@ -431,7 +431,7 @@ fun under2( w : evv<e>, op : (a1,a2) -> e b, x1 : a1, x2 : a2 ) : e b {
 }
 
 fun clause-control2( op : (x1:a1, x2:a2, r: resume-context<b,e,r>) -> e r ) : op2<a1,a2,b,e,r> {
-  Clause2(fn(m,w,x1,x2){ yield-to(m, fn(k){ op(x1,x2,Resume-context(k)) } ) })
+  Clause2(fn(m,w,x1,x2){ yield-to(m, fn(k){ op(x1,x2,ResumeContext(k)) } ) })
 }
 
 fun clause-tail2(op : (a1,a2) -> e b) : op2<a1,a2,b,e,r> {
@@ -561,7 +561,7 @@ fun read(i:int) {
 }
 
 fun reader(init,action) {
-  read-handle( Reader-hnd( clause-control( fn(x,k){ k(init) } )), id, action)
+  read-handle( ReaderHnd( clause-control( fn(x,k){ k(init) } )), id, action)
 }
 
 // State

--- a/test/overload/unpack.kk
+++ b/test/overload/unpack.kk
@@ -13,8 +13,8 @@ fun add(a1: a, a2: a, b1: b, b2: b, .?a/num: num<a>, .?b/num: num<b>, ?a/show: a
   println(a1 + a2)
   println(a/num/(+)(a1, a2))
 
-val int/basic-num: basic-num<int> = Basic-num(0)
-val float/basic-num: basic-num<float64> = Basic-num(0.0)
+val int/basic-num: basic-num<int> = BasicNum(0)
+val float/basic-num: basic-num<float64> = BasicNum(0.0)
 
 fun num(add, sub, ?basic-num)
   Num(basic-num, add, sub)

--- a/test/overload/unpack.kk.out
+++ b/test/overload/unpack.kk.out
@@ -10,7 +10,7 @@ overload/unpack/int/num: num<int>
 overload/unpack/num/(+): forall<a> (num : num<a>) -> ((a, a) -> a)
 overload/unpack/num/(-): forall<a> (num : num<a>) -> ((a, a) -> a)
 overload/unpack/num/base: forall<a> (num : num<a>) -> basic-num<a>
-overload/unpack/Basic-num: forall<a> (zero : a) -> basic-num<a>
+overload/unpack/BasicNum: forall<a> (zero : a) -> basic-num<a>
 overload/unpack/Num: forall<a> (base : basic-num<a>, (+) : (a, a) -> a, (-) : (a, a) -> a) -> num<a>
 overload/unpack/add: forall<a,b> (a1 : a, a2 : a, b1 : b, b2 : b, ?a/num : num<a>, ?b/num : num<b>, ?a/show : (a) -> string, ?b/show : (b) -> string) -> console ()
 overload/unpack/main: () -> console ()

--- a/test/perf/heaps/testsuite.kk
+++ b/test/perf/heaps/testsuite.kk
@@ -33,7 +33,7 @@ fun rand(s : rand-state) {
     val s2 = (172 * s.s2) % 30307
     val s3 = (170 * s.s3) % 30323
     val r = (float64(s1)/30269.0 + float64(s2)/30307.0 + float64(s3)/30323.0) % 1.0
-    (r, Rand-state(s1, s2, s3))
+    (r, RandState(s1, s2, s3))
 }
 
 fun rand-list(tc : test-config) {
@@ -45,7 +45,7 @@ fun rand-list(tc : test-config) {
         }
     }
 
-    val init = Rand-state(19379, 17844, 5912)
+    val init = RandState(19379, 17844, 5912)
     go(init, tc.testsize, [])
 }
 
@@ -61,7 +61,7 @@ fun main() {
     // Test implementations:
 
     print("Testing consistency: ")
-    val test = rand-list(Test-config(100, 10000.int32))
+    val test = rand-list(TestConfig(100, 10000.int32))
     val r1 = heapsort-leftist-heaps-okasaki(test)
     val r2 = heapsort-pairing-heaps-okasaki(test)
     val r3 = heapsort-pairing-heaps-tailcall(test)
@@ -81,9 +81,9 @@ fun main() {
 
     // Benchmark:
 
-    val tcs = [ Test-config( 1000000, 100000000.int32)
-              , Test-config( 5000000, 500000000.int32)
-              , Test-config(10000000, 1000000000.int32)]
+    val tcs = [ TestConfig( 1000000, 100000000.int32)
+              , TestConfig( 5000000, 500000000.int32)
+              , TestConfig(10000000, 1000000000.int32)]
 
     tcs.map(fn(tc) {
         print-test-config(tc)

--- a/test/perf/sets/testsuite.kk
+++ b/test/perf/sets/testsuite.kk
@@ -42,7 +42,7 @@ fun rand(s : rand-state) {
     val s2 = (172 * s.s2) % 30307
     val s3 = (170 * s.s3) % 30323
     val r = (float64(s1)/30269.0 + float64(s2)/30307.0 + float64(s3)/30323.0) % 1.0
-    (r, Rand-state(s1, s2, s3))
+    (r, RandState(s1, s2, s3))
 }
 
 fun rand-list(tc : test-config) {
@@ -54,7 +54,7 @@ fun rand-list(tc : test-config) {
         }
     }
 
-    val init = Rand-state(19379, 17844, 5912)
+    val init = RandState(19379, 17844, 5912)
     go(init, tc.testsize, [])
 }
 
@@ -62,7 +62,7 @@ fun main() {
     // Test implementations:
 
     print("Testing consistency: ")
-    val test = rand-list(Test-config(100, 1000.int32))
+    val test = rand-list(TestConfig(100, 1000.int32))
     val r1  = count-b-trees(1, 1000, test)
     val r2  = count-b-trees-pad-full(1, 1000, test)
     val r3  = count-b-trees-pad-separate(1, 1000, test)
@@ -99,9 +99,9 @@ fun main() {
 
     // Benchmark:
 
-    val tcs = [ Test-config( 1000000, 10000000.int32)
-              , Test-config( 5000000, 50000000.int32)
-              , Test-config(10000000, 100000000.int32)]
+    val tcs = [ TestConfig( 1000000, 10000000.int32)
+              , TestConfig( 5000000, 50000000.int32)
+              , TestConfig(10000000, 100000000.int32)]
 
     tcs.map(fn(tc) {
         print-test-config(tc)

--- a/test/type/inf1.kk.out
+++ b/test/type/inf1.kk.out
@@ -2,7 +2,7 @@ type/inf1/linear-set/eq: forall<a,e> (linear-set<a>) -> ((a, a) -> e bool)
 type/inf1/linear-set/list: forall<a> (linear-set<a>) -> list<a>
 type/inf1/set/(+): forall<e,a> (l1 : linear-set<a>, l2 : linear-set<a>) -> e linear-set<a>
 type/inf1/val/(+): forall<e,a> (l : linear-set<a>, a : a) -> e linear-set<a>
-type/inf1/Linear-set: forall<a> (list : list<a>, eq : (a, a) -> _e bool) -> linear-set<a>
+type/inf1/LinearSet: forall<a> (list : list<a>, eq : (a, a) -> _e bool) -> linear-set<a>
 type/inf1/foo0: forall<e> (l1 : linear-set<int>, l2 : linear-set<int>) -> e linear-set<int>
 type/inf1/foo1: forall<e> (l1 : linear-set<int>, l2 : linear-set<int>) -> e linear-set<int>
 type/inf1/foo2: forall<e> (l1 : linear-set<int>, l2 : linear-set<int>) -> e linear-set<int>


### PR DESCRIPTION
This PR implements #537 and fixes uses of `struct` constructors in `lib/std` and `test`. Not everything was covered by tests so I had to inspect the output of `grep -R '[A-Z][a-z]*-[a-z]+'` manually, I hope I didn't miss anything. Not covered:
- `type` constructors that don't follow this convention
- `lib/v1`