### PR TITLE
Fix specializer infinite loop and unbounded stderr traces at -O1 and up

### DIFF
--- a/src/Core/Specialize.hs
+++ b/src/Core/Specialize.hs
@@ -14,7 +14,7 @@ import Control.Applicative
 import Control.Monad.State
 import Control.Monad.Reader
 import Control.Arrow ((***))
-import Data.Monoid((<>), Alt(..), Endo(..))
+import Data.Monoid((<>), Alt(..), Any(..), Endo(..))
 import Data.Maybe (mapMaybe, fromMaybe, catMaybes, isJust, fromJust)
 import Data.Function
 
@@ -148,11 +148,11 @@ specOneCall inlineDef@(InlineDef{ inlineName=specName, inlineExpr=specExpr, inli
       App (Var (TName name _) _) args
        | gArgs <- goodArgs specArgs args
        , any isJust gArgs
-        -> replaceCall specName specExpr sort specArgs (newArgs gArgs args) Nothing
+        -> fromMaybe e <$> replaceCall specName specExpr sort specArgs (newArgs gArgs args) Nothing
       App (TypeApp (Var (TName name ty) _) typeArgs) args
        | gArgs <- goodArgs specArgs args
        , any isJust gArgs
-        -> replaceCall specName specExpr sort specArgs (newArgs gArgs args) $ Just typeArgs
+        -> fromMaybe e <$> replaceCall specName specExpr sort specArgs (newArgs gArgs args) (Just typeArgs)
       _ -> return e
 
   where newArgs gArgs args = zipWith fromMaybe args gArgs
@@ -240,8 +240,7 @@ specInnerCalls from to isSpecParam specParamNames expr
         all eqVar (zip specParamNames args)
 
     eqVar (name,Var v _)  = name == v
-    eqVar (name,arg)      = trace ("specialize: specInnerCalls: argument does not match: " ++ show name ++ " as " ++ show arg) $
-                            False
+    eqVar (name,arg)      = False  -- the recursive call does not pass the specialized parameter unchanged; leave it (and decline to specialize in replaceCall)
 
     sicAppTo args
       = App varTo (map sicExpr (filterBools (map not isSpecParam) args))
@@ -301,7 +300,8 @@ comment = unlines . map ("// " ++) . lines
 -- 3. Only then, replace the recursive calls to f in the body (specInnerCalls)
 -- The important thing is that we don't try to get the type of the body at the same time as replacing the recursive calls
 -- since the type of the body depends on the type of the functions that it calls and vice versa
-replaceCall :: Name -> Expr -> DefSort -> [Bool] -> [Expr] -> Maybe [Type] -> SpecM Expr
+-- returns Nothing if the call should not be specialized after all
+replaceCall :: Name -> Expr -> DefSort -> [Bool] -> [Expr] -> Maybe [Type] -> SpecM (Maybe Expr)
 replaceCall name expr0 sort bools args mybeTypeArgs
   = do
       expr <- uniquefyExprU expr0
@@ -328,23 +328,49 @@ replaceCall name expr0 sort bools args mybeTypeArgs
       specName <- uniqueName "spec"
       let specType  = typeOf specBody0
           specTName = TName specName specType
-          specBody  = case specBody0 of
+          (specBody,specInnerBody)
+                    = case specBody0 of
                         Lam args eff (Let specArgs body)
                           -> -- uniquefyExpr $
-                             Lam args eff $
-                               (Let specArgs $
-                                specInnerCalls (TName name (typeOf expr)) specTName bools speccedParams body)
+                             let sbody = specInnerCalls (TName name (typeOf expr)) specTName bools speccedParams body
+                             in (Lam args eff (Let specArgs sbody), sbody)
                         _ -> failure "Specialize.replaceCall: Unexpected output from specialize pass"
 
-      -- simplify so the new specialized arguments are potentially inlined unlocking potential further specialization
-      sspecBody <- uniqueSimplify defaultEnv False False 1 10 specBody
-      -- trace ("\n// ----start--------\n// specializing " <> show name <> " to parameters " <> show speccedParams <> " with args " <> comment (show speccedArgs) <> "\n// specTName: " <> show (getName specTName) <> ", specBody0: \n" <> show specBody <> "\n\n, sspecBody: \n" <> show sspecBody <> "\n// ---- start recurse---") $ return ()
+      -- A recursive call to the original definition that could not be rewritten to call the
+      -- specialized definition (specInnerCalls requires that the specialized parameters are
+      -- passed along unchanged, which is guaranteed for definitions validated by
+      -- makeSpecialize, but not for the ones added by multiStepInlines) remains as a call to
+      -- the original in the specialized body. That is fine as long as that residual call is
+      -- not specializable itself: but if it has a 'good' argument in a specializable position
+      -- (e.g. `fexec-loop( fset(e,...), ...)` where the total `fset` stays applied under an
+      -- `@open` instead of being beta-reduced), then specOneExpr -- a top-down rewrite that
+      -- descends into the result -- would specialize that residual call again, recreating the
+      -- same residual call from the same inline definition inside yet another specialized
+      -- definition, and so on forever while the core keeps growing. Decline to specialize
+      -- such calls. Residual calls that only become specializable after simplification (e.g.
+      -- a specialized argument that itself calls the original, as in specializing `repeatN`
+      -- on `fn() repeatN(10,f)`) are fine: those arguments come from the call site and shrink
+      -- with every specialization step, so that recursion terminates.
+      let hasSpecializableResidual body = getAny $ flip foldMapExpr body $ \e ->
+            case e of
+              App (Var (TName n _) _) rargs
+                | n == name -> Any (any isJust (goodArgs bools rargs))
+              App (TypeApp (Var (TName n _) _) _) rargs
+                | n == name -> Any (any isJust (goodArgs bools rargs))
+              _             -> mempty
 
-      let specDef = Def specName specType sspecBody Private sort InlineAuto rangeNull
-                     $ "// specialized: " <> show name <> ", on parameters " <> concat (intersperse ", " (map show speccedParams)) <> ", using:\n" <>
-                       comment (unlines [show param <> " = " <> show arg | (param,arg) <- zip speccedParams speccedArgs])
+      if hasSpecializableResidual specInnerBody
+        then return Nothing
+        else do
+          -- simplify so the new specialized arguments are potentially inlined unlocking potential further specialization
+          sspecBody <- uniqueSimplify defaultEnv False False 1 10 specBody
+          -- trace ("\n// ----start--------\n// specializing " <> show name <> " to parameters " <> show speccedParams <> " with args " <> comment (show speccedArgs) <> "\n// specTName: " <> show (getName specTName) <> ", specBody0: \n" <> show specBody <> "\n\n, sspecBody: \n" <> show sspecBody <> "\n// ---- start recurse---") $ return ()
 
-      return $ Let [DefRec [specDef]] (App (Var (defTName specDef) InfoNone) newArgs)
+          let specDef = Def specName specType sspecBody Private sort InlineAuto rangeNull
+                         $ "// specialized: " <> show name <> ", on parameters " <> concat (intersperse ", " (map show speccedParams)) <> ", using:\n" <>
+                           comment (unlines [show param <> " = " <> show arg | (param,arg) <- zip speccedParams speccedArgs])
+
+          return $ Just $ Let [DefRec [specDef]] (App (Var (defTName specDef) InfoNone) newArgs)
 
 fnTypeParams :: Expr -> [TypeVar]
 fnTypeParams (TypeLam typeParams _) = typeParams

--- a/test/cgen/specialize/recursive-arg.kk
+++ b/test/cgen/specialize/recursive-arg.kk
@@ -1,0 +1,62 @@
+// A function that is multi-step specializable (fexec-loop calls feval which is
+// specializable on `e` through the lambda passed to `map`) but whose recursive
+// call does not pass the specialized parameter `e` along unchanged (it passes
+// `fset(e,...)`, which stays a "good" argument because the total `fset` is
+// `@open`-ed into the caller's effect row instead of being beta-reduced).
+// The specializer used to loop forever on this at -O1 and up, printing
+// "specInnerCalls: argument does not match" with a core dump to stderr each
+// round (issue: specializer loops / unbounded specInnerCalls traces).
+// Now the specializer declines to specialize such calls.
+
+effect viol-flag
+  fun mark-viol(knd: string): ()
+
+type rv
+  RInt(n: int)
+  RArr(elems: list<rv>)
+
+alias fenv = list<(string, rv)>
+
+type fexpr
+  FLit(n: int)
+  FVar(name: string)
+  FArr(elems: list<fexpr>)
+
+fun fget(e: fenv, key: string): rv
+  match e.filter(fn(p) p.fst == key)
+    Cons((_, v), _) -> v
+    Nil -> RInt(0)
+
+fun fset(e: fenv, key: string, v: rv): fenv
+  Cons((key, v), e.filter(fn(p) p.fst != key))
+
+fun as-int(v: rv): exn int
+  match v
+    RInt(n) -> n
+    _ -> throw("int expected")
+
+fun feval(e: fenv, ex: fexpr): <div,exn,viol-flag> rv
+  match ex
+    FLit(n) ->
+      if n == 0 then mark-viol("zero")
+      RInt(n)
+    FVar(x) -> fget(e, x)
+    FArr(elems) -> RArr(elems.map(fn(el) feval(e, el)))
+
+fun fexec-loop(e: fenv, c: string, body: fexpr): <div,exn,viol-flag> rv
+  if fget(e, c).as-int == 0 then feval(e, body)
+  else fexec-loop(fset(e, c, RInt(fget(e, c).as-int - 1)), c, body)
+
+fun fexec(e: fenv, c: string, b: int, body: fexpr): <div,exn,viol-flag> rv
+  fexec-loop(fset(e, c, RInt(b)), c, body)
+
+fun run-program(body: fexpr): <div,exn> rv
+  var first := ""
+  with fun mark-viol(knd)
+    if first == "" then first := knd
+  fexec([], "c", 3, body)
+
+pub fun main()
+  match run-program(FArr([FLit(1), FVar("c")]))
+    RArr(Cons(v, _)) -> println(v.as-int)
+    _ -> println("unexpected")

--- a/test/cgen/specialize/recursive-arg.kk.out
+++ b/test/cgen/specialize/recursive-arg.kk.out
@@ -1,0 +1,54 @@
+1
+ 
+cgen/specialize/recursive-arg/mark-viol/@select: forall<e,a> (hnd : viol-flag<e,a>) -> clause1<string,(),viol-flag,e,a>
+cgen/specialize/recursive-arg/viol-flag/@cfc: forall<e,a> (viol-flag<e,a>) -> int
+cgen/specialize/recursive-arg/viol-flag/@fun-mark-viol: forall<e,a> (viol-flag<e,a>) -> clause1<string,(),viol-flag,e,a>
+cgen/specialize/recursive-arg/viol-flag/@handle: forall<a,e,b> (hnd : viol-flag<e,b>, ret : (res : a) -> e b, action : () -> <viol-flag|e> a) -> e b
+cgen/specialize/recursive-arg/viol-flag/@tag: htag<viol-flag>
+cgen/specialize/recursive-arg/@Hnd-viol-flag: forall<e,a> (int, clause1<string,(),viol-flag,e,a>) -> viol-flag<e,a>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (e : fenv, list<fexpr>) -> <div,exn,viol-flag> list<rv>
+cgen/specialize/recursive-arg/@lift-xxx: (e : fenv, list<fexpr>) -> <div,exn,viol-flag> list<rv>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key@xxx : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key@xxx : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key@xxx : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key@xxx : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@lift-xxx: (key : string, list<(string, rv)>) -> list<(string, rv)>
+cgen/specialize/recursive-arg/@mlift-xxx: (n : int, ()) -> rv
+cgen/specialize/recursive-arg/@mlift-xxx: (list<rv>) -> <div,exn,viol-flag> rv
+cgen/specialize/recursive-arg/@mlift-xxx: (body : fexpr, c : string, e : fenv, int) -> <exn,div,viol-flag> rv
+cgen/specialize/recursive-arg/@mlift-xxx: (body : fexpr, c : string, e : fenv, int) -> <exn,div,viol-flag> rv
+cgen/specialize/recursive-arg/@mlift-xxx: (rv, list<rv>) -> <div,exn,viol-flag> list<rv>
+cgen/specialize/recursive-arg/@mlift-xxx: (list<fexpr>, e : fenv, rv) -> <pure,viol-flag> list<rv>
+cgen/specialize/recursive-arg/@mlift-xxx: (int) -> ()
+cgen/specialize/recursive-arg/@mlift-xxx: (rv) -> pure ()
+cgen/specialize/recursive-arg/@mlift-xxx: forall<h> (first : local-var<h,string>, knd : string, string) -> <local<h>,div,exn> ()
+cgen/specialize/recursive-arg/FArr: (elems : list<fexpr>) -> fexpr
+cgen/specialize/recursive-arg/FLit: (n : int) -> fexpr
+cgen/specialize/recursive-arg/FVar: (name : string) -> fexpr
+cgen/specialize/recursive-arg/RArr: (elems : list<rv>) -> rv
+cgen/specialize/recursive-arg/RInt: (n : int) -> rv
+cgen/specialize/recursive-arg/as-int: (v : rv) -> exn int
+cgen/specialize/recursive-arg/feval: (e : fenv, ex : fexpr) -> <pure,viol-flag> rv
+cgen/specialize/recursive-arg/fexec: (e : fenv, c : string, b : int, body : fexpr) -> <pure,viol-flag> rv
+cgen/specialize/recursive-arg/fexec-loop: (e : fenv, c : string, body : fexpr) -> <pure,viol-flag> rv
+cgen/specialize/recursive-arg/fget: (e : fenv, key : string) -> rv
+cgen/specialize/recursive-arg/fset: (e : fenv, key : string, v : rv) -> fenv
+cgen/specialize/recursive-arg/is-farr: (fexpr : fexpr) -> bool
+cgen/specialize/recursive-arg/is-flit: (fexpr : fexpr) -> bool
+cgen/specialize/recursive-arg/is-fvar: (fexpr : fexpr) -> bool
+cgen/specialize/recursive-arg/is-rarr: (rv : rv) -> bool
+cgen/specialize/recursive-arg/is-rint: (rv : rv) -> bool
+cgen/specialize/recursive-arg/main: () -> <pure,console> ()
+cgen/specialize/recursive-arg/mark-viol: (knd : string) -> viol-flag ()
+cgen/specialize/recursive-arg/run-program: (body : fexpr) -> pure rv


### PR DESCRIPTION
## Summary

At `-O1` and higher, the specializer can go into an **infinite loop**, printing a
`specialize: specInnerCalls: argument does not match` trace followed by a full
pretty-printed core term to stderr on **every** round. On the original ~900-line module
this produced 215MB of stderr in ~20 minutes before we killed the compiler. Reproduces
with the v3.2.2 and v3.2.3 release binaries; the same file compiles in seconds at the
default optimization level or with `--fno-specialize`.

This PR fixes the loop, silences the stray debug trace, and adds a minimized regression
test (`test/cgen/specialize/recursive-arg.kk`, 55 lines) that hangs koka 3.2.3 at `-O1`
within seconds.

## Root cause

Two things in `src/Core/Specialize.hs` combine into the loop:

1. **Unvalidated multi-step specialization candidates.** `makeSpecialize` only marks a
   function specializable on a parameter if *every* self-recursive call passes that
   parameter along unchanged (`allPassedInSameOrder`), and only for singleton recursive
   groups. `multiStepInlines`, however, marks any function that merely *calls* a
   specializable function with one of its own parameters in a specializable argument
   position — without validating its own recursive calls, and including members of
   mutual recursion groups. In the reproducer, `fexec-loop` (part of a mutually
   recursive interpreter group) becomes "specializable" on its environment parameter
   `e` this way, even though its self-call passes `fset(e2, c, ...)` rather than `e`.

2. **The top-down rewrite descends into its own output.** When a call to such a
   function is specialized, `specInnerCalls` cannot rewrite the non-conforming
   self-call (this is exactly the *argument does not match* trace), so the specialized
   body retains a call to the **original** function. Crucially, that residual call's
   argument `fset(e2, c, RInt(...))` is itself a "good" argument per `goodArg`: the
   total `fset` stays an *application* because it is `@open`-ed into the caller's
   `<exn,div,viol-flag>` effect row instead of being beta-reduced (which is why a user
   effect in the row is needed to trigger this, and why `-O0` is fine).
   `specOneExpr` (`rewriteTopDownM`) then descends into the freshly created
   specialized definition, finds the residual call, and specializes it again —
   instantiating the same pristine inline body with the same kind of residual call one
   level deeper, forever, with one trace + core dump per round.

## Fix

In `replaceCall`, after rewriting the inner recursive calls, **decline to specialize**
the call site (leave the call expression unchanged) if the rewritten body still
contains a call to the original definition with a good argument in a specializable
position. Such a residual call would provably be specialized again by the top-down
rewrite, recreating itself indefinitely.

This is deliberately the narrowest condition that kills the loop; existing behavior is
preserved:

- *Intentional partial specialization* still works: a residual call whose arguments
  are not specializable is fine (see `test/cgen/specialize/branch.kk`, where the
  swapped `map_other(g, f)` self-call intentionally keeps calling the original).
- *Nested specialization through arguments* still works: a self-call inside the
  **let-bound specialized argument** (e.g. specializing `repeatN` on
  `fn() repeatN(10, f)` in `test/cgen/specialize/twostep-large2.kk`) shrinks with
  every step and terminates, so it is not flagged (only the rewritten body is checked,
  before simplification).

Additionally, the unconditional `trace` in `specInnerCalls.eqVar` is removed: it was
debug output that escaped into release builds and is what turned a non-terminating
compile into hundreds of MB of stderr. A non-rewritable recursive call now degrades
silently (and, with the fix above, can no longer cause runaway re-specialization).

## Verification

- The new `test/cgen/specialize/recursive-arg.kk` hangs an unpatched compiler at `-O1`
  (>30s timeout, MBs of stderr) and compiles in ~2s with this fix; its runtime output
  is identical at `-O0`/`-O1`/`-O2`.
- The original ~1000-line reproducer now compiles at `-O1`/`-O2`/`-O3` with **zero**
  stderr output, and its program output is byte-identical to the `-O0` build.
- `cabal test koka-test`: all `cgen/specialize` tests pass unchanged (including
  `branch`, `maptwice`, `twostep-large2`, which exercise the boundary cases above).
  The only failing tests in my environment (5 `jsgen` tests, `lib/slice`) fail
  identically on an unpatched build (missing node / pcre2-8 in the container).
- Specialization still fires on normal code (e.g. `xs.map(f).foldl(0,(+))` still
  produces the expected specialized definitions in `--showcore` output).

## Provenance

Found while building a fuzzing oracle (a random-program generator with an embedded
interpreter) at https://github.com/PatrikHagglund/pl0e (`src/efuzz.koka`); the
distinctive trigger is a mutually recursive evaluator group over an effect row
containing a small user effect, threading an environment through a total
`fset`-style helper. Workaround until this lands: `--fno-specialize`.
