### PR TITLE
Fix: use Lit for constructor tags instead of Var in ParcReuseSpec

### DIFF
--- a/src/Backend/C/FromCore.hs
+++ b/src/Backend/C/FromCore.hs
@@ -1938,19 +1938,19 @@ genAppNormal v@(Var allocAt _) [at, Let dgs expr]  | getName allocAt == nameAllo
   = genExpr (Let dgs (App v [at,expr]))
 
 -- special: conAssignFields
-genAppNormal (Var (TName conTagScanFieldsAssign typeAssign) _) (Var reuseName (InfoConField conName conRepr nameNil):(Var tag _):(Var scan _):fieldValues) | conTagScanFieldsAssign == nameConTagScanFieldsAssign
+genAppNormal (Var (TName conTagScanFieldsAssign typeAssign) _) (Var reuseName (InfoConField conName conRepr nameNil):(Lit (LitInt tag)):(Lit (LitInt scan)):fieldValues) | conTagScanFieldsAssign == nameConTagScanFieldsAssign
   = do tmp <- genVarName "con"
-       let setTag  = tmp <.> text "->_base._block.header.tag = (kk_tag_t)" <.> parens (text (show tag)) <.> semi
-           setScan = tmp <.> text "->_base._block.header.scan_fsize = (uint8_t)" <.> parens (text (show scan)) <.> semi
+       let setTag  = tmp <.> text "->_base._block.header.tag = (kk_tag_t)" <.> parens (pretty tag) <.> semi
+           setScan = tmp <.> text "->_base._block.header.scan_fsize = (uint8_t)" <.> parens (pretty scan) <.> semi
            fieldNames = case splitFunScheme typeAssign of
                           Just (_,args,_,_) -> tail (tail (tail (map fst args)))
                           _ -> failure ("Backend.C.FromCore: illegal conAssignFields type: " ++ show (pretty typeAssign))
        (decls, tmpDecl, assigns, result) <- genAssignFields tmp conName conRepr reuseName fieldNames fieldValues
        return (decls ++ [tmpDecl, setScan, setTag] ++ assigns, result)
 
-genAppNormal (Var (TName conTagFieldsAssign typeAssign) _) (Var reuseName (InfoConField conName conRepr nameNil):(Var tag _):fieldValues) | conTagFieldsAssign == nameConTagFieldsAssign
+genAppNormal (Var (TName conTagFieldsAssign typeAssign) _) (Var reuseName (InfoConField conName conRepr nameNil):(Lit (LitInt tag)):fieldValues) | conTagFieldsAssign == nameConTagFieldsAssign
   = do tmp <- genVarName "con"
-       let setTag = tmp <.> text "->_base._block.header.tag = (kk_tag_t)" <.> parens (text (show tag)) <.> semi
+       let setTag = tmp <.> text "->_base._block.header.tag = (kk_tag_t)" <.> parens (pretty tag) <.> semi
            fieldNames = case splitFunScheme typeAssign of
                           Just (_,args,_,_) -> tail (tail (map fst args))
                           _ -> failure ("Backend.C.FromCore: illegal conAssignFields type: " ++ show (pretty typeAssign))

--- a/src/Backend/C/ParcReuseSpec.hs
+++ b/src/Backend/C/ParcReuseSpec.hs
@@ -204,21 +204,21 @@ genConTagScanFieldsAssign :: Type -> TName -> ConRepr -> TName -> Int -> Int -> 
 genConTagScanFieldsAssign resultType conName conRepr reuseName tag scan fieldExprs
   = App (Var (TName nameConTagScanFieldsAssign typeConFieldsAssign) (InfoArity 0 (length fieldExprs + 2)))
         ([Var reuseName (InfoConField conName conRepr nameNil),
-          Var (TName (newName (show tag)) typeUnit) InfoNone,
-          Var (TName (newName (show scan)) typeUnit) InfoNone] ++ map snd fieldExprs)
+          Lit (LitInt (toInteger tag)),
+          Lit (LitInt (toInteger scan))] ++ map snd fieldExprs)
   where
     fieldTypes = [(name,typeOf expr) | (name,expr) <- fieldExprs]
-    typeConFieldsAssign = TFun ([(nameNil,typeOf reuseName), (nameNil, typeUnit), (nameNil, typeUnit)] ++ fieldTypes) typeTotal resultType
+    typeConFieldsAssign = TFun ([(nameNil,typeOf reuseName), (nameNil, typeInt), (nameNil, typeInt)] ++ fieldTypes) typeTotal resultType
 
 -- genConFieldsAssign tp conName reuseName [(field1,expr1)...(fieldN,exprN)]
 -- generates:  c = (conName*)reuseName; c->tag = tag; c->field1 := expr1; ... ; c->fieldN := exprN; (tp*)(c)
 genConTagFieldsAssign :: Type -> TName -> ConRepr -> TName -> Int -> [(Name,Expr)] -> Expr
 genConTagFieldsAssign resultType conName conRepr reuseName tag fieldExprs
   = App (Var (TName nameConTagFieldsAssign typeConFieldsAssign) (InfoArity 0 (length fieldExprs + 1)))
-        ([Var reuseName (InfoConField conName conRepr nameNil), Var (TName (newName (show tag)) typeUnit) InfoNone] ++ map snd fieldExprs)
+        ([Var reuseName (InfoConField conName conRepr nameNil), Lit (LitInt (toInteger tag))] ++ map snd fieldExprs)
   where
     fieldTypes = [(name,typeOf expr) | (name,expr) <- fieldExprs]
-    typeConFieldsAssign = TFun ([(nameNil,typeOf reuseName), (nameNil, typeUnit)] ++ fieldTypes) typeTotal resultType
+    typeConFieldsAssign = TFun ([(nameNil,typeOf reuseName), (nameNil, typeInt)] ++ fieldTypes) typeTotal resultType
 
 -- genConTagFieldsAssign tp conName reuseName [(field1,expr1)...(fieldN,exprN)]
 -- generates:  c = (conName*)reuseName; c->field1 := expr1; ... ; c->fieldN := exprN; (tp*)(c)


### PR DESCRIPTION
In genConTagFieldsAssign and genConTagScanFieldsAssign, constructor tag values and scan counts were represented as Var nodes with names like (1), (2) etc. These leaked into freeLocals as spurious free variables of enclosing lambdas, causing the C backend to generate closure captures for undeclared variables (_lp_1_rp_ in C).

Fix: Use Lit (LitInt n) instead of Var (TName (newName (show n)) typeUnit). Updated FromCore.hs pattern matches to expect Lit instead of Var.