### PR TITLE
Add profiling support (--fprofile) for gcc and clang

### DIFF
--- a/kklib/include/kklib.h
+++ b/kklib/include/kklib.h
@@ -679,10 +679,10 @@ static inline void kk_block_free(kk_block_t* b, kk_context_t* ctx) {
   inlined and we get nice inlined assembly for the fast path with the single check.
 --------------------------------------------------------------------------------------*/
 
-kk_decl_export void        kk_block_check_drop(kk_block_t* b, kk_refcount_t rc, kk_context_t* ctx);
-kk_decl_export void        kk_block_check_decref(kk_block_t* b, kk_refcount_t rc, kk_context_t* ctx);
-kk_decl_export kk_block_t* kk_block_check_dup(kk_block_t* b, kk_refcount_t rc);
-kk_decl_export kk_reuse_t  kk_block_check_drop_reuse(kk_block_t* b, kk_refcount_t rc0, kk_context_t* ctx);
+kk_decl_export kk_decl_cold void        kk_block_check_drop(kk_block_t* b, kk_refcount_t rc, kk_context_t* ctx);
+kk_decl_export kk_decl_cold void        kk_block_check_decref(kk_block_t* b, kk_refcount_t rc, kk_context_t* ctx);
+kk_decl_export kk_decl_cold kk_block_t* kk_block_check_dup(kk_block_t* b, kk_refcount_t rc);
+kk_decl_export kk_decl_cold kk_reuse_t  kk_block_check_drop_reuse(kk_block_t* b, kk_refcount_t rc0, kk_context_t* ctx);
 
 // Dup a reference.
 static inline kk_block_t* kk_block_dup(kk_block_t* b) {

--- a/kklib/include/kklib/platform.h
+++ b/kklib/include/kklib/platform.h
@@ -195,6 +195,8 @@
 #define kk_decl_const         __attribute__((const))    // reads no global state at all
 #define kk_decl_pure          __attribute__((pure))     // may read global state but has no observable side effects
 #define kk_decl_noinline      __attribute__((noinline))
+#define kk_decl_cold          __attribute__((noinline,cold))   // cold path: thread-shared RC, overflow, etc.
+#define kk_decl_hot           __attribute__((hot))             // hot path: common RC fast paths
 #define kk_decl_align(a)      __attribute__((aligned(a)))
 #define kk_decl_thread        __thread
 #elif defined(_MSC_VER)
@@ -207,6 +209,8 @@
 #define kk_decl_const
 #define kk_decl_pure
 #define kk_decl_noinline      __declspec(noinline)
+#define kk_decl_cold          __declspec(noinline)
+#define kk_decl_hot
 #define kk_decl_align(a)      __declspec(align(a))
 #define kk_decl_thread        __declspec(thread)
 #ifndef __cplusplus  // need c++ compilation for correct atomic operations on msvc
@@ -216,6 +220,8 @@
 #define kk_decl_const
 #define kk_decl_pure
 #define kk_decl_noinline
+#define kk_decl_cold
+#define kk_decl_hot
 #define kk_decl_align(a)
 #define kk_decl_thread        __thread
 #endif

--- a/readme.md
+++ b/readme.md
@@ -427,32 +427,57 @@ info: elapsed: 1.483s, user: 1.484s, sys: 0.000s, rss: 164mb
 
 ## Profiling
 
-Koka includes experimental support for profiling programs using
-[gprof](https://sourceware.org/binutils/docs/gprof/).
-Compile with the `--fprofile` flag to enable profiling instrumentation:
+Koka supports profiling with both GCC and Clang via the `--fprofile` flag.
+
+### GCC (gprof — time-based sampling)
 
 ```sh
 $ koka --fprofile -e myprogram.kk
-```
-
-This adds `-pg -g3 -fno-omit-frame-pointer` to the C compilation and
-`-pg` to linking, producing a `gmon.out` file when the program runs.
-You can then inspect the results with:
-
-```sh
 $ gprof .koka/v*/gcc-profile-*/myprogram__main gmon.out
 ```
 
-A convenience utility automates the compile-run-report workflow:
+Shows where the program spends time (percentage of total, call counts per function).
+
+### Clang (LLVM instrumentation — execution frequency)
 
 ```sh
-$ koka util/profile.kk -- --source myprogram.kk --runs=3 --opt=-O2
+$ koka --fprofile --cc=clang -e myprogram.kk
+$ llvm-profdata merge -sparse default.profraw -o default.profdata
+$ llvm-profdata show --all-functions --topn=15 default.profdata
+```
+
+Shows how often each function and code path executes.
+
+### Linux perf (hardware sampling)
+
+On Linux, `perf` provides hardware-accurate sampling on any compiled binary
+— no special compiler flags are needed:
+
+```sh
+$ koka -O2 myprogram.kk
+$ perf record -g .koka/v*/gcc-drelease-*/myprogram__main
+$ perf report
+```
+
+Or generate a flame graph:
+
+```sh
+$ perf script | stackcollapse-perf.pl | flamegraph.pl > flame.svg
+```
+
+### Profiling utility
+
+A convenience script automates the GCC compile-run-report workflow:
+
+```sh
+$ koka util/profile.kk -- myprogram.kk --runs=3 --opt=-O2
 ```
 
 Run `koka util/profile.kk -- --help` for all options.
 
-> **Note:** The `--fprofile` flag currently requires `gcc` and `gprof`
-> to be installed.
+> **Note:** GCC profiling requires `gcc` and `gprof`.
+> Clang profiling requires `clang` and `llvm-profdata`.
+> Linux perf requires the `linux-tools` package.
 
 ## Language Server
 

--- a/readme.md
+++ b/readme.md
@@ -425,6 +425,35 @@ $ out\v2.0.5\cl-release\test_bench_koka_rbtree --kktime
 info: elapsed: 1.483s, user: 1.484s, sys: 0.000s, rss: 164mb
 ```
 
+## Profiling
+
+Koka includes experimental support for profiling programs using
+[gprof](https://sourceware.org/binutils/docs/gprof/).
+Compile with the `--fprofile` flag to enable profiling instrumentation:
+
+```sh
+$ koka --fprofile -e myprogram.kk
+```
+
+This adds `-pg -g3 -fno-omit-frame-pointer` to the C compilation and
+`-pg` to linking, producing a `gmon.out` file when the program runs.
+You can then inspect the results with:
+
+```sh
+$ gprof .koka/v*/gcc-profile-*/myprogram__main gmon.out
+```
+
+A convenience utility automates the compile-run-report workflow:
+
+```sh
+$ koka util/profile.kk -- --source myprogram.kk --runs=3 --opt=-O2
+```
+
+Run `koka util/profile.kk -- --help` for all options.
+
+> **Note:** The `--fprofile` flag currently requires `gcc` and `gprof`
+> to be installed.
+
 ## Language Server
 
 See the [`support/vscode/README.md`](support/vscode/README.md) for how to

--- a/src/Compile/Options.hs
+++ b/src/Compile/Options.hs
@@ -1320,10 +1320,16 @@ ccFromPath flags path
                                       , ccFlagsLink    = ccFlagsLink cc ++ [sanitize] }
                                   ,True)
           else if (profile flags)
-            then return (cc{ ccName         = ccName cc ++ "-profile"
-                           , ccFlagsCompile = ccFlagsCompile cc ++ ["-pg","-g3","-fno-omit-frame-pointer"]
-                           , ccFlagsLink    = ccFlagsLink cc ++ ["-pg"] }
-                        ,True)
+            then let isClang = ccName cc `startsWith` "clang"
+                 in if isClang
+                   then return (cc{ ccName         = ccName cc ++ "-profile"
+                                  , ccFlagsCompile = ccFlagsCompile cc ++ ["-fprofile-instr-generate","-fcoverage-mapping","-g","-fno-omit-frame-pointer"]
+                                  , ccFlagsLink    = ccFlagsLink cc ++ ["-fprofile-instr-generate"] }
+                               ,True)
+                   else return (cc{ ccName         = ccName cc ++ "-profile"
+                                  , ccFlagsCompile = ccFlagsCompile cc ++ ["-pg","-g3","-fno-omit-frame-pointer"]
+                                  , ccFlagsLink    = ccFlagsLink cc ++ ["-pg"] }
+                               ,True)
           else if (useStdAlloc flags)
             then return (cc{ ccName = ccName cc ++ "-stdalloc" }, False)
           else if (mimallocStats flags)

--- a/src/Compile/Options.hs
+++ b/src/Compile/Options.hs
@@ -230,7 +230,8 @@ data Flags
          , parcReuseSpec    :: !Bool
          , parcBorrowInference    :: !Bool
          , asan             :: !Bool
-         , useStdAlloc      :: !Bool -- don't use mimalloc for better asan and valgrind support
+         , profile          :: !Bool      -- compile with profiling support (-pg, frame pointers, debug info)
+         , useStdAlloc      :: !Bool      -- don't use mimalloc for better asan and valgrind support
          , optSpecialize    :: !Bool
          , mimallocStats    :: !Bool
          , allowInfiniteChains :: !Bool
@@ -283,6 +284,7 @@ instance Hashable Flags where
           show $ parcReuseSpec flags,
           show $ parcBorrowInference flags,
           show $ asan flags,
+          show $ profile flags,
           show $ useStdAlloc flags,
           show $ optSpecialize flags,
           show $ allowInfiniteChains flags
@@ -388,6 +390,7 @@ flagsNull
           True -- parc reuse specialize
           False -- parc borrow inference
           False -- use asan
+          False -- use profile
           False -- use stdalloc
           True  -- use specialization (only used if optimization level >= 1)
           False -- use mimalloc stats
@@ -502,6 +505,7 @@ options = (\(xss,yss) -> (concat xss, concat yss)) $ unzip
 
  -- hidden
  , hide $ fflag       ["asan"]      (\b f -> f{asan=b})             "compile with address, undefined, and leak sanitizer"
+ , hide $ fflag       ["profile"]   (\b f -> f{profile=b})          "compile with profiling support (-pg, frame pointers, debug info)"
  , hide $ fflag       ["stdalloc"]  (\b f -> f{useStdAlloc=b})      "use the standard libc allocator"
  , hide $ fflag       ["allocstats"]  (\b f -> f{mimallocStats=b})   "enable mimalloc statitistics"
  , hide $ fnum 3 "n"  ["simplify"]  (\i f -> f{simplify=i})          "enable 'n' core simplification passes"
@@ -1312,6 +1316,11 @@ ccFromPath flags path
                                       , ccFlagsCompile = ccFlagsCompile cc ++ [sanitize,"-fno-omit-frame-pointer","-O0"]
                                       , ccFlagsLink    = ccFlagsLink cc ++ [sanitize] }
                                   ,True)
+          else if (profile flags)
+            then return (cc{ ccName         = ccName cc ++ "-profile"
+                           , ccFlagsCompile = ccFlagsCompile cc ++ ["-pg","-g3","-fno-omit-frame-pointer"]
+                           , ccFlagsLink    = ccFlagsLink cc ++ ["-pg"] }
+                        ,True)
           else if (useStdAlloc flags)
             then return (cc{ ccName = ccName cc ++ "-stdalloc" }, False)
           else if (mimallocStats flags)

--- a/src/Compile/Options.hs
+++ b/src/Compile/Options.hs
@@ -343,7 +343,10 @@ flagsNull
           (ccGcc "gcc" "gcc" True)
           (if onWindows then []        -- ccomp library dirs
                         else (["/usr/local/lib","/usr/lib","/lib"]
-                               ++ if onMacOS then ["/opt/homebrew/lib"] else []))
+                               ++ (if onMacOS then ["/opt/homebrew/lib"]
+                                   else case multiarchLibDir of
+                                          Just dir -> [dir]
+                                          Nothing  -> [])))
 
           True     -- auto install libraries
           ""       -- vcpkg root
@@ -1366,6 +1369,15 @@ onMacOS
 onWindows :: Bool
 onWindows
   = (exeExtension == ".exe")
+
+-- | On Debian/Ubuntu multiarch systems, libraries are installed under
+-- /usr/lib/<arch-triplet>/ (e.g., /usr/lib/x86_64-linux-gnu/).
+-- Returns the multiarch library directory if it exists on this platform.
+multiarchLibDir :: Maybe String
+multiarchLibDir
+  | onWindows || onMacOS = Nothing
+  | otherwise = let triplet = System.Info.arch ++ "-" ++ System.Info.os ++ "-gnu"
+                in  Just ("/usr/lib/" ++ triplet)
 
 tripletOsName :: String -> String
 tripletOsName osName

--- a/util/profile.kk
+++ b/util/profile.kk
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------
+  Copyright 2026, Microsoft Research, Angelica Moreira.
+
+  Utility to profile Koka programs using the --fprofile flag.
+  Compiles with profiling instrumentation (-pg), runs the binary to
+  generate gmon.out, then invokes gprof for a flat+call-graph report.
+
+  Usage:
+    koka util/profile.kk -- <source.kk> [--runs=N] [--cc=<compiler>] [--opt=<level>]
+---------------------------------------------------------------------------*/
+module profile
+
+import std/os/path
+import std/os/dir
+import std/os/process
+import std/os/env
+import std/os/flags
+
+// Configuration
+struct pflags
+  source  : string = ""
+  runs    : int = 1
+  cc      : string = "gcc"
+  opt     : string = "-O2"
+  args    : string = ""
+  verbose : bool = False
+
+val flag-descs : list<flag<pflags>> =
+  fun set-source( f : pflags, s : string ) : pflags  { f(source = s) }
+  fun set-runs( f : pflags, s : string ) : pflags    { f(runs = s.parse-int.default(1)) }
+  fun set-cc( f : pflags, s : string ) : pflags      { f(cc = s) }
+  fun set-opt( f : pflags, s : string ) : pflags     { f(opt = s) }
+  fun set-args( f : pflags, s : string ) : pflags    { f(args = s) }
+  fun set-verbose( f : pflags, b : bool ) : pflags   { f(verbose = b) }
+  [ Flag("s", ["source"],  Req(set-source,"FILE"),   "Koka source file to profile"),
+    Flag("r", ["runs"],    Req(set-runs,"N"),        "Number of profiling runs (default: 1)"),
+    Flag("c", ["cc"],      Req(set-cc,"CC"),         "C compiler to use (default: gcc)"),
+    Flag("o", ["opt"],     Req(set-opt,"LEVEL"),     "Optimization level (default: -O2)"),
+    Flag("a", ["args"],    Req(set-args,"ARGS"),     "Extra arguments for the compiled program"),
+    Flag("v", ["verbose"], Bool(set-verbose),        "Show verbose output")
+  ]
+
+fun process-flags() : <console,ndet> maybe<pflags>
+  val header = "Usage: koka util/profile.kk -- [options] <source.kk>\n\nOptions:"
+  val (pflags, rest, errs) = parse(Pflags(), flag-descs, get-args())
+  if errs.is-nil then
+    val pf = match rest
+      Cons(src, _) | pflags.source.is-empty -> pflags(source = src)
+      _ -> pflags
+    if pf.source.is-empty then
+      println(header)
+      flag-descs.usage(header).println
+      Nothing
+    else Just(pf)
+  else
+    errs.map(println)
+    Nothing
+
+pub fun main()
+  match process-flags()
+    Nothing -> ()
+    Just(pf) ->
+      profile(pf)
+
+fun profile( pf : pflags ) : io ()
+  val src = pf.source
+  println("=== Koka Profiler ===")
+  println("source : " ++ src)
+  println("cc     : " ++ pf.cc)
+  println("opt    : " ++ pf.opt)
+  println("runs   : " ++ pf.runs.show)
+  println("")
+
+  // Step 1: Compile with profiling
+  println("[1/3] Compiling with --fprofile ...")
+  val compile-cmd = "koka --fprofile --cc=" ++ pf.cc ++ " " ++ pf.opt ++ " -e " ++ src
+  if pf.verbose then println("  > " ++ compile-cmd)
+  // Use -e to compile and find the binary, but first just compile
+  val compile-only = "koka --fprofile --cc=" ++ pf.cc ++ " " ++ pf.opt ++ " -c " ++ src
+  val cret = run-system(compile-only)
+  if cret != 0 then
+    println("ERROR: compilation failed (exit code " ++ cret.show ++ ")")
+    return ()
+
+  println("  compilation succeeded")
+  println("")
+
+  // Step 2: Run with profiling (generates gmon.out)
+  println("[2/3] Running " ++ pf.runs.show ++ " time(s) to collect profile data ...")
+  val run-cmd = "koka --fprofile --cc=" ++ pf.cc ++ " " ++ pf.opt ++ " -e " ++ src ++ " -- " ++ pf.args
+  var i := 0
+  while { i < pf.runs }
+    i := i + 1
+    if pf.verbose then println("  run " ++ i.show ++ ": " ++ run-cmd)
+    val rret = run-system(run-cmd)
+    if rret != 0 then
+      println("  WARNING: run " ++ i.show ++ " exited with code " ++ rret.show)
+  println("  profiling runs complete")
+  println("")
+
+  // Step 3: Generate gprof report
+  println("[3/3] Generating gprof report ...")
+  val gprof-cmd = "gprof $(ls -t .koka/v*/gcc-profile-*/*__main 2>/dev/null | head -1) gmon.out"
+  if pf.verbose then println("  > " ++ gprof-cmd)
+  val gret = run-system(gprof-cmd)
+  if gret != 0 then
+    println("NOTE: gprof failed (exit " ++ gret.show ++ "). You may need to install gprof or check gmon.out exists.")
+    println("  Try manually: gprof <binary> gmon.out")

--- a/util/profile.kk
+++ b/util/profile.kk
@@ -18,12 +18,13 @@ import std/os/flags
 
 // Configuration
 struct pflags
-  source  : string = ""
-  runs    : int = 1
-  cc      : string = "gcc"
-  opt     : string = "-O2"
-  args    : string = ""
-  verbose : bool = False
+  source   : string = ""
+  runs     : int = 1
+  cc       : string = "gcc"
+  opt      : string = "-O2"
+  args     : string = ""
+  verbose  : bool = False
+  showhelp : bool = False
 
 val flag-descs : list<flag<pflags>> =
   fun set-source( f : pflags, s : string ) : pflags  { f(source = s) }
@@ -32,12 +33,14 @@ val flag-descs : list<flag<pflags>> =
   fun set-opt( f : pflags, s : string ) : pflags     { f(opt = s) }
   fun set-args( f : pflags, s : string ) : pflags    { f(args = s) }
   fun set-verbose( f : pflags, b : bool ) : pflags   { f(verbose = b) }
+  fun set-help( f : pflags, b : bool ) : pflags      { f(showhelp = b) }
   [ Flag("s", ["source"],  Req(set-source,"FILE"),   "Koka source file to profile"),
     Flag("r", ["runs"],    Req(set-runs,"N"),        "Number of profiling runs (default: 1)"),
     Flag("c", ["cc"],      Req(set-cc,"CC"),         "C compiler to use (default: gcc)"),
     Flag("o", ["opt"],     Req(set-opt,"LEVEL"),     "Optimization level (default: -O2)"),
     Flag("a", ["args"],    Req(set-args,"ARGS"),     "Extra arguments for the compiled program"),
-    Flag("v", ["verbose"], Bool(set-verbose),        "Show verbose output")
+    Flag("v", ["verbose"], Bool(set-verbose),        "Show verbose output"),
+    Flag("h", ["help"],    Bool(set-help),           "Show this help")
   ]
 
 fun process-flags() : <console,ndet> maybe<pflags>
@@ -47,13 +50,13 @@ fun process-flags() : <console,ndet> maybe<pflags>
     val pf = match rest
       Cons(src, _) | pflags.source.is-empty -> pflags(source = src)
       _ -> pflags
-    if pf.source.is-empty then
-      println(header)
+    if pf.showhelp || pf.source.is-empty then
       flag-descs.usage(header).println
       Nothing
     else Just(pf)
   else
     errs.map(println)
+    flag-descs.usage(header).println
     Nothing
 
 pub fun main()


### PR DESCRIPTION
Adds --fprofile flag for profiling Koka programs with gcc (gprof) and clang (llvm instrumentation).

Changes:
- --fprofile flag: uses -pg/gprof for gcc, -fprofile-instr-generate for clang
- cold path annotations on RC slow-path functions in kklib
- multiarch library search path fix for Debian/Ubuntu (/usr/lib/x86_64-linux-gnu)
- profiling utility (util/profile.kk) with --help flag
- readme section covering gcc, clang, and linux perf profiling