### PR TITLE
Free fun changes

### DIFF
--- a/kklib/src/init.c
+++ b/kklib/src/init.c
@@ -47,16 +47,19 @@ bool kk_function_is_null(kk_function_t f, kk_context_t* ctx) {
 
 // null functions
 void kk_free_fun_null(void* p, kk_block_t* b, kk_context_t* ctx) {
+  // TODO: 
+  //   Should we require a custom free function, instead of using this?
+  //   This function at least leaks the Koka block
+  //   and possibly also the pointer if not retained/released by C code.
   kk_unused(p);
   kk_unused(b);
   kk_unused(ctx);
 }
 
-// free memory
+// free C memory (allocated by kk_malloc, kk_calloc, kk_realloc)
 void kk_free_fun(void* p, kk_block_t* b, kk_context_t* ctx) {
-  kk_unused(b);
-  kk_unused(ctx);
-  kk_free(p,ctx);
+  kk_free(p,ctx); // free the payload
+  kk_free(b,ctx); // free the koka block
 }
 
 


### PR DESCRIPTION
It seems to me that we need to adjust at least `kk_free_fun` to deallocate the Koka block in addition to the payload.

I'm not sure how this API is intended to be used but at least in my and others' code using a Koka boxed value to wrap c pointers, we are transferring ownership of the pointer to Koka to manage lifetimes. Even if we were not, if the Koka datatype is freed, it seems like at least the Koka block should be freed, if not also the C pointer. 
If however, the C pointer is not intended to be freed, we should free the opposite pointer. And we should possibly have two alternative APIs (`kk_free_fun_ptr_owned`, `kk_free_fun_ptr_ref`), or something to handle the two likely cases. 

What is the purpose of `kk_free_fun_null`? It is used in `kk_cptr_box`. At the very least it seems like it will leak the Koka block for the box, and at most, both the Koka block and the C pointer wrapped by the box (if the C code isn't the final owner). It seems to me that maybe we should have `kk_cptr_box` require an explicit free fun, so the user of the API has to make a conscious choice here?