### PR TITLE
fix rangeMapFindIn containment filter

### DIFF
--- a/src/Syntax/RangeMap.hs
+++ b/src/Syntax/RangeMap.hs
@@ -247,7 +247,7 @@ rangeMapLookup r (RM rm)
 rangeMapFindIn :: Bool -> Range -> RangeMap -> [(Range, RangeInfo)]
 rangeMapFindIn forInlay rng (RM rm)
   = mergeImplicits forInlay {-for inlay -} $
-    filter (\(rngx, info) -> rangeStart rngx >= start || rangeEnd rngx <= end) rm
+    filter (\(rngx, info) -> rangeStart rngx >= start && rangeEnd rngx <= end) rm
     where start = rangeStart rng
           end = rangeEnd rng
 


### PR DESCRIPTION
## Summary

In `rangeMapFindIn`, the filter used `||`, so a range satisfied the predicate if either edge was inside the query span, which matches far too many entries. Use `&&` so only ranges **fully contained** in the query range are kept (consistent with needing both `rangeStart >= start` and `rangeEnd <= end`).