### PR TITLE
fix unifyLabels closed flags and Skolem EQ branch

### DIFF
--- a/src/Type/Unify.hs
+++ b/src/Type/Unify.hs
@@ -440,7 +440,7 @@ unifyLabels ls1 ls2 closed1 closed2
                       -> if (id1 < id2)
                            then do (ds1,ds2) <- unifyLabels ll1 ls2 closed1 closed2
                                    return (ds1,l1:ds2)
-                           else do (ds1,ds2) <- unifyLabels ls2 ll2 closed1 closed2
+                           else do (ds1,ds2) <- unifyLabels ls1 ll2 closed1 closed2
                                    return (l2:ds1,ds2)
                     _ ->
                          do -- trace ("unify labels: " ++ show (pretty l1, pretty l2)) $


### PR DESCRIPTION
## Summary

- **GT:** pass `(closed1, closed2)` into the recursive `unifyLabels` call instead of `(closed2, closed2)`.
- **EQ (Skolem scopes):** when `id1 >= id2`, pass `(ls1, ll2)` instead of `(ls2, ll2)` so the case mirrors the `id1 < id2` branch (`ll1` / `ls2`).