### PR TITLE
kind inference: report a kind error for wrong-kinded type alias arguments

### DIFF
--- a/src/Kind/Infer.hs
+++ b/src/Kind/Infer.hs
@@ -1742,7 +1742,13 @@ resolveApp idmap partialSyn (TpCon name r,args) rng
                             addError rng (text "Type alias" <+> color (colorType cs) (pretty name) <+> text "has too many arguments")
                     else return ()
                   args' <- mapM (resolveType idmap True) args    -- partially applied synonyms are allowed in synonym applications
-                  let tsyn = (TSyn (TypeSyn name kind rank (Just syn)) args' (subNew (zip params args') |-> tp))
+                  let checkSynArg (param,arg')  -- report wrong-kinded arguments and keep the expansion substitution well-kinded
+                        = if getKind param == getKind arg' then return arg'
+                          else do cs <- getColorScheme
+                                  kindError cs (Infer rng) rng NoMatch (KICon (getKind param)) (KICon (getKind arg'))
+                                  return (TVar param)
+                  subArgs <- mapM checkSynArg (zip params args')
+                  let tsyn = (TSyn (TypeSyn name kind rank (Just syn)) args' (subNew (zip params subArgs) |-> tp))
                   -- trace ("resolved type syn: " ++ show (pretty syn)) $
                   return tsyn
                   -- NOTE: on partially applied type synonyms, we get a funky body type with free parameters but this

--- a/src/Kind/Unify.hs
+++ b/src/Kind/Unify.hs
@@ -8,7 +8,7 @@
 {--}
 -----------------------------------------------------------------------------
 
-module Kind.Unify( Context(..), unify, mgu, match ) where
+module Kind.Unify( Context(..), Unify(..), unify, kindError, mgu, match ) where
 
 import Lib.PPrint
 import Common.Range

--- a/test/kind/wrong/alias-effect-row.kk
+++ b/test/kind/wrong/alias-effect-row.kk
@@ -1,0 +1,6 @@
+type myeff :: X
+
+alias property<e> = () -> e bool
+
+fun check(prop : property<myeff>) : ()
+  ()

--- a/test/kind/wrong/alias-effect-row.kk.out
+++ b/test/kind/wrong/alias-effect-row.kk.out
@@ -1,0 +1,10 @@
+test/kind/wrong/alias-effect-row@kk(5,27): kind error: Invalid type
+ type context : property<myeff>
+ type : myeff
+ inferred kind: X
+ expected kind: E
+test/kind/wrong/alias-effect-row@kk(5,18): kind error: Invalid type
+ type context : property<myeff>
+ type : property<myeff>
+ inferred kind: X
+ expected kind: E

--- a/test/kind/wrong/alias-effect-row2.kk
+++ b/test/kind/wrong/alias-effect-row2.kk
@@ -1,0 +1,12 @@
+// issue #598: alias with effect parameter applied to a single effect label
+// crashed with Type.TypeVar.subNew.KindMismatch instead of a kind error
+effect yield<a>
+  ctl yield(elem : a) : ()
+
+alias stream<a,e> = () -> <yield<a>|e> ()
+
+fun repeat(value : a) : stream<a,div>
+  fun rec()
+    yield(value)
+    rec()
+  rec

--- a/test/kind/wrong/alias-effect-row2.kk.out
+++ b/test/kind/wrong/alias-effect-row2.kk.out
@@ -1,0 +1,10 @@
+test/kind/wrong/alias-effect-row2@kk(8,34): kind error: Invalid type
+ type context : stream<a,div>
+ type : div
+ inferred kind: X
+ expected kind: E
+test/kind/wrong/alias-effect-row2@kk(8,25): kind error: Invalid type
+ type context : stream<a,div>
+ type : stream<a,div>
+ inferred kind: X
+ expected kind: E


### PR DESCRIPTION
  
  The snippet below previously produced an internal error (I believe the same one in https://github.com/koka-lang/koka/issues/598):
  
  ```koka
  type myeff :: X
  
  alias property<e> = () -> e bool
  
  fun check(prop : property<myeff>) : ()
    ()
  ```
  
Applying a type alias to an argument of the wrong kind (e.g.
`alias property<e> = () -> e bool` used as `property<console>` where
`e :: E` but `console :: X`, or issue #598's `stream<a,div>`) crashed
the compiler with an internal assertion (Type.TypeVar.subNew.KindMismatch)
instead of reporting an error, since resolveApp substituted alias
arguments without checking their kinds.

Check each parameter/argument pair: on a kind mismatch, report a
standard kind error (via kindError, now exported from Kind.Unify) and
substitute the parameter for itself to keep the expansion substitution
well-kinded.