### PR TITLE
Explicitly include <sys/wait.h> for WIFEXITED, etc. (fixes OpenBSD build)

### DIFF
--- a/kklib/src/os.c
+++ b/kklib/src/os.c
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <fcntl.h>
 #endif


### PR DESCRIPTION
Commit [`d5b946`](https://github.com/koka-lang/koka/commit/d5b946ecce68f3ce102d4eeac8f75d29771733ab) broke `kklib` on OpenBSD. [According to POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html), `WIFEXITED` and other macros are provided by `<sys/wait.h>`, I think it doesn't hurt to include it on every POSIX-y platform.