### PR TITLE
fix CSS bugs and improve responsive layout in spec documentation

### DIFF
--- a/doc/koka.css
+++ b/doc/koka.css
@@ -171,7 +171,8 @@ pre.koka.source {
 }
 
 .madoko pre.koka.source {
-  overflow: visible; /* so tooltips .pc always show */
+  overflow-x: auto;
+  overflow-y: visible; /* so tooltips .pc always show */
 }
 
 .koka.doc .comment p {

--- a/doc/koka.css
+++ b/doc/koka.css
@@ -37,7 +37,7 @@ pre.koka, code.koka, .koka.doc .header {
   }
 }
 
-@media screen and (max-device-width: 1022px) {
+@media screen and (width <= 1022px) {
   body.madoko,body.koka {
     max-width: 100%;
     padding: 0em 0.5em 40em 0.5em;
@@ -45,7 +45,7 @@ pre.koka, code.koka, .koka.doc .header {
   }
 }
 
-@media screen and (min-device-width: 2048px) {
+@media screen and (width >= 2048px) {
   html {
     font-size:120%;
   }
@@ -58,13 +58,15 @@ pre.koka, code.koka, .koka.doc .header {
     margin: 0pt;
   }
   h2,h3,h4 {
-    page-break-after: avoid;
+    break-after: avoid;
   }
   p {
     text-align: justify;
   }
-  @page:left  { margin: 8% 5% 8% 5%; }
-  @page:right { margin: 8% 5% 8% 5%; }
+
+  @page :left  { margin: 8% 5%; }
+
+  @page :right { margin: 8% 5%; }
 }
 /* p,li,div.koka.doc.comment { text-align: justify;} */
 
@@ -134,7 +136,8 @@ pre code code, .madoko pre code code {
 }
 
 .koka .dash {
-  margin-left: -0.05ex; margin-right: -0.05ex
+  margin-left: -0.05ex;
+  margin-right: -0.05ex;
 }
 
 .koka .minus {
@@ -149,7 +152,7 @@ pre code code, .madoko pre code code {
 }
 
 .koka .postfix {
-  color: gray
+  color: gray;
 }
 
 
@@ -183,7 +186,7 @@ pre.koka.source {
 }
 
 .koka.source a:hover,
-.koka.code a:hover, code.koka a:hover
+.koka.code a:hover, code.koka a:hover,
 .koka.pre a:hover, pre.koka a:hover {
   text-decoration: none
 }

--- a/doc/spec/install.mdk
+++ b/doc/spec/install.mdk
@@ -75,9 +75,9 @@ types, fully qualified names, and implicit arguments.
 ~ end flexrow
 
 
-[vscode-caesar]: images/vscode-caesar.png "VS Code caesar examples" { width:60%; min-width:400px; }
-[vscode-inlay-off]: images/vscode-inlay-off.png "VS Code example without inlay hints" { height:4em; min-width:200px; }
-[vscode-inlay-on]:  images/vscode-inlay-on.png "VS Code example with inlay hints on" { height:4em; min-width:200px; }
+[vscode-caesar]: images/vscode-caesar.png "VS Code caesar examples" { width:60%; max-width:100%; }
+[vscode-inlay-off]: images/vscode-inlay-off.png "VS Code example without inlay hints" { max-height:4em; min-width:200px; max-width:100%; }
+[vscode-inlay-on]:  images/vscode-inlay-on.png "VS Code example with inlay hints on" { max-height:4em; min-width:200px; max-width:100%; }
 
 
 ### Manual Installation

--- a/doc/spec/styles/book.css
+++ b/doc/spec/styles/book.css
@@ -69,6 +69,9 @@ code, .madoko code {
 
 .grammar table,
 table.grammar  {
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
   margin: 0.5ex 0.5ex 0.5ex 2ex;
   padding: 0.5ex 1ex 0.5ex 1ex;
 }
@@ -368,4 +371,26 @@ html {
   float:right;
   clear:both;
   margin:0em 0em 1em 2em;
+}
+
+@media screen and (700px < width < 1024px) {
+  .maincontent {
+    max-width: 60em;
+    margin: 0 auto;
+  }
+}
+
+@media screen and (width <= 700px) {
+  .floatright {
+    float: none;
+    width: 100%;
+    min-width: 0;
+    margin: 0 0 1em 0;
+  }
+
+  img {
+    max-width: 100% !important;
+    width: auto !important;
+    height: auto !important;
+  }
 }

--- a/doc/spec/styles/book.css
+++ b/doc/spec/styles/book.css
@@ -380,6 +380,11 @@ html {
   }
 }
 
+.sidepanel .toc .tocblock {
+  white-space: normal;
+  overflow-wrap: break-word;
+}
+
 @media screen and (width <= 700px) {
   .floatright {
     float: none;

--- a/doc/spec/styles/book.css
+++ b/doc/spec/styles/book.css
@@ -388,6 +388,11 @@ html {
     margin: 0 0 1em 0;
   }
 
+  .banners .banner {
+    width: 100%;
+    min-width: 0;
+  }
+
   img {
     max-width: 100% !important;
     width: auto !important;


### PR DESCRIPTION
Hi! I'm a first-time contributor and noticed some layout issues in the Koka spec documentation while reading through it, so I put together fixes in a single PR. Happy to adjust anything if the approach isn't quite right!

## overview 

The first is a set of CSS bugs in `doc/koka.css`: a missing comma in a hover selector that silently dropped styles for `pre.koka` elements, missing trailing semicolons, an incorrect `@page:left`/`@page:right` syntax (should be `@page :left`), and the use of deprecated properties `page-break-after` and `device-width`. It also splits `overflow: visible` on `.madoko pre.koka.source` into `overflow-x: auto` and `overflow-y: visible`, so that code blocks can scroll horizontally while keeping type-popup tooltips (`.pc`) unclipped.

The second is a set of responsive layout fixes in `doc/spec/styles/book.css` and `doc/spec/install.mdk`. On narrow viewports, BNF grammar tables in the language spec were pushing the page wider rather than scrolling — fixed with `display: block; overflow-x: auto`. The "Why Koka?" feature banners were narrower than the surrounding text due to a `min-width` constraint winning over the flex width calculation. The VS Code install screenshot (`floatright`) left almost no room for text on small screens. Image inline styles were also causing images to appear too small or with distorted aspect ratios on mobile, addressed by resetting `width`/`height` via a media query. On tablet-width windows (700px–1024px), Madoko's generated CSS does not apply a content-width cap, so percentage-sized images appeared larger than on desktop — matched by adding the same `max-width: 60em` constraint. Finally, long sidebar TOC entries such as "3.3.6. Inductive, Co-inductive, and Recursive Types" were not wrapping, making the sidebar horizontally scrollable; overriding Madoko's `white-space: nowrap` with a higher-specificity selector enables wrapping.

## Screenshots (before fix)

### Page-level horizontal scroll caused by code block overflow

<img width="1458" height="1132" alt="sidebar-code-overflow" src="https://github.com/user-attachments/assets/43f08fcd-18c5-452b-9064-5865332c0134" />

`overflow: visible` on `.madoko pre.koka.source` allows long code blocks to push the page wider than the viewport, enabling page-level horizontal scrolling. Because the sidebar is `position: fixed`, scrolling shifts only the main content — causing it to slide behind the sidebar and become partially hidden.

<img width="940" height="1058" alt="code-block-overflow" src="https://github.com/user-attachments/assets/1af499d1-c3ef-4e14-ae37-03061a4bc87d" />

A closer view: translation tables and long lines extend to the right with no scrollbar on the code block itself, relying on page-level scroll instead.

### BNF grammar table overflow

<img width="940" height="1058" alt="bnf-table-overflow" src="https://github.com/user-attachments/assets/b5f96735-b508-485e-bfbe-e32c770e1148" />

BNF grammar tables in section 4.2 (Lexical grammar) lacked `display: block; overflow-x: auto`, so they pushed the entire page wider rather than scrolling within the table container.

### VS Code install section — image aspect ratio

<img width="940" height="1058" alt="install-vscode-images" src="https://github.com/user-attachments/assets/f96b8de1-442b-45dd-af54-c80669f2d118" />

`vscode-inlay-on/off` had `height: 4em` fixed while `max-width: 100%` constrained the width on narrow screens, causing aspect ratio distortion. `vscode-caesar` had `min-width: 400px` which, per CSS spec, wins over `max-width: 100%`, making the max-width constraint ineffective on narrow screens.

### Sidebar TOC overflow

<img width="1458" height="1132" alt="sidebar-toc-overflow" src="https://github.com/user-attachments/assets/3c553260-eacb-4291-8bf3-cd59c1eaa050" />

Madoko generates `white-space: nowrap` on `.sidepanel .tocblock`, preventing long TOC entries from wrapping. As shown, titles such as "3.3.6. Inductive, Co-inductive, and Recursive Types" are cut off at the sidebar edge instead of wrapping to a second line, and the sidebar becomes horizontally scrollable as a result.

### Why Koka banners on narrow viewport

<img width="1458" height="1132" alt="why-koka-banners-sp" src="https://github.com/user-attachments/assets/dee5d7a5-e5ff-432e-a27e-3b27ede031c0" />

`.banners .banner` uses `min-width: 20em` (≈320px) for a two-column flex layout. On narrow viewports (~375px), this min-width wins over the calculated `calc(50% - 1.5em)` (≈164px), leaving each banner narrower than the viewport and visibly narrower than the surrounding paragraph text.

