### PR TITLE
Fix prefix/postfix identifiers

### DIFF
--- a/koka.cabal
+++ b/koka.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.39.1.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -245,6 +245,7 @@ test-suite koka-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      NameSpec
       Paths_koka
   hs-source-dirs:
       test
@@ -264,6 +265,7 @@ test-suite koka-test
     , hspec-core
     , isocline >=1.0.6
     , json
+    , koka
     , mtl
     , parsec
     , process

--- a/package.yaml
+++ b/package.yaml
@@ -118,7 +118,7 @@ tests:
       - -rtsopts
       - -with-rtsopts=-N
     dependencies:
-      # - koka
+      - koka
       - extra
       - filepath
       - hspec

--- a/src/Common/Name.hs
+++ b/src/Common/Name.hs
@@ -50,7 +50,7 @@ module Common.Name
           , toImplicitParamName, isImplicitParamName, splitImplicitParamName
           , fromImplicitParamName
 
-          , prepend, postpend
+          , prepend, postpend, isSymbolName
           , asciiEncode, moduleNameToPath, pathToModuleName
           -- , canonicalSep, canonicalName, nonCanonicalName, canonicalSplit
 
@@ -67,7 +67,7 @@ module Common.Name
 -- import Lib.Trace( trace )
 import Debug.Trace
 import Lib.PPrint
-import Data.Char(isUpper,toLower,toUpper,isAlphaNum,isDigit,isAlpha)
+import Data.Char(isUpper,isLower,toLower,toUpper,isAlphaNum,isDigit,isAlpha)
 import Common.Failure(failure,assertion, HasCallStack)
 import Common.File( joinPaths, splitOn, endsWith, startsWith, isPathSep )
 import Common.Range( rangeStart, posLine, posColumn )
@@ -203,6 +203,10 @@ isIdChar :: Char -> Bool
 isIdChar c
   = (isAlphaNum c || c == '_' || c == '@' || c == '-')
 
+isSymbolChar :: Char -> Bool
+isSymbolChar c
+  = c `elem` "$%&*+~!\\^#=.:-|<>/"
+
 isIdStartChar :: Char -> Bool
 isIdStartChar c
   = (isAlpha c || c == '_' || c == '@')
@@ -212,11 +216,11 @@ isIdEndChar c
   = isIdChar c || c == '\''
 
 isSymbolId :: String -> Bool
-isSymbolId "" = False
-isSymbolId s  = not (isIdStartChar (head s)) || not (isIdEndChar (last s))
-  -- where
-  --
-  --   isIdEndChar c    = (c == '\'' || c == '?')
+isSymbolId s
+  = case s of
+      [c] -> not (isIdStartChar c && isIdEndChar c)
+      (c:cs) -> not (isIdStartChar c && isIdEndChar (last cs) && all isIdEndChar (init cs))
+      "" -> False
 
 wrapId :: String -> String
 wrapId s
@@ -592,26 +596,83 @@ nameStartsWith :: Name -> String -> Bool
 nameStartsWith name pre
   = nameStem name `startsWith` pre
 
+-- | Check if a string is a valid lower-case identifier (starts with optional @ followed by lowercase)
+isLowerId :: String -> Bool
+isLowerId s = case dropWhile (=='@') s of
+                (c:_) -> isLower c
+                _     -> False
+
+-- | Check if a string is a valid constructor identifier (starts with optional @ followed by uppercase)
+isConstructorId :: String -> Bool
+isConstructorId s = case dropWhile (=='@') s of
+                      (c:_) -> isUpper c
+                      _     -> False
+
+-- | Check if a string is a valid identifier (lower or constructor)
+isValidId :: String -> Bool
+isValidId s = isLowerId s || isConstructorId s
+
+-- | Append two strings, inserting 'x' if the suffix starts with a non-alpha character after a hyphen
+-- to maintain well-formed identifiers.
+appendWithXAfterHyphen :: String -> String -> String
+appendWithXAfterHyphen pre suf = case (reverse pre, suf) of
+  ('-':_, c:_) | not (isAlpha c) -> pre ++ "x" ++ suf
+  _ -> pre ++ suf
+
+-- | Ensure a prefix string is a valid lower-case identifier.
+-- If not, prepend "@x".
+-- Also drops a trailing '@' if adding '@x' (to avoid double @ or empty @).
+ensureLowerId :: String -> String
+ensureLowerId s
+  | isLowerId s = s
+  | otherwise   = "@x" ++ dropTrailingAt s
+  where
+    dropTrailingAt str = case reverse str of
+                           ('@':rest) -> reverse rest
+                           _          -> str
+
 prepend :: String -> Name -> Name
-prepend pre name
+prepend pre name | isSymbolName name
   = nameMapStem name $ \stem ->
-    let append p s = case (reverse p, s) of
-                      ('-':_, c:cs)  | not (isAlpha c) -> p ++ "x" ++ s -- keep well-formed identifiers
-                      _ -> p ++ s
-    in case stem of
-        ('@':t) -> case pre of -- keep hidden names hidden
-                    '@':_ -> append pre t
-                    _     -> '@' : append pre t
-        _       -> append pre stem
+    let (rsyms,rid) = span isSymbolChar (reverse stem)
+        prefix = reverse rid
+        syms = reverse rsyms
+        newprefix = prependRaw pre prefix
+    in ensureLowerId newprefix ++ syms
+
+prepend pre name
+  = nameMapStem name $ \stem -> prependStr pre stem
+
+prependRaw :: String -> String -> String
+prependRaw pre stem
+  = case stem of
+      ('@':t) -> case pre of -- keep hidden names hidden
+                    '@':_ -> appendWithXAfterHyphen pre t
+                    _     -> '@' : appendWithXAfterHyphen pre t
+      _       -> appendWithXAfterHyphen pre stem
+
+prependStr :: String -> String -> String
+prependStr pre stem
+  = let result = prependRaw pre stem
+    in if result `startsWith` "@" && not (isValidId result)
+         then "@x" ++ result
+         else result
 
 
 postpend :: String -> Name -> Name
 postpend post name | isSymbolName name
   = -- we must always end in symbols for operators so postpend inserts before the symbols
     nameMapStem name $ \stem ->
-    let (rsyms,rid) = span (not . isIdChar) (reverse stem)
-    in (if null rid || rid == "@" then "@x" else reverse rid) -- ensure it becomes a valid lowerid
-        ++ post ++ reverse rsyms
+    let (rsyms,rid) = span isSymbolChar (reverse stem)
+        prefix = reverse rid
+        -- ensure prefix is valid only when we actually end in operator symbols;
+        -- note: we don't use ensureLowerId here as we don't want to drop trailing @
+        validPrefix
+          | null rsyms = prefix
+          | null prefix || not (isLowerId prefix) = "@x" ++ prefix
+          | otherwise = prefix
+    in validPrefix ++ post ++ reverse rsyms
+
 postpend post name
   = nameMapStem name $ \stem ->
     let (xs,ys) = span (\c -> c=='?' || c=='\'') (reverse stem)

--- a/src/Syntax/Lexer.x
+++ b/src/Syntax/Lexer.x
@@ -94,7 +94,7 @@ $charesc      = [nrt\\\'\"]    -- "
 @qconid       = @modulepath @conid
 
 @op           = $symbol+ | \/
-@idsym        = @lowerid? $symbol+ | \/
+@idsym        = @lowerid? ($symbol+ | \/)
 @qidop        = @modulepath \(@idsym\)
 @idop         = \(@idsym\)
 

--- a/test/NameSpec.hs
+++ b/test/NameSpec.hs
@@ -1,0 +1,246 @@
+module NameSpec (spec) where
+
+import Test.Hspec
+import Common.Name
+import Common.ColorScheme
+import Syntax.Lexer
+import Syntax.Lexeme
+import qualified Common.Range as R
+import qualified Data.ByteString.Char8 as BC
+import Control.Monad (forM_)
+
+spec :: Spec
+spec = do
+  let testLex s = do
+        let input = BC.pack s
+            res = lexing (R.Source "test" input) 1 input
+        case res of
+          (Lexeme _ (LexIdOp name) : _) -> return (Just name)
+          (Lexeme _ (LexId name) : _)   -> return (Just name)
+          (Lexeme _ (LexCons name _) : _) -> return (Just name)
+          _ -> return Nothing
+
+  describe "Common.Name" $ do
+    it "pretty prints operators correctly" $ do
+      let n1 = newName "|->"
+      show (prettyName defaultColorScheme n1) `shouldBe` "(|->)"
+      
+    it "postpends unique identifiers to operators correctly" $ do
+      let n1 = newName "|->"
+      let n2 = postpend "@1" n1
+      show (prettyName defaultColorScheme n2) `shouldBe` "(@x@1|->)"
+      
+    it "prepends identifiers to modified operators correctly" $ do
+      let n1 = newName "|->"
+      let n2 = postpend "@1" n1
+      let n3 = prepend "@lift-x" n2
+      show (prettyName defaultColorScheme n3) `shouldBe` "(@lift-xx@1|->)"
+      
+    it "postpends unique identifiers to regular names correctly" $ do
+      let n1 = newName "foo"
+      let n2 = postpend "@2" n1
+      show (prettyName defaultColorScheme n2) `shouldBe` "foo@2"
+
+    it "handles division operator correctly" $ do
+      let n1 = newName "/"
+      show (prettyName defaultColorScheme n1) `shouldBe` "(/)"
+      let n2 = postpend "@1" n1
+      show (prettyName defaultColorScheme n2) `shouldBe` "(@x@1/)"
+      
+    it "lexes modified operators correctly" $ do
+      let n1 = newName "|->"
+      let n2 = postpend "@1" n1
+      let s = show (prettyName defaultColorScheme n2)
+      name <- testLex s
+      fmap showPlain name `shouldBe` Just (showPlain n2)
+
+    it "lexes modified division operator correctly" $ do
+      let n1 = newName "/"
+      let n2 = postpend "@1" n1
+      let s = show (prettyName defaultColorScheme n2)
+      name <- testLex s
+      fmap showPlain name `shouldBe` Just (showPlain n2)
+
+    it "lexes qualified modified operators correctly" $ do
+      let n1 = readQualifiedName "std/core/|->"
+      let n2 = postpend "@1" n1
+      let s = show (prettyName defaultColorScheme n2)
+      s `shouldBe` "std/core/(@x@1|->)"
+      name <- testLex s
+      fmap showPlain name `shouldBe` Just (showPlain n2)
+
+    it "handles operators ending in hyphen correctly" $ do
+      let n1 = newName "|-"
+      let n2 = postpend "@1" n1
+      show (prettyName defaultColorScheme n2) `shouldBe` "(@x@1|-)"
+      let s = show (prettyName defaultColorScheme n2)
+      name <- testLex s
+      fmap showPlain name `shouldBe` Just (showPlain n2)
+
+    it "handles multiple postpends and prepends" $ do
+      let n1 = newName "|"
+      let n2 = postpend "@1" n1
+      let n3 = postpend "@2" n2
+      let n4 = prepend "@lift" n3
+      show (prettyName defaultColorScheme n4) `shouldBe` "(@liftx@1@2|)"
+      let s = show (prettyName defaultColorScheme n4)
+      name <- testLex s
+      fmap showPlain name `shouldBe` Just (showPlain n4)
+
+    it "handles complex combinations with division" $ do
+      let n1 = newName "/"
+      let n2 = postpend "@unique" n1
+      let n3 = prepend "@special" n2
+      show (prettyName defaultColorScheme n3) `shouldBe` "(@specialx@unique/)"
+      let s = show (prettyName defaultColorScheme n3)
+      name <- testLex s
+      fmap showPlain name `shouldBe` Just (showPlain n3)
+
+    it "handles prepending a hyphenated prefix" $ do
+      let n1 = newName "foo"
+      let n2 = prepend "lift-" n1
+      show (prettyName defaultColorScheme n2) `shouldBe` "lift-foo"
+      let s = show (prettyName defaultColorScheme n2)
+      name <- testLex s
+      fmap showPlain name `shouldBe` Just (showPlain n2)
+
+    it "handles postpending a hyphenated suffix" $ do
+      let n1 = newName "foo"
+      let n2 = postpend "-@1" n1
+      show (prettyName defaultColorScheme n2) `shouldBe` "foo-@1"
+      let s = show (prettyName defaultColorScheme n2)
+      name <- testLex s
+      fmap showPlain name `shouldBe` Just (showPlain n2)
+
+    describe "round-trip tests for common patterns" $ do
+      let patterns = 
+            [ ("@ from makeHidden", prepend "@")
+            , ("@lift- from toHiddenUniqueName", toHiddenUniqueName 123 "lift")
+            , ("@uniq- from toHiddenUniqueName", toHiddenUniqueName 123 "uniq")
+            , ("@unroll- from toHiddenUniqueName", toHiddenUniqueName 123 "unroll")
+            , ("@mlift- from toHiddenUniqueName", toHiddenUniqueName 123 "mlift")
+            , ("@trmc- from makeHiddenName", makeHiddenName "trmc")
+            , ("@trmcm- from makeHiddenName", makeHiddenName "trmcm")
+            , ("@is- from makeHiddenName", makeHiddenName "is")
+            , ("@base- from makeHiddenName", makeHiddenName "base")
+            , ("@new- from makeHiddenName", makeHiddenName "new")
+            , ("@as- from makeHiddenName", makeHiddenName "as")
+            , ("@eval- from makeHiddenName", makeHiddenName "eval")
+            , ("@arg- from makeHiddenName", makeHiddenName "arg")
+            , ("@default- from makeHiddenName", makeHiddenName "default")
+            , ("' from postpend", postpend "'")
+            , ("tv from prepend", prepend "tv")
+            , ("rec from prepend", prepend "rec")
+            , ("this from prepend", prepend "this")
+            , ("other from prepend", prepend "other")
+            , ("is- from prepend", prepend "is-")
+            , ("wild from prepend", prepend "wild")
+            ]
+          testRoundTrip label op nameStr = 
+            it (label ++ " with " ++ nameStr) $ do
+              let n1 = readQualifiedName nameStr
+                  n2 = op n1
+                  s = show (prettyName defaultColorScheme n2)
+              name <- testLex s
+              fmap showPlain name `shouldBe` Just (showPlain n2)
+
+      forM_ patterns $ \(label, op) -> do
+        testRoundTrip label op "foo"
+        testRoundTrip label op "(|->)"
+        testRoundTrip label op "(/)"
+        testRoundTrip label op "std/core/(|->)"
+
+    describe "round-trip tests for constructor name patterns" $ do
+      -- These are names derived from constructor/operation names via hidden name transformations.
+      -- Note: While some are new constructor names (Hnd, Op, Ops), others are identifiers derived from constructor names (tag, val, op, etc.)
+      -- These patterns ensure that the hiding/transformation functions produce valid, lexable names.
+      let constructorPatterns = 
+            [ ("@Hnd- from toHandlerConName", toHandlerConName)
+            , ("@Op- from toOpConName", toOpConName)
+            , ("@Ops- from toOpsConName", toOpsConName)
+            , ("@tag- from toOpenTagName", toOpenTagName)
+            , ("@val- from toValueOperationName", toValueOperationName)
+            , ("@extern- from newHiddenExternalName", newHiddenExternalName)
+            , ("@create- from newCreatorName", newCreatorName)
+            , ("@op- from toOpTypeName", toOpTypeName)
+            , ("@singleton- from makeHiddenName \"singleton\"", makeHiddenName "singleton")
+            ]
+          testRoundTrip label op nameStr = 
+            it (label ++ " with " ++ nameStr) $ do
+              let n1 = readQualifiedName nameStr
+                  n2 = op n1
+                  s = show (prettyName defaultColorScheme n2)
+              name <- testLex s
+              fmap showPlain name `shouldBe` Just (showPlain n2)
+
+      forM_ constructorPatterns $ \(label, op) -> do
+        testRoundTrip label op "Foo"
+        testRoundTrip label op "Cons"
+        testRoundTrip label op "std/core/List"
+    describe "round-trip tests for other prepend/postpend patterns" $ do
+      let otherPatterns = 
+            [ ("tv from CodeAction.hs:187", prepend "tv")
+            , ("rec from CodeAction.hs:232", prepend "rec")
+            , ("this from CodeAction.hs:309", prepend "this")
+            , ("other from CodeAction.hs:310", prepend "other")
+            , ("is- from Kind/Infer.hs:298", prepend "is-")
+            , ("wild from Core/FunLift.hs:235", prepend "wild")
+            ]
+          testRoundTrip label op nameStr = 
+            it (label ++ " with " ++ nameStr) $ do
+              let n1 = readQualifiedName nameStr
+                  n2 = op n1
+                  s = show (prettyName defaultColorScheme n2)
+              name <- testLex s
+              fmap showPlain name `shouldBe` Just (showPlain n2)
+
+      forM_ otherPatterns $ \(label, op) -> do
+        testRoundTrip label op "foo"
+        testRoundTrip label op "Foo"
+
+    describe "isSymbolName preservation" $ do
+      let checkSymbolName op nameStr = 
+            it ("preserves isSymbolName for " ++ nameStr) $ do
+              let n1 = newName nameStr
+              let n2 = op n1
+              isSymbolName n1 `shouldBe` True
+              isSymbolName n2 `shouldBe` True
+              
+              let s = show (prettyName defaultColorScheme n2)
+              let input = BC.pack s
+              let res = lexing (R.Source "test" input) 1 input
+              case res of
+                (Lexeme _ (LexIdOp _) : _) -> return ()
+                _ -> expectationFailure $ "Expected LexIdOp but got " ++ show res
+
+      checkSymbolName (prepend "@lift") "|->"
+      checkSymbolName (postpend "@1") "/"
+      checkSymbolName (prepend "@op-") "+"
+
+    describe "Primed identifier tests" $ do
+      it "classifies t' as a non-symbol name" $ do
+        isSymbolName (newName "t'") `shouldBe` False
+      it "classifies t'' as a non-symbol name" $ do
+        isSymbolName (newName "t''") `shouldBe` False
+      it "classifies r'' as a non-symbol name" $ do
+        isSymbolName (newName "r''") `shouldBe` False
+      it "round-trips primed names through pretty/lex" $ do
+        let n1 = newName "t''"
+            s = show (prettyName defaultColorScheme n1)
+        s `shouldBe` "t''"
+        name <- testLex s
+        fmap showPlain name `shouldBe` Just (showPlain n1)
+
+    describe "Issue 794 regression test" $ do
+      it "handles the specific name from the issue (@mlift-x@10003/)" $ do
+        let n1 = newName "/"
+        let n2 = postpend "@10003" n1
+        let n3 = prepend "@mlift-" n2
+        
+        showPlain n3 `shouldBe` "@mlift-x@10003/"
+        isSymbolName n3 `shouldBe` True
+        show (prettyName defaultColorScheme n3) `shouldBe` "(@mlift-x@10003/)"
+        
+        let s = show (prettyName defaultColorScheme n3)
+        name <- testLex s
+        fmap showPlain name `shouldBe` Just (showPlain n3)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -15,6 +15,7 @@ import Text.JSON
 import Test.Hspec
 import Test.Hspec.Core.Runner
 import Test.Hspec.Core.Formatters hiding (Error)
+import qualified NameSpec
 
 commonFlags :: [String]
 commonFlags = ["-c", "-v0", "--console=raw",
@@ -284,7 +285,9 @@ main = do
   runKoka stdcfg "" "test/lazy/queue/bankers.kk"
   runKoka stdcfg{flags = "--target=js":(flags stdcfg)} "" "util/link-test.kk" -- precompiled js libraries as well
   putStrLn "ok."
-  let spec = (if (target options == "js" || not (par options)) then id else parallel) $
+  let spec = do
+        describe "Unit tests" NameSpec.spec
+        (if (target options == "js" || not (par options)) then id else parallel) $
              discoverTests cfg (pwd </> "test")
   summary <- withArgs [] (runSpec spec hcfg{configFormatter=Just specProgress})
   evaluateSummary summary


### PR DESCRIPTION
@daanx 

This fixes a lot of the .kki format errors, and I've included a test file that covers a lot of the common usages of make unique symbolic names from the code.