### PR TITLE
fix unifyLabels GT branch closed flags

### DIFF
--- a/src/Type/Unify.hs
+++ b/src/Type/Unify.hs
@@ -430,7 +430,7 @@ unifyLabels ls1 ls2 closed1 closed2
            in case {-compareLabel l1 l2-} labelNameCompare name1 name2 of
             LT ->do (ds1,ds2) <- unifyLabels ll1 ls2 closed1 closed2
                     return (ds1,l1:ds2)
-            GT ->do (ds1,ds2) <- unifyLabels ls1 ll2 closed2 closed2
+            GT ->do (ds1,ds2) <- unifyLabels ls1 ll2 closed1 closed2
                     return (l2:ds1,ds2)
             EQ -> -- labels are equal
                   case (args1,args2) of


### PR DESCRIPTION
## Summary

Fix a typo in `unifyLabels`: the `GT` case passed `closed2` for both boolean arguments instead of `(closed1, closed2)`.

This matches the `LT` branch and the recursive `unifyLabels` call, so each effect row keeps the correct "closed" flag.