### PR TITLE
std/async: OS threads with thread-safe channels, and cross-thread refcount fixes

### DIFF
--- a/kklib/include/kklib.h
+++ b/kklib/include/kklib.h
@@ -962,6 +962,9 @@ static inline void kk_reuse_drop(kk_reuse_t r, kk_context_t* ctx) {
 kk_decl_export void        kk_block_mark_shared(kk_block_t* b, kk_context_t* ctx);
 kk_decl_export void        kk_box_mark_shared(kk_box_t b, kk_context_t* ctx);
 kk_decl_export void        kk_box_mark_shared_recx(kk_box_t b, kk_context_t* ctx);
+kk_decl_export void        kk_block_make_stuck(kk_block_t* b);  // refcount becomes stuck: dup/drop no-ops, never freed (for process-lifetime globals)
+kk_decl_export void        kk_block_mark_static(kk_block_t* b, kk_context_t* ctx);  // mark a reachable graph stuck (toplevel constants)
+kk_decl_export void        kk_box_mark_static(kk_box_t b, kk_context_t* ctx);
 
 
 /*--------------------------------------------------------------------------------------

--- a/kklib/include/kklib/box.h
+++ b/kklib/include/kklib/box.h
@@ -256,6 +256,17 @@ static inline kk_box_t kk_int8_box(int8_t i, kk_context_t* ctx) {
   return kk_intf_box(i);
 }
 
+static inline uint8_t kk_uint8_unbox(kk_box_t v, kk_context_t* ctx) {
+  kk_unused(ctx);
+  kk_intf_t i = kk_intf_unbox(v);
+  kk_assert_internal((i >= 0 && i <= UINT8_MAX) || kk_box_is_any(v));
+  return (uint8_t)(i);
+}
+static inline kk_box_t kk_uint8_box(uint8_t i, kk_context_t* ctx) {
+  kk_unused(ctx);
+  return kk_intf_box(i);
+}
+
 #if (KK_INTF_SIZE == 8) && KK_BOX_DOUBLE64
 kk_decl_export kk_box_t kk_double_box(double d, kk_context_t* ctx);
 kk_decl_export double   kk_double_unbox(kk_box_t b, kk_borrow_t borrow, kk_context_t* ctx);

--- a/kklib/include/kklib/string.h
+++ b/kklib/include/kklib/string.h
@@ -131,8 +131,11 @@ static inline kk_string_t kk_string_empty() {
   static const char* _static_##name = chars; \
   decl kk_string_t name = { { kk_datatype_null_init } };
 
+// One-time thread-safe initialization (function-local literals can be first used by
+// two threads concurrently); the literal's refcount is made STUCK so cross-thread
+// dup/drop of the shared static is a no-op (see `kk_string_literal_init`).
 #define kk_init_string_literal(name,ctx) \
-  if (kk_datatype_is_null(name.bytes)) { name = kk_string_alloc_from_utf8n(_static_len_##name, _static_##name, ctx); }
+  if (kk_datatype_is_null(name.bytes)) { kk_string_literal_init(&name, _static_len_##name, _static_##name, ctx); }
 
 #define kk_define_string_literal(decl,name,len,chars,ctx) \
   kk_declare_string_literal(decl,name,len,chars); \
@@ -464,6 +467,7 @@ static inline bool   kk_string_contains(kk_string_t str, kk_string_t sub, kk_con
   Utilities that are string specific
 --------------------------------------------------------------------------------------------------*/
 
+kk_decl_export void kk_string_literal_init(kk_string_t* p, kk_ssize_t len, const char* chars, kk_context_t* ctx);  // one-time thread-safe literal init (stuck refcount)
 kk_decl_export kk_ssize_t kk_decl_pure kk_string_count_borrow(kk_string_t str, kk_context_t* ctx);  // number of code points
 kk_decl_export kk_ssize_t kk_decl_pure kk_string_count(kk_string_t str, kk_context_t* ctx);  // number of code points
 kk_decl_export kk_ssize_t kk_decl_pure kk_string_count_pattern_borrow(kk_string_t str, kk_string_t pattern, kk_context_t* ctx);

--- a/kklib/src/init.c
+++ b/kklib/src/init.c
@@ -276,12 +276,16 @@ struct kk_evv_s {
 };
 
 kk_datatype_ptr_t kk_evv_empty_singleton(kk_context_t* ctx) {
-  static struct kk_evv_s* evv = NULL;
-  if (evv == NULL) {
-    evv = kk_block_alloc_as(struct kk_evv_s, 0, KK_TAG_EVV_VECTOR, ctx);
-    // evv->cfc = kk_integer_from_small(-1);
-  }
-  kk_base_type_dup_as(struct kk_evv_s*, evv);
+  // Use the STATICALLY-allocated empty evidence vector (`KK_HEADER_STATIC` gives it
+  // a "stuck" refcount == RC_STUCK, so dup/drop are no-ops and it is never freed).
+  // This singleton is shared across ALL threads: every thread's `ctx->evv` starts
+  // here and every handler push/pop dup/drops the empty evv. A heap block with an
+  // ordinary refcount (the previous `kk_block_alloc_as` version) is corrupted by
+  // concurrent NON-atomic dup/drop from multiple threads -- which manifests as
+  // effect-handler / continuation memory corruption once a second async loop runs
+  // on its own OS thread (see std/async spawn-thread).
+  struct kk_evv_s* evv = (struct kk_evv_s*)&kk_evv_empty_static;
+  kk_base_type_dup_as(struct kk_evv_s*, evv);   // no-op on a stuck refcount
   return kk_datatype_from_base(evv, ctx);
 }
 

--- a/kklib/src/refcount.c
+++ b/kklib/src/refcount.c
@@ -165,12 +165,32 @@ static inline kk_refcount_t kk_atomic_acquire(kk_block_t* b) {
   return kk_atomic_load_acquire(&b->header.refcount);
 }
 
-static void kk_block_make_shared(kk_block_t* b) {
+// Make a block's refcount "stuck": it is never modified (dup/drop become no-ops) and
+// the block is never freed. For process-lifetime globals (string literals, constants)
+// that are stored in C statics and used from ANY thread: a stuck refcount is what a
+// compile-time static gets (KK_HEADER_STATIC) and avoids cross-thread refcount races.
+kk_decl_export void kk_block_make_stuck(kk_block_t* b) {
+  kk_block_refcount_set(b, RC_STUCK);
+}
+
+static void kk_block_make_shared(kk_block_t* b, bool stuck) {
   kk_refcount_t rc = kk_block_refcount(b);
   kk_assert_internal(!kk_refcount_is_thread_shared(rc));  // not thread shared already
   if (!kk_refcount_is_thread_shared(rc)) {
-    rc = -rc;                                     // cannot overflow as rc is positive
-    if (rc <= RC_STICKY_DROP) { rc = RC_STICKY; } // for high reference counts default to sticky
+    if (stuck) {
+      // process-lifetime global (toplevel constant): refcount becomes permanently
+      // inert (dup/drop no-ops, never freed) -- same as a compile-time static.
+      rc = RC_STUCK;
+    }
+    else {
+      // positive rc N encodes N+1 references (0 == unique); thread-shared -N encodes
+      // N references (freed when an atomic drop sees -1 == RC_SHARED_UNIQUE). So the
+      // count-preserving map is N+1 refs -> -(N+1), i.e. `~rc` -- NOT `-rc`, which
+      // loses one reference for every rc >= 1 (a marked block with 2 references was
+      // encoded as having 1, so the next drop freed it while still referenced).
+      rc = ~rc;                                     // -(rc+1); cannot overflow as rc is positive
+      if (rc <= RC_STICKY_DROP) { rc = RC_STICKY; } // for high reference counts default to sticky
+    }
     kk_block_refcount_set(b, rc);
   }
 }
@@ -559,12 +579,12 @@ static kk_decl_noinline void kk_block_drop_free_rec_old(kk_block_t* b, kk_contex
 #define MAX_RECURSE_DEPTH (100)
 
 // Stackless marking is more expensive so we switch to this only after recursing first.
-static kk_decl_noinline void kk_block_mark_shared_recx(kk_block_t* b, kk_context_t* ctx);
+static kk_decl_noinline void kk_block_mark_shared_recx(kk_block_t* b, bool stuck, kk_context_t* ctx);
 
 
 // Check if a field `i` in a block `b` should be marked, i.e. it is heap allocated and not yet thread shared.
 // Optimizes by already marking leaf blocks that have no scan fields.
-static inline kk_block_t* kk_block_field_should_mark(kk_block_t* b, kk_ssize_t field, kk_context_t* ctx)
+static inline kk_block_t* kk_block_field_should_mark(kk_block_t* b, kk_ssize_t field, bool stuck, kk_context_t* ctx)
 {
   kk_unused(ctx);
   kk_box_t v = kk_block_field(b, field);
@@ -573,7 +593,7 @@ static inline kk_block_t* kk_block_field_should_mark(kk_block_t* b, kk_ssize_t f
     if (!kk_block_is_thread_shared(child)) {
       if (child->header.scan_fsize == 0) {
         // mark leaf objects directly as shared
-        kk_block_make_shared(child);
+        kk_block_make_shared(child, stuck);
       }
       else {
         return child;
@@ -584,7 +604,7 @@ static inline kk_block_t* kk_block_field_should_mark(kk_block_t* b, kk_ssize_t f
 }
 
 // Recurse up to `depth` while marking objects
-static kk_decl_noinline void kk_block_mark_shared_rec(kk_block_t* b, const kk_ssize_t depth, kk_context_t* ctx)
+static kk_decl_noinline void kk_block_mark_shared_rec(kk_block_t* b, const kk_ssize_t depth, bool stuck, kk_context_t* ctx)
 {
   while(true) {
     if (kk_block_is_thread_shared(b)) {
@@ -595,8 +615,8 @@ static kk_decl_noinline void kk_block_mark_shared_rec(kk_block_t* b, const kk_ss
     kk_assert_internal(scan_fsize > 0);
     if (scan_fsize == 1) {
       // if just one field, we can recursively scan without using stack space
-      kk_block_make_shared(b);
-      kk_block_t* child = kk_block_field_should_mark(b, 0, ctx);
+      kk_block_make_shared(b, stuck);
+      kk_block_t* child = kk_block_field_should_mark(b, 0, stuck, ctx);
       if (child != NULL) {
         // try to mark the child now
         b = child;
@@ -606,8 +626,8 @@ static kk_decl_noinline void kk_block_mark_shared_rec(kk_block_t* b, const kk_ss
     }
     else if (scan_fsize == 2 && !kk_box_is_non_null_ptr(kk_block_field(b, 0))) {
       // optimized code for lists/nodes with boxed first element
-      kk_block_make_shared(b);
-      kk_block_t* child = kk_block_field_should_mark(b, 1, ctx);
+      kk_block_make_shared(b, stuck);
+      kk_block_t* child = kk_block_field_should_mark(b, 1, stuck, ctx);
       if (child != NULL) {
         b = child;
         continue; // tailcall
@@ -617,7 +637,7 @@ static kk_decl_noinline void kk_block_mark_shared_rec(kk_block_t* b, const kk_ss
     else {
       // more than 1 field
       if (depth < MAX_RECURSE_DEPTH) {
-        kk_block_make_shared(b);
+        kk_block_make_shared(b, stuck);
         kk_ssize_t i = 0;
         if kk_unlikely(scan_fsize >= KK_SCAN_FSIZE_MAX) {
           scan_fsize = (kk_ssize_t)kk_intf_unbox(kk_block_field(b, 0));
@@ -625,13 +645,13 @@ static kk_decl_noinline void kk_block_mark_shared_rec(kk_block_t* b, const kk_ss
         }
         // mark fields up to the last one
         for (; i < (scan_fsize-1); i++) {
-          kk_block_t* child = kk_block_field_should_mark(b, i, ctx);
+          kk_block_t* child = kk_block_field_should_mark(b, i, stuck, ctx);
           if (child != NULL) {
-            kk_block_mark_shared_rec(child, depth+1, ctx); // recurse with increased depth
+            kk_block_mark_shared_rec(child, depth+1, stuck, ctx); // recurse with increased depth
           }
         }
         // and recurse into the last one
-        kk_block_t* child = kk_block_field_should_mark(b, i, ctx);
+        kk_block_t* child = kk_block_field_should_mark(b, i, stuck, ctx);
         if (child != NULL) {
           b = child;
           scan_fsize = b->header.scan_fsize;
@@ -641,7 +661,7 @@ static kk_decl_noinline void kk_block_mark_shared_rec(kk_block_t* b, const kk_ss
       }
       else {
         // max recursion depth reached: switch to stackless marking
-        kk_block_mark_shared_recx(b, ctx);
+        kk_block_mark_shared_recx(b, stuck, ctx);
         return;
       }
     }
@@ -651,15 +671,15 @@ static kk_decl_noinline void kk_block_mark_shared_rec(kk_block_t* b, const kk_ss
 
 
 // mark a large vector
-static kk_decl_noinline void kk_block_mark_shared_recx_large(kk_block_t* b, kk_context_t* ctx) {
+static kk_decl_noinline void kk_block_mark_shared_recx_large(kk_block_t* b, bool stuck, kk_context_t* ctx) {
   kk_assert_internal(b->header.scan_fsize == KK_SCAN_FSIZE_MAX);
   kk_ssize_t scan_fsize = kk_block_scan_fsize(b);
   for (kk_ssize_t i = 1; i < scan_fsize; i++) {  // start at 1 to skip the large scan field itself
-    if (kk_block_field_should_mark(b, i, ctx)) {
-      kk_block_mark_shared_recx(b, ctx);
+    if (kk_block_field_should_mark(b, i, stuck, ctx)) {
+      kk_block_mark_shared_recx(b, stuck, ctx);
     }
   }
-  kk_block_make_shared(b);
+  kk_block_make_shared(b, stuck);
 }
 
 // Unfortunately, we cannot use the _field_idx as the index for marking
@@ -703,9 +723,8 @@ static uint8_t kk_block_mark_idx(kk_block_t* b) {
 }
 
 // Stackless marking by using pointer reversal
-static kk_decl_noinline void kk_block_mark_shared_recx(kk_block_t* b, kk_context_t* ctx)
+static kk_decl_noinline void kk_block_mark_shared_recx(kk_block_t* b, bool stuck, kk_context_t* ctx)
 {
-  fprintf(stderr, "mark shared recx\n");
   kk_block_t* parent = NULL;
   if (kk_block_is_thread_shared(b)) return;
   if (b->header.scan_fsize == 0) return;
@@ -717,7 +736,7 @@ recurse:
   scan_fsize = b->header.scan_fsize;
   if (scan_fsize == KK_SCAN_FSIZE_MAX) {
     // stack recurse over the stack for large objects (vectors)
-    kk_block_mark_shared_recx_large(b, ctx);
+    kk_block_mark_shared_recx_large(b, stuck, ctx);
   }
   else {
     i = 0;
@@ -728,7 +747,7 @@ markfields:
     kk_assert_internal(scan_fsize > 0);
     kk_assert_internal(i <= scan_fsize);
     while (i < scan_fsize) {
-      kk_block_t* child = kk_block_field_should_mark(b, i, ctx);
+      kk_block_t* child = kk_block_field_should_mark(b, i, stuck, ctx);
       i++;
       if (child != NULL) {
         // visit the child, but remember our state and link back to the parent
@@ -741,7 +760,7 @@ markfields:
       }
     }
     kk_block_mark_idx_done(b);
-    kk_block_make_shared(b);
+    kk_block_make_shared(b, stuck);
   }
 
   //--- moving back up along the parent chain ------------------
@@ -763,15 +782,27 @@ markfields:
 }
 
 
-kk_decl_export void kk_block_mark_shared( kk_block_t* b, kk_context_t* ctx ) {
+static void kk_block_mark_sharedx( kk_block_t* b, bool stuck, kk_context_t* ctx ) {
   if (!kk_block_is_thread_shared(b)) {
     if (b->header.scan_fsize == 0) {
-      kk_block_make_shared(b); // no scan fields
+      kk_block_make_shared(b, stuck); // no scan fields
     }
     else {
-      kk_block_mark_shared_rec(b, 0, ctx);
+      kk_block_mark_shared_rec(b, 0, stuck, ctx);
     }
   }
+}
+
+kk_decl_export void kk_block_mark_shared( kk_block_t* b, kk_context_t* ctx ) {
+  kk_block_mark_sharedx(b, false, ctx);
+}
+
+// Mark a reachable graph as STATIC: every not-yet-shared block becomes stuck
+// (dup/drop no-ops, never freed) -- for process-lifetime globals such as computed
+// toplevel constants stored in C statics and used from any thread. Blocks that are
+// already thread-shared are left as-is (they stay atomically counted).
+kk_decl_export void kk_block_mark_static( kk_block_t* b, kk_context_t* ctx ) {
+  kk_block_mark_sharedx(b, true, ctx);
 }
 
 kk_decl_export void kk_box_mark_shared( kk_box_t b, kk_context_t* ctx ) {
@@ -780,10 +811,15 @@ kk_decl_export void kk_box_mark_shared( kk_box_t b, kk_context_t* ctx ) {
   }
 }
 
+kk_decl_export void kk_box_mark_static( kk_box_t b, kk_context_t* ctx ) {
+  if (kk_box_is_non_null_ptr(b)) {
+    kk_block_mark_static( kk_ptr_unbox(b,ctx), ctx );
+  }
+}
 
 kk_decl_export void kk_box_mark_shared_recx(kk_box_t b, kk_context_t* ctx) {
   if (kk_box_is_non_null_ptr(b)) {
-    kk_block_mark_shared_recx(kk_ptr_unbox(b, ctx), ctx);
+    kk_block_mark_shared_recx(kk_ptr_unbox(b, ctx), false, ctx);
   }
 }
 

--- a/kklib/src/string.c
+++ b/kklib/src/string.c
@@ -383,6 +383,29 @@ kk_string_t kk_string_alloc_from_utf8(const char* str, kk_context_t* ctx) {
   return kk_string_alloc_from_utf8n(kk_sstrlen(str), str, ctx);
 }
 
+// Initialize a lazily-allocated string literal ONCE, thread-safely (see
+// `kk_init_string_literal`). Literals live in C statics and are used from ANY
+// thread, so: (1) the one-time initialization must be a release-CAS publish (two
+// threads may execute a function-local literal's first use concurrently), and
+// (2) the block's refcount is made STUCK -- a plain refcount on a shared static
+// would be dup/dropped non-atomically across threads (lost counts -> premature
+// free -> heap corruption); stuck makes dup/drop no-ops and the literal lives for
+// the process, exactly like a compile-time static (KK_HEADER_STATIC).
+kk_decl_export void kk_string_literal_init(kk_string_t* p, kk_ssize_t len, const char* chars, kk_context_t* ctx) {
+  kk_string_t s = kk_string_alloc_from_utf8n(len, chars, ctx);
+  if (kk_datatype_is_ptr(s.bytes)) {
+    kk_block_make_stuck(kk_datatype_as_ptr(s.bytes, ctx));
+  }
+  kk_intb_t expected = kk_datatype_null().dbox;
+  if (!kk_atomic_cas_strong_acq_rel((_Atomic(kk_intb_t)*)&(p->bytes.dbox), &expected, s.bytes.dbox)) {
+    // another thread won the initialization: discard ours (un-stick, then drop)
+    if (kk_datatype_is_ptr(s.bytes)) {
+      kk_block_refcount_set(kk_datatype_as_ptr(s.bytes, ctx), 0);
+      kk_string_drop(s, ctx);
+    }
+  }
+}
+
 kk_string_t kk_string_convert_from_qutf8(kk_bytes_t str, kk_context_t* ctx) {
   // to avoid reallocation (to accommodate invalid sequences), we first check if
   // it is already valid utf-8 which should be very common; in that case we return the bytes/string as-is.

--- a/lib/std/async/api/coop/thread.kk
+++ b/lib/std/async/api/coop/thread.kk
@@ -49,6 +49,10 @@ pub fun xchannel/xemit( x : xchannel<a>, value : a ) : ioc ()
 pub fun xchannel/xreceive( x : xchannel<a> ) : <async,ndet> a
   x.chan.receive
 
+// No native handle to close on a cooperative host; a no-op for API parity.
+pub fun xchannel/close( x : xchannel<a> ) : ioc ()
+  ()
+
 // No OS threads here: gated out by `native-threads()`. If a caller ignores the
 // gate and calls this, it is a no-op (the body never runs) -- deliberately inert
 // rather than throwing, since it is never reached on a correctly-gated path.

--- a/lib/std/async/api/coop/thread.kk
+++ b/lib/std/async/api/coop/thread.kk
@@ -49,6 +49,9 @@ pub fun xchannel/xemit( x : xchannel<a>, value : a ) : ioc ()
 pub fun xchannel/xreceive( x : xchannel<a> ) : <async,ndet> a
   x.chan.receive
 
+pub fun xchannel/try-xreceive( x : xchannel<a> ) : <async,ndet> maybe<a>
+  x.chan.try-receive
+
 // No native handle to close on a cooperative host; a no-op for API parity.
 pub fun xchannel/close( x : xchannel<a> ) : ioc ()
   ()

--- a/lib/std/async/api/coop/thread.kk
+++ b/lib/std/async/api/coop/thread.kk
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------
+  Copyright 2026, Tim Whiting, Microsoft Research, Daan Leijen.
+
+  This is free software; you can redistribute it and/or modify it under the
+  terms of the Apache License, Version 2.0. A copy of the License can be
+  found in the LICENSE file at the root of this distribution.
+---------------------------------------------------------------------------*/
+
+// Cooperative fallback threading backend for `std/async/thread`.
+//
+// Web and wasi hosts have no OS threads, so `compute` degrades to a cooperative
+// strand: yield to the loop once (giving other strands a chance to run), then
+// run `work` inline on the single thread. Same API as the native backend, so
+// applications stay portable.
+module async/api/coop/thread
+
+import async/async
+import async/channel
+
+// Run `work` cooperatively: yield to other strands, then compute inline.
+pub fun await-compute( work : () -> a ) : async a
+  yield()
+  work()
+
+// ----------------------------------------------------------------
+// thread-safe channel + spawn-thread: on a single-threaded cooperative host
+// there ARE no other threads, so an `xchannel` is just a plain channel and
+// `native-threads()` is False (callers gate real threading on it). The API
+// matches the native backend so `std/async/thread` stays host-consistent.
+
+pub value struct xchannel<a>( chan : channel<a> )
+pub value struct xsender<a>( chan : channel<a> )
+
+pub fun native-threads() : bool
+  False
+
+pub fun xchannel() : async xchannel<a>
+  Xchannel(channel())
+
+pub fun xchannel/sender( x : xchannel<a> ) : xsender<a>
+  Xsender(x.chan)
+
+pub fun xsender/xemit( s : xsender<a>, value : a ) : ioc ()
+  s.chan.emit-io(value)
+
+pub fun xchannel/xemit( x : xchannel<a>, value : a ) : ioc ()
+  x.chan.emit-io(value)
+
+pub fun xchannel/xreceive( x : xchannel<a> ) : <async,ndet> a
+  x.chan.receive
+
+// No OS threads here: gated out by `native-threads()`. If a caller ignores the
+// gate and calls this, it is a no-op (the body never runs) -- deliberately inert
+// rather than throwing, since it is never reached on a correctly-gated path.
+pub fun spawn-thread( body : () -> <async,ioc> () ) : ioc ()
+  println("std/async: spawn-thread has no effect on this host (no OS threads)")

--- a/lib/std/async/api/coop/thread.kk
+++ b/lib/std/async/api/coop/thread.kk
@@ -18,7 +18,7 @@ import async/async
 import async/channel
 
 // Run `work` cooperatively: yield to other strands, then compute inline.
-pub fun await-compute( work : () -> a ) : async a
+pub fun await-compute( work : () -> ioc a ) : <async|ioc> a
   yield()
   work()
 

--- a/lib/std/async/api/uv/thread.c
+++ b/lib/std/async/api/uv/thread.c
@@ -1,0 +1,241 @@
+/*---------------------------------------------------------------------------
+  Copyright 2026, Tim Whiting, Microsoft Research, Daan Leijen.
+
+  This is free software; you can redistribute it and/or modify it under the
+  terms of the Apache License, Version 2.0. A copy of the License can be
+  found in the LICENSE file at the root of this distribution.
+---------------------------------------------------------------------------*/
+
+// Threading primitives for `std/async`, built on libuv.
+//
+// - `kk_uv_queue_work` : run a pure computation on a libuv threadpool worker
+//   thread and deliver the (thread-shared) result back on the owning loop.
+//
+// The heap is thread-local and Perceus refcounts are non-atomic, so anything
+// that crosses a thread boundary is marked thread-shared first (atomic
+// refcounts) exactly as `kk_task_schedule`/`kk_promise_set` do in
+// `kklib/src/thread.c`. The `work` closure crosses to the worker (marked on
+// the loop thread before queueing); the `result` crosses back (marked on the
+// worker thread before the loop consumes it).
+
+// for IDE
+// #include <kklib.h>
+// #include "std_async_api_uv_evloop.h"
+
+#include <uv.h>
+
+// -------------------------------------------------------------------------
+// compute: offload a pure `work` computation to a libuv threadpool thread
+// -------------------------------------------------------------------------
+
+// `kk_function_t` is a (boxed) datatype value, not a pointer, so — like the uv
+// `handle->data` idiom in evloop.c — we store the underlying block pointer as a
+// `void*` (NULL when consumed) and rebuild the function on use.
+typedef struct kk_uv_compute_s {
+  uv_work_t     req;       // must be first: we alias `kk_uv_compute_t*` <-> `uv_work_t*`
+  void*         work;      // () -> box  block ptr ; marked thread-shared before queueing; NULL once consumed
+  kk_box_t      result;    // filled by the worker (marked thread-shared there)
+  void*         resume;    // (box) -> ioc () block ptr ; loop-thread callback; NULL once consumed/disposed
+  bool          ran;       // whether `work` actually executed (vs. canceled before it started)
+} kk_uv_compute_t;
+
+// Runs on a libuv threadpool (worker) thread.
+static void kk_uv_compute_work_cb(uv_work_t* req) {
+  kk_uv_compute_t* w = (kk_uv_compute_t*)req;
+  // libuv reuses a small fixed pool of worker threads; `kk_get_context` lazily
+  // creates (and caches) a Koka context per OS thread.
+  kk_context_t* ctx = kk_get_context();
+  kk_function_t work = kk_datatype_from_ptr((kk_ptr_t)w->work, ctx);
+  w->work = NULL;
+  // call consumes (drops) the `work` reference; the reachable graph is already thread-shared
+  kk_box_t res = kk_function_call(kk_box_t, (kk_function_t, kk_context_t*), work, (work, ctx), ctx);
+  // the result was allocated on this worker heap and is about to cross back to
+  // the loop thread: mark it thread-shared so refcounting stays atomic
+  kk_box_mark_shared(res, ctx);
+  w->result = res;
+  w->ran = true;
+}
+
+// Runs on the owning (loop) thread after the worker completes or the request is canceled.
+static void kk_uv_compute_after_cb(uv_work_t* req, int status) {
+  kk_unused(status);
+  kk_context_t* ctx = kk_get_context();
+  kk_uv_compute_t* w = (kk_uv_compute_t*)req;
+  void* resume_ptr = w->resume;
+  w->resume = NULL;
+  if (resume_ptr != NULL) {
+    // normal delivery on the loop thread; `resume` consumes both itself and the boxed result
+    kk_function_t resume = kk_datatype_from_ptr((kk_ptr_t)resume_ptr, ctx);
+    kk_box_t res = (w->ran ? w->result : kk_box_any(ctx));
+    kk_function_call(kk_unit_t, (kk_function_t, kk_box_t, kk_context_t*), resume, (resume, res, ctx), ctx);
+  }
+  else {
+    // disposed/canceled before delivery: release anything still held
+    if (w->ran) { kk_box_drop(w->result, ctx); }
+    if (w->work != NULL) { kk_datatype_drop(kk_datatype_from_ptr((kk_ptr_t)w->work, ctx), ctx); }
+  }
+  kk_free(w, ctx);
+}
+
+// Dispose (on cancelation). Runs on the loop thread (same thread as `after_cb`),
+// so there is no race on `w->resume`. Prevents delivery and best-effort cancels
+// the queued work; `after_cb` still runs exactly once and frees `w`.
+static void kk_uv_compute_dispose(uv_handle_t* h, void* arg, kk_context_t* ctx) {
+  kk_unused(arg);
+  kk_uv_compute_t* w = (kk_uv_compute_t*)h;
+  if (w->resume != NULL) {
+    kk_datatype_drop(kk_datatype_from_ptr((kk_ptr_t)w->resume, ctx), ctx);
+    w->resume = NULL;
+  }
+  uv_cancel((uv_req_t*)&w->req);  // if it already started/finished, after_cb still frees w
+}
+
+// Setup: queue `work` on the loop's threadpool, delivering the result via `resume`.
+// `work` : () -> box , `resume` : (box) -> ioc () . Returns a dispose function.
+kk_std_core_exn__error kk_uv_queue_work(kk_uv_loop_t loop, kk_function_t work, kk_function_t resume, kk_context_t* ctx) {
+  kk_uv_compute_t* w = (kk_uv_compute_t*)kk_zalloc(sizeof(kk_uv_compute_t), ctx);
+  if (w == NULL) {
+    kk_function_drop(work, ctx);
+    kk_function_drop(resume, ctx);
+    return kk_error_from_uv_errno(UV_ENOMEM, ctx);
+  }
+  // `work` crosses to a worker thread -> mark its reachable graph thread-shared (atomic refcounts)
+  kk_block_mark_shared(kk_datatype_as_ptr(work, ctx), ctx);
+  w->work = (void*)kk_datatype_as_ptr(work, ctx);
+  w->resume = (void*)kk_datatype_as_ptr(resume, ctx);   // stays on the loop thread; not marked
+  w->ran = false;
+  int err = uv_queue_work(kk_uv_loop(loop, ctx), &w->req, &kk_uv_compute_work_cb, &kk_uv_compute_after_cb);
+  if (err != 0) {
+    kk_function_drop(work, ctx);
+    kk_function_drop(resume, ctx);
+    kk_free(w, ctx);
+    return kk_error_from_uv_errno(err, ctx);
+  }
+  return kk_result_uv_handle_dispose((uv_handle_t*)w, NULL, &kk_uv_compute_dispose, ctx);
+}
+
+// -------------------------------------------------------------------------
+// xchannel: a THREAD-SAFE channel. Any thread may `xemit`; each value is marked
+// thread-shared, pushed onto a mutex-protected FIFO queue, and the OWNER loop is
+// woken via `uv_async_send`. The async callback (which runs on the owner loop
+// thread) drains the whole queue and hands each value to `deliver` -- an
+// owner-thread callback that emits into a normal loop-local Koka channel that
+// receivers await. This is the "extend libuv" core the persistent-thread work
+// builds on.
+// -------------------------------------------------------------------------
+
+typedef struct kk_xnode_s { struct kk_xnode_s* next; kk_box_t value; } kk_xnode_t;
+
+typedef struct kk_xchan_s {
+  uv_async_t   async;    // MUST be first: we alias `kk_xchan_t*` <-> `uv_async_t*`/`uv_handle_t*`
+  uv_mutex_t   mutex;
+  kk_xnode_t*  head;     // FIFO queue head/tail, guarded by `mutex`
+  kk_xnode_t*  tail;
+  void*        deliver;  // (box) -> ioc () block ptr; OWNER-thread ref (delivers into the Koka channel)
+} kk_xchan_t;
+
+// OWNER loop thread: drain the queue and deliver each value in FIFO order. libuv
+// coalesces `uv_async_send`s, so we must drain ALL queued values per wake.
+static void kk_xchan_async_cb(uv_async_t* async) {
+  kk_xchan_t* c = (kk_xchan_t*)async;
+  kk_context_t* ctx = kk_get_context();
+  uv_mutex_lock(&c->mutex);
+  kk_xnode_t* n = c->head; c->head = NULL; c->tail = NULL;
+  uv_mutex_unlock(&c->mutex);
+  while (n != NULL) {
+    kk_xnode_t* next = n->next;
+    // keep our stored `deliver` ref alive across the (consuming) call
+    kk_function_t deliver = kk_datatype_from_ptr((kk_ptr_t)c->deliver, ctx);
+    kk_function_dup(deliver, ctx);
+    kk_function_call(kk_unit_t, (kk_function_t, kk_box_t, kk_context_t*), deliver, (deliver, n->value, ctx), ctx);
+    free(n);
+    n = next;
+  }
+}
+
+// after uv_close completes (owner thread): drop anything still held, then free
+static void kk_xchan_close_cb(uv_handle_t* h) {
+  kk_xchan_t* c = (kk_xchan_t*)h;
+  kk_context_t* ctx = kk_get_context();
+  uv_mutex_destroy(&c->mutex);
+  kk_xnode_t* n = c->head;
+  while (n != NULL) { kk_xnode_t* next = n->next; kk_box_drop(n->value, ctx); free(n); n = next; }
+  if (c->deliver != NULL) kk_datatype_drop(kk_datatype_from_ptr((kk_ptr_t)c->deliver, ctx), ctx);
+  free(c);
+}
+
+// cptr free fun: the last drop of the boxed channel (owner thread) schedules the
+// async handle's close, which frees the struct in `close_cb`
+static void kk_xchan_free(void* p, kk_block_t* block, kk_context_t* ctx) {
+  kk_unused(block); kk_unused(ctx);
+  kk_xchan_t* c = (kk_xchan_t*)p;
+  uv_close((uv_handle_t*)&c->async, kk_xchan_close_cb);
+}
+
+// noop dispose for the creation await (the channel outlives the await -- its
+// lifetime is the boxed cptr handed back through `resume`)
+static void kk_xchan_noop_dispose(uv_handle_t* h, void* arg, kk_context_t* ctx) {
+  kk_unused(h); kk_unused(arg); kk_unused(ctx);
+}
+
+// Setup (owner loop thread): create the channel on `loop`, deliver its values via
+// `deliver`, and hand the boxed channel pointer back immediately through `resume`.
+kk_std_core_exn__error kk_xchan_create(kk_uv_loop_t loop, kk_function_t deliver, kk_function_t resume, kk_context_t* ctx) {
+  kk_xchan_t* c = (kk_xchan_t*)calloc(1, sizeof(kk_xchan_t));
+  if (c == NULL) { kk_function_drop(deliver, ctx); kk_function_drop(resume, ctx); return kk_error_from_uv_errno(UV_ENOMEM, ctx); }
+  uv_mutex_init(&c->mutex);
+  int err = uv_async_init(kk_uv_loop(loop, ctx), &c->async, kk_xchan_async_cb);
+  if (err != 0) { uv_mutex_destroy(&c->mutex); free(c); kk_function_drop(deliver, ctx); kk_function_drop(resume, ctx); return kk_error_from_uv_errno(err, ctx); }
+  c->head = c->tail = NULL;
+  c->deliver = (void*)kk_datatype_as_ptr(deliver, ctx);   // owner-thread ref
+  kk_box_t boxed = kk_cptr_raw_box(&kk_xchan_free, c, ctx);
+  kk_function_call(kk_unit_t, (kk_function_t, kk_box_t, kk_context_t*), resume, (resume, boxed, ctx), ctx);
+  return kk_result_uv_handle_dispose(NULL, NULL, &kk_xchan_noop_dispose, ctx);
+}
+
+// Emit `value` into the channel from ANY thread: mark it thread-shared, enqueue
+// under the mutex, and wake the owner loop.
+kk_unit_t kk_xchan_emit(kk_box_t xcbox, kk_box_t value, kk_context_t* ctx) {
+  kk_xchan_t* c = (kk_xchan_t*)kk_cptr_raw_unbox_borrowed(xcbox, ctx);
+  kk_box_mark_shared(value, ctx);
+  kk_xnode_t* n = (kk_xnode_t*)malloc(sizeof(kk_xnode_t));
+  n->next = NULL; n->value = value;   // ownership of `value` transferred to the node
+  uv_mutex_lock(&c->mutex);
+  if (c->tail != NULL) c->tail->next = n; else c->head = n;
+  c->tail = n;
+  uv_mutex_unlock(&c->mutex);
+  uv_async_send(&c->async);
+  kk_box_drop(xcbox, ctx);            // drop this (dup'd) channel reference
+  return kk_Unit;
+}
+
+// -------------------------------------------------------------------------
+// spawn-thread: a PERSISTENT worker thread running its OWN Koka async loop.
+// The thread gets a fresh per-thread Koka context and calls `body`, which is a
+// Koka wrapper that runs `async(...)` -- i.e. it inits its own uv_loop, installs
+// the async/exn handlers, runs the user body, and `uv_run(UV_RUN_DEFAULT)`s until
+// its work drains. So the worker is "just another async main" on its own thread,
+// able to host the delivery callbacks of thread-safe channels correctly.
+// -------------------------------------------------------------------------
+
+static void kk_thread_entry(void* arg) {
+  // `arg` is the `() -> ioc ()` body block ptr (marked thread-shared before spawn)
+  kk_context_t* ctx = kk_get_context();   // fresh, lazily-created per-thread context
+  kk_function_t body = kk_datatype_from_ptr((kk_ptr_t)arg, ctx);
+  kk_function_call(kk_unit_t, (kk_function_t, kk_context_t*), body, (body, ctx), ctx);
+}
+
+// Spawn an OS thread that runs `body` (a `() -> ioc ()` that wraps `async(...)`).
+kk_unit_t kk_spawn_thread(kk_function_t body, kk_context_t* ctx) {
+  // `body` crosses to the new thread -> mark its reachable graph thread-shared
+  kk_block_mark_shared(kk_datatype_as_ptr(body, ctx), ctx);
+  void* body_ptr = (void*)kk_datatype_as_ptr(body, ctx);
+  uv_thread_t tid;
+  int err = uv_thread_create(&tid, kk_thread_entry, body_ptr);
+  if (err != 0) {
+    // reclaim the body ref on failure
+    kk_datatype_drop(kk_datatype_from_ptr((kk_ptr_t)body_ptr, ctx), ctx);
+    kk_warning_message("spawn-thread: uv_thread_create failed: %s\n", uv_strerror(err));
+  }
+  return kk_Unit;
+}

--- a/lib/std/async/api/uv/thread.c
+++ b/lib/std/async/api/uv/thread.c
@@ -67,11 +67,10 @@ static void kk_uv_compute_after_cb(uv_work_t* req, int status) {
   kk_uv_compute_t* w = (kk_uv_compute_t*)req;
   void* resume_ptr = w->resume;
   w->resume = NULL;
-  if (resume_ptr != NULL) {
+  if (resume_ptr != NULL && w->ran) {
     // normal delivery on the loop thread; `resume` consumes both itself and the boxed result
     kk_function_t resume = kk_datatype_from_ptr((kk_ptr_t)resume_ptr, ctx);
-    kk_box_t res = (w->ran ? w->result : kk_box_any(ctx));
-    kk_function_call(kk_unit_t, (kk_function_t, kk_box_t, kk_context_t*), resume, (resume, res, ctx), ctx);
+    kk_function_call(kk_unit_t, (kk_function_t, kk_box_t, kk_context_t*), resume, (resume, w->result, ctx), ctx);
   }
   else {
     // disposed/canceled before delivery: release anything still held
@@ -152,7 +151,7 @@ static void kk_xchan_async_cb(uv_async_t* async) {
     kk_function_t deliver = kk_datatype_from_ptr((kk_ptr_t)c->deliver, ctx);
     kk_function_dup(deliver, ctx);
     kk_function_call(kk_unit_t, (kk_function_t, kk_box_t, kk_context_t*), deliver, (deliver, n->value, ctx), ctx);
-    free(n);
+    kk_free(n, ctx);
     n = next;
   }
 }
@@ -163,9 +162,9 @@ static void kk_xchan_close_cb(uv_handle_t* h) {
   kk_context_t* ctx = kk_get_context();
   uv_mutex_destroy(&c->mutex);
   kk_xnode_t* n = c->head;
-  while (n != NULL) { kk_xnode_t* next = n->next; kk_box_drop(n->value, ctx); free(n); n = next; }
+  while (n != NULL) { kk_xnode_t* next = n->next; kk_box_drop(n->value, ctx); kk_free(n, ctx); n = next; }
   if (c->deliver != NULL) kk_datatype_drop(kk_datatype_from_ptr((kk_ptr_t)c->deliver, ctx), ctx);
-  free(c);
+  kk_free(c, ctx);
 }
 
 // noop dispose for the creation await (the channel outlives the await -- its
@@ -183,11 +182,11 @@ static void kk_xchan_noop_dispose(uv_handle_t* h, void* arg, kk_context_t* ctx) 
 // cross-thread free -> heap corruption). Lifetime is managed explicitly: the
 // channel lives until `xchannel/close` (owner thread) or process exit.
 kk_std_core_exn__error kk_xchan_create(kk_uv_loop_t loop, kk_function_t deliver, kk_function_t resume, kk_context_t* ctx) {
-  kk_xchan_t* c = (kk_xchan_t*)calloc(1, sizeof(kk_xchan_t));
+  kk_xchan_t* c = (kk_xchan_t*)kk_zalloc(sizeof(kk_xchan_t), ctx);
   if (c == NULL) { kk_function_drop(deliver, ctx); kk_function_drop(resume, ctx); return kk_error_from_uv_errno(UV_ENOMEM, ctx); }
   uv_mutex_init(&c->mutex);
   int err = uv_async_init(kk_uv_loop(loop, ctx), &c->async, kk_xchan_async_cb);
-  if (err != 0) { uv_mutex_destroy(&c->mutex); free(c); kk_function_drop(deliver, ctx); kk_function_drop(resume, ctx); return kk_error_from_uv_errno(err, ctx); }
+  if (err != 0) { uv_mutex_destroy(&c->mutex); kk_free(c, ctx); kk_function_drop(deliver, ctx); kk_function_drop(resume, ctx); return kk_error_from_uv_errno(err, ctx); }
   c->head = c->tail = NULL;
   c->deliver = (void*)kk_datatype_as_ptr(deliver, ctx);   // owner-thread ref
   kk_box_t boxed = kk_cptr_box(c, ctx);                    // unrefcounted handle
@@ -211,7 +210,7 @@ kk_unit_t kk_xchan_close(kk_box_t xcbox, kk_context_t* ctx) {
 kk_unit_t kk_xchan_emit(kk_box_t xcbox, kk_box_t value, kk_context_t* ctx) {
   kk_xchan_t* c = (kk_xchan_t*)kk_cptr_unbox_borrowed(xcbox, ctx);
   kk_box_mark_shared(value, ctx);
-  kk_xnode_t* n = (kk_xnode_t*)malloc(sizeof(kk_xnode_t));
+  kk_xnode_t* n = (kk_xnode_t*)kk_malloc(sizeof(kk_xnode_t), ctx);
   n->next = NULL; n->value = value;   // ownership of `value` transferred to the node
   uv_mutex_lock(&c->mutex);
   if (c->tail != NULL) c->tail->next = n; else c->head = n;

--- a/lib/std/async/api/uv/thread.c
+++ b/lib/std/async/api/uv/thread.c
@@ -164,22 +164,20 @@ static void kk_xchan_close_cb(uv_handle_t* h) {
   free(c);
 }
 
-// cptr free fun: the last drop of the boxed channel (owner thread) schedules the
-// async handle's close, which frees the struct in `close_cb`
-static void kk_xchan_free(void* p, kk_block_t* block, kk_context_t* ctx) {
-  kk_unused(block); kk_unused(ctx);
-  kk_xchan_t* c = (kk_xchan_t*)p;
-  uv_close((uv_handle_t*)&c->async, kk_xchan_close_cb);
-}
-
 // noop dispose for the creation await (the channel outlives the await -- its
-// lifetime is the boxed cptr handed back through `resume`)
+// lifetime is the UNREFCOUNTED cptr handed back through `resume`, closed
+// explicitly via `xchannel/close`, never by a Koka drop)
 static void kk_xchan_noop_dispose(uv_handle_t* h, void* arg, kk_context_t* ctx) {
   kk_unused(h); kk_unused(arg); kk_unused(ctx);
 }
 
 // Setup (owner loop thread): create the channel on `loop`, deliver its values via
-// `deliver`, and hand the boxed channel pointer back immediately through `resume`.
+// `deliver`, and hand the boxed channel pointer back through `resume`. The handle
+// is boxed as an UNREFCOUNTED raw pointer (kk_cptr_box, a value for heap
+// addresses): it is NOT Koka memory, and a `sender` crosses it to worker threads,
+// so refcounting it would run a destructor on whatever thread drops last (a
+// cross-thread free -> heap corruption). Lifetime is managed explicitly: the
+// channel lives until `xchannel/close` (owner thread) or process exit.
 kk_std_core_exn__error kk_xchan_create(kk_uv_loop_t loop, kk_function_t deliver, kk_function_t resume, kk_context_t* ctx) {
   kk_xchan_t* c = (kk_xchan_t*)calloc(1, sizeof(kk_xchan_t));
   if (c == NULL) { kk_function_drop(deliver, ctx); kk_function_drop(resume, ctx); return kk_error_from_uv_errno(UV_ENOMEM, ctx); }
@@ -188,15 +186,26 @@ kk_std_core_exn__error kk_xchan_create(kk_uv_loop_t loop, kk_function_t deliver,
   if (err != 0) { uv_mutex_destroy(&c->mutex); free(c); kk_function_drop(deliver, ctx); kk_function_drop(resume, ctx); return kk_error_from_uv_errno(err, ctx); }
   c->head = c->tail = NULL;
   c->deliver = (void*)kk_datatype_as_ptr(deliver, ctx);   // owner-thread ref
-  kk_box_t boxed = kk_cptr_raw_box(&kk_xchan_free, c, ctx);
+  kk_box_t boxed = kk_cptr_box(c, ctx);                    // unrefcounted handle
   kk_function_call(kk_unit_t, (kk_function_t, kk_box_t, kk_context_t*), resume, (resume, boxed, ctx), ctx);
   return kk_result_uv_handle_dispose(NULL, NULL, &kk_xchan_noop_dispose, ctx);
+}
+
+// Close the channel from the OWNER thread (the loop that created it): uv_close the
+// async handle, then `close_cb` drains any queued values, drops the deliver, and
+// frees the struct. Owner-thread only, so no cross-thread free. Callers must
+// ensure no other thread `xemit`s after close (senders then dangle).
+kk_unit_t kk_xchan_close(kk_box_t xcbox, kk_context_t* ctx) {
+  kk_xchan_t* c = (kk_xchan_t*)kk_cptr_unbox_borrowed(xcbox, ctx);
+  uv_close((uv_handle_t*)&c->async, kk_xchan_close_cb);
+  kk_box_drop(xcbox, ctx);
+  return kk_Unit;
 }
 
 // Emit `value` into the channel from ANY thread: mark it thread-shared, enqueue
 // under the mutex, and wake the owner loop.
 kk_unit_t kk_xchan_emit(kk_box_t xcbox, kk_box_t value, kk_context_t* ctx) {
-  kk_xchan_t* c = (kk_xchan_t*)kk_cptr_raw_unbox_borrowed(xcbox, ctx);
+  kk_xchan_t* c = (kk_xchan_t*)kk_cptr_unbox_borrowed(xcbox, ctx);
   kk_box_mark_shared(value, ctx);
   kk_xnode_t* n = (kk_xnode_t*)malloc(sizeof(kk_xnode_t));
   n->next = NULL; n->value = value;   // ownership of `value` transferred to the node

--- a/lib/std/async/api/uv/thread.c
+++ b/lib/std/async/api/uv/thread.c
@@ -24,6 +24,10 @@
 
 #include <uv.h>
 
+#if defined(__APPLE__)
+#include <pthread/qos.h>
+#endif
+
 // -------------------------------------------------------------------------
 // compute: offload a pure `work` computation to a libuv threadpool thread
 // -------------------------------------------------------------------------
@@ -228,6 +232,14 @@ kk_unit_t kk_xchan_emit(kk_box_t xcbox, kk_box_t value, kk_context_t* ctx) {
 // -------------------------------------------------------------------------
 
 static void kk_thread_entry(void* arg) {
+#if defined(__APPLE__)
+  // Once the process becomes a Cocoa GUI app (GLFW/Metal init), macOS applies
+  // QoS-based timer coalescing: a default/background-QoS worker thread has its
+  // libuv timers batched to ~1s, so a persistent worker loop barely ticks. Pin
+  // the worker to user-interactive QoS so its timers fire promptly, matching the
+  // main (UI) thread.
+  pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+#endif
   // `arg` is the `() -> ioc ()` body block ptr (marked thread-shared before spawn)
   kk_context_t* ctx = kk_get_context();   // fresh, lazily-created per-thread context
   kk_function_t body = kk_datatype_from_ptr((kk_ptr_t)arg, ctx);

--- a/lib/std/async/api/uv/thread.kk
+++ b/lib/std/async/api/uv/thread.kk
@@ -92,6 +92,11 @@ pub fun xchannel/xemit( x : xchannel<a>, value : a ) : ioc ()
 pub fun xchannel/xreceive( x : xchannel<a> ) : <async,ndet> a
   x.chan.receive
 
+// Receive on the OWNER loop without waiting: `Just` if a value has already
+// been delivered to this loop, `Nothing` otherwise.
+pub fun xchannel/try-xreceive( x : xchannel<a> ) : <async,ndet> maybe<a>
+  x.chan.try-receive
+
 // Close the channel from the OWNER thread. The handle is unrefcounted (not Koka
 // memory), so it does not free on drop -- call this to close the uv_async handle
 // (letting a finite program's loop drain) once no thread will `xemit` again. An

--- a/lib/std/async/api/uv/thread.kk
+++ b/lib/std/async/api/uv/thread.kk
@@ -23,12 +23,11 @@ extern import
 
 // Primitive: queue `work` on the loop's threadpool, delivering its result to
 // `resume` on the loop thread. Returns a dispose function (cancels the work).
-extern compute-prim( evloop : any, work : () -> a, resume : (a) -> ioc () ) : ioc error<() -> ioc ()>
+extern compute-prim( evloop : any, work : () -> ioc a, resume : (a) -> ioc () ) : ioc error<() -> ioc ()>
   c "kk_uv_queue_work"
 
 // Run `work` on a worker thread and await its result on the current loop.
-// `work` must be self-contained over thread-shared/immutable input (see `compute`).
-pub fun await-compute( work : () -> a ) : async a
+pub fun await-compute( work : () -> ioc a ) : <async|ioc> a
   match setup/await-error("compute", fn(evloop, resume) compute-prim(evloop, work, resume))
     Ok(x)      -> x
     Error(exn) -> impossible("async/compute: failed to queue work: " ++ exn.show)

--- a/lib/std/async/api/uv/thread.kk
+++ b/lib/std/async/api/uv/thread.kk
@@ -54,9 +54,16 @@ pub fun xchannel/sender( x : xchannel<a> ) : xsender<a>
 extern xchan-create-prim( evloop : any, deliver : (a) -> ioc (), resume : (any) -> ioc () ) : ioc error<() -> ioc ()>
   c "kk_xchan_create"
 
-// enqueue+wake from any thread (the C side marks the value thread-shared)
-extern xchan-emit-prim( xc : any, value : a ) : ()
+// enqueue+wake from any thread (the C side marks the value thread-shared).
+// Typed `ioc` (not total) to match the web/coop fallback (a plain channel emit),
+// so the portable `std/async/thread` signature is host-consistent.
+extern xchan-emit-prim( xc : any, value : a ) : ioc ()
   c "kk_xchan_emit"
+
+// True on hosts with real OS worker threads (native); False on web/wasi where
+// `spawn-thread` has no real thread. Callers gate threaded topologies on this.
+pub fun native-threads() : bool
+  True
 
 // Create a thread-safe channel bound to the CURRENT async loop.
 pub fun xchannel() : async xchannel<a>
@@ -70,12 +77,12 @@ pub fun xchannel() : async xchannel<a>
 // thread-shared and wakes the owner loop; a waiting `xreceive` resumes there. No
 // observable Koka effect (the queue+wake is invisible to the caller). Give a
 // worker `x.sender` -- never the whole `xchannel` (which holds the Koka channel).
-pub fun xsender/xemit( s : xsender<a>, value : a ) : ()
+pub fun xsender/xemit( s : xsender<a>, value : a ) : ioc ()
   xchan-emit-prim(s.xc, value)
 
 // Convenience: emit from the owner side (also fine cross-thread, but a worker
 // should capture `x.sender`, not `x`, to avoid holding the Koka channel).
-pub fun xchannel/xemit( x : xchannel<a>, value : a ) : ()
+pub fun xchannel/xemit( x : xchannel<a>, value : a ) : ioc ()
   xchan-emit-prim(x.xc, value)
 
 // Receive on the OWNER loop (the loop that created the channel).

--- a/lib/std/async/api/uv/thread.kk
+++ b/lib/std/async/api/uv/thread.kk
@@ -60,6 +60,10 @@ extern xchan-create-prim( evloop : any, deliver : (a) -> ioc (), resume : (any) 
 extern xchan-emit-prim( xc : any, value : a ) : ioc ()
   c "kk_xchan_emit"
 
+// close the channel from the OWNER thread (uv_close + free); no cross-thread free
+extern xchan-close-prim( xc : any ) : ioc ()
+  c "kk_xchan_close"
+
 // True on hosts with real OS worker threads (native); False on web/wasi where
 // `spawn-thread` has no real thread. Callers gate threaded topologies on this.
 pub fun native-threads() : bool
@@ -89,6 +93,13 @@ pub fun xchannel/xemit( x : xchannel<a>, value : a ) : ioc ()
 pub fun xchannel/xreceive( x : xchannel<a> ) : <async,ndet> a
   x.chan.receive
 
+// Close the channel from the OWNER thread. The handle is unrefcounted (not Koka
+// memory), so it does not free on drop -- call this to close the uv_async handle
+// (letting a finite program's loop drain) once no thread will `xemit` again. An
+// app that runs for its whole lifetime need not call it.
+pub fun xchannel/close( x : xchannel<a> ) : ioc ()
+  xchan-close-prim(x.xc)
+
 // ----------------------------------------------------------------
 // spawn-thread: a PERSISTENT worker thread running its OWN async loop.
 
@@ -107,3 +118,6 @@ fun thread-main( body : () -> <async,ioc> () ) : ioc ()
 // Cross-thread communication is via `xchannel`/`xsender` (thread-safe channels).
 pub fun spawn-thread( body : () -> <async,ioc> () ) : ioc ()
   spawn-thread-prim(fn() thread-main(body))
+
+
+

--- a/lib/std/async/api/uv/thread.kk
+++ b/lib/std/async/api/uv/thread.kk
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------
+  Copyright 2026, Tim Whiting, Microsoft Research, Daan Leijen.
+
+  This is free software; you can redistribute it and/or modify it under the
+  terms of the Apache License, Version 2.0. A copy of the License can be
+  found in the LICENSE file at the root of this distribution.
+---------------------------------------------------------------------------*/
+
+// Native (libuv) threading backend for `std/async/thread`.
+//
+// Offloads a pure computation to a libuv threadpool worker thread and delivers
+// the (thread-shared) result back on the owning async loop. See `thread.c` for
+// the `mark_shared` discipline that keeps refcounts sound across threads.
+module async/api/uv/thread
+
+import async/api/uv/evloop  // transitively supplies the evloop.h declarations to thread.c
+import async/internal
+import async/async
+import async/channel
+
+extern import
+  c[host=libc] file "thread.c"
+
+// Primitive: queue `work` on the loop's threadpool, delivering its result to
+// `resume` on the loop thread. Returns a dispose function (cancels the work).
+extern compute-prim( evloop : any, work : () -> a, resume : (a) -> ioc () ) : ioc error<() -> ioc ()>
+  c "kk_uv_queue_work"
+
+// Run `work` on a worker thread and await its result on the current loop.
+// `work` must be self-contained over thread-shared/immutable input (see `compute`).
+pub fun await-compute( work : () -> a ) : async a
+  match setup/await-error("compute", fn(evloop, resume) compute-prim(evloop, work, resume))
+    Ok(x)      -> x
+    Error(exn) -> impossible("async/compute: failed to queue work: " ++ exn.show)
+
+// ----------------------------------------------------------------
+// xchannel: a THREAD-SAFE channel (native). Any thread may `xemit`; the owner
+// loop is woken via uv_async to deliver values into a loop-local Koka channel
+// that receivers await. See thread.c for the mutex-queue + mark_shared discipline.
+
+// The C thread-safe channel handle + the owner-side Koka channel receivers await.
+pub value struct xchannel<a>( xc : any, chan : channel<a> )
+
+// The cross-thread SENDER half: JUST the C handle (no Koka channel), so a worker
+// closure that captures it never holds -- and never races on -- the owner-side
+// Koka `channel` (whose mutable state the owner concurrently mutates). This is
+// the ONLY part that should cross a thread boundary.
+pub value struct xsender<a>( xc : any )
+
+pub fun xchannel/sender( x : xchannel<a> ) : xsender<a>
+  Xsender(x.xc)
+
+// create the C channel on `evloop` and hand its boxed handle back via `resume`
+extern xchan-create-prim( evloop : any, deliver : (a) -> ioc (), resume : (any) -> ioc () ) : ioc error<() -> ioc ()>
+  c "kk_xchan_create"
+
+// enqueue+wake from any thread (the C side marks the value thread-shared)
+extern xchan-emit-prim( xc : any, value : a ) : ()
+  c "kk_xchan_emit"
+
+// Create a thread-safe channel bound to the CURRENT async loop.
+pub fun xchannel() : async xchannel<a>
+  val ch = channel()
+  val xc = match setup/await-error("xchannel", fn(evloop, resume) xchan-create-prim(evloop, fn(v) ch.emit-io(v), resume))
+    Ok(p)      -> p
+    Error(exn) -> impossible("async/xchannel: could not create: " ++ exn.show)
+  Xchannel(xc, ch)
+
+// Emit `value` from ANY thread through the SENDER (thread-safe). Marks the value
+// thread-shared and wakes the owner loop; a waiting `xreceive` resumes there. No
+// observable Koka effect (the queue+wake is invisible to the caller). Give a
+// worker `x.sender` -- never the whole `xchannel` (which holds the Koka channel).
+pub fun xsender/xemit( s : xsender<a>, value : a ) : ()
+  xchan-emit-prim(s.xc, value)
+
+// Convenience: emit from the owner side (also fine cross-thread, but a worker
+// should capture `x.sender`, not `x`, to avoid holding the Koka channel).
+pub fun xchannel/xemit( x : xchannel<a>, value : a ) : ()
+  xchan-emit-prim(x.xc, value)
+
+// Receive on the OWNER loop (the loop that created the channel).
+pub fun xchannel/xreceive( x : xchannel<a> ) : <async,ndet> a
+  x.chan.receive
+
+// ----------------------------------------------------------------
+// spawn-thread: a PERSISTENT worker thread running its OWN async loop.
+
+extern spawn-thread-prim( body : () -> ioc () ) : ioc ()
+  c "kk_spawn_thread"
+
+// run a full async handler on THIS thread's own loop -- exactly what `async` does
+// (event-loop-init + async/exn handlers + event-loop-run / uv_run). The spawned
+// worker thread calls this so its body is a real async context.
+fun thread-main( body : () -> <async,ioc> () ) : ioc ()
+  async(body)
+
+// Spawn a persistent OS worker thread that runs `body` under its OWN async loop.
+// `body` is a real async context: it may `wait`, `spawn`, `xreceive`/`xemit`, etc.
+// The thread runs until `body`'s loop drains (no active handles), then exits.
+// Cross-thread communication is via `xchannel`/`xsender` (thread-safe channels).
+pub fun spawn-thread( body : () -> <async,ioc> () ) : ioc ()
+  spawn-thread-prim(fn() thread-main(body))

--- a/lib/std/async/bchannel.kk
+++ b/lib/std/async/bchannel.kk
@@ -1,0 +1,263 @@
+/*---------------------------------------------------------------------------
+  Copyright 2026, Tim Whiting, Microsoft Research, Daan Leijen.
+
+  This is free software; you can redistribute it and/or modify it under the
+  terms of the Apache License, Version 2.0. A copy of the License can be
+  found in the LICENSE file at the root of this distribution.
+---------------------------------------------------------------------------*/
+
+/* Bounded (windowed, batching) cross-thread channels with backpressure.
+
+A `bchannel` layers flow control over the unbounded thread-safe `xchannel`
+using a two-channel topology, entirely in portable Koka:
+
+- data flows receiver<-producer as *batches* through one `xchannel` (owned by
+  the receiver's loop),
+- grants flow producer<-receiver as *ints* through a second `xchannel` (owned
+  by the producer's loop) that acts as the producer's ack mailbox.
+
+Each batch carries the sender of its producer's ack mailbox, so the receiver
+can attribute consumption back to the right producer without any registry. A
+grant is "how many more items I am willing to accept": the receiver grants a
+batch's size back once that batch is fully *consumed* (not merely delivered),
+so at most `window` items per producer are unconsumed anywhere in the system
+-- the C queue, the receiver's Koka channel, and the current batch combined.
+Grants are POOLED per producer and cross only in half-window chunks (plus a
+final flush at `bchannel/close`): granting per batch would let an eager
+producer lock into size-1 batches with a reverse crossing per item (measured:
+~50x slower than the unbounded xchannel; with pooled grants a saturated
+stream runs half-window batches both ways and measures FASTER than xchannel).
+Pooling cannot stall a suspended producer: the receiver only ever waits when
+it has consumed everything delivered, and a suspended producer has a full
+window outstanding, so consuming it necessarily crosses the half-window
+threshold and fires a grant first.
+
+The producer ships eagerly while it has demand (low latency when the receiver
+keeps up) and buffers loop-locally while it does not; a granted producer ships
+its whole backlog as a single transfer (one `mark_shared` traversal, one mutex
+acquisition, one `uv_async_send` for the entire batch). Batches are capped at
+half the window so consumption pipelines with transfer (double buffering).
+`emit` suspends -- awaiting grants, never blocking the OS thread -- once the
+local backlog reaches `cap`: that is the backpressure point.
+
+Push vs demand is purely the receiver's grant policy: the ack is an int, so a
+receiver may grant less (shrink the window when it is backed up) or more
+(grow it) than it consumed. The default policy regrants exactly what it
+consumes, keeping the window constant.
+
+Typical use (the `bconnect` token is the only thing that crosses the spawn):
+
+    val b : bchannel<int> = bchannel(64)   // on the receiving loop
+    val c = b.connect
+    spawn-thread(fn()
+      val s = c.sender                     // on the producer's own loop
+      list(1,1000).foreach fn(i) s.emit(i)
+      s.close                              // flush + await full window
+    )
+    val xs = list(1,1000).map(fn(_) b.receive)
+    b.close
+*/
+module async/bchannel
+
+import async/async
+import async/channel
+import async/thread
+
+// A batch crossing the thread boundary: the items (oldest first), the sender of
+// the producer's ack mailbox, and the producer's id (so the receiver can pool
+// grants per producer -- `xsender`s themselves are not comparable).
+abstract value struct batch<a>( id : int, ack : xsender<int>, items : list<a> )
+
+// Receiver-side cursor into the batch currently being consumed.
+abstract struct bcursor<a>( id : int, ack : xsender<int>, remaining : list<a>, size : int )
+
+// A bounded channel (the RECEIVER half); lives on the loop that created it.
+// `grants` pools consumed-counts per producer: granting per BATCH would let an
+// eager producer degenerate into size-1 batches forever (each ack(1) refills
+// demand for exactly one item), so grants are held until they reach half a
+// window and cross as one int (`close` flushes any sub-threshold remainder).
+abstract struct bchannel<a>(
+  data   : xchannel<batch<a>>,
+  window : int,
+  cursor : ref<global, maybe<bcursor<a>>>,
+  grants : ref<global, list<(int, xsender<int>, int)>>   // (producer id, ack, pooled grant)
+)
+
+// Create a bounded channel on the current loop. `window` is the maximum number
+// of unconsumed items each producer may have in flight.
+pub fun bchannel( window : int = 64 ) : <async,ioc> bchannel<a>
+  Bchannel(xchannel(), max(window, 1), ref(Nothing), ref([]))
+
+// The portable connection token: hand THIS across a `spawn-thread` (never the
+// `bchannel`, which holds receiver-loop state). Carries only the cross-thread
+// data sender and the agreed window; abstract so the transport (currently an
+// `xchannel` of batches) stays an implementation detail.
+abstract value struct bconnect<a>( data : xsender<batch<a>>, window : int )
+
+pub fun bchannel/connect( b : bchannel<a> ) : bconnect<a>
+  Bconnect(b.data.sender, b.window)
+
+// The producer half; MUST be created (via `bconnect/sender`) on the producer's
+// own loop, since its ack mailbox is an `xchannel` owned by that loop. All of
+// its state is loop-local.
+abstract struct bsender<a>(
+  id        : int,                        // this producer's identity in receiver grant pooling
+  data      : xsender<batch<a>>,
+  window    : int,
+  cap       : int,                        // local backlog bound: emit suspends at/above this
+  acks      : xchannel<int>,              // grant mailbox, delivered on THIS loop
+  ack-send  : xsender<int>,               // crosses with every batch
+  demand    : ref<global, int>,           // items we may still ship
+  pending   : ref<global, list<a>>,       // local backlog, newest first
+  pending-n : ref<global, int>
+)
+
+// Open the producer half on the CURRENT (producer) loop. `cap` bounds the
+// local backlog (`emit` suspends once it is reached); it defaults to the
+// window, bounding this producer's total footprint to about two windows.
+pub fun bconnect/sender( c : bconnect<a>, cap : int = 0 ) : <async,ioc> bsender<a>
+  val acks : xchannel<int> = xchannel()
+  val capx = if cap <= 0 then c.window else cap
+  Bsender(unique(), c.data, c.window, capx, acks, acks.sender, ref(c.window), ref([]), ref(0))
+
+// Fold any grants that arrived while we were busy into `demand` (never waits).
+fun drain-acks( s : bsender<a> ) : <async,ioc> ()
+  match s.acks.try-xreceive
+    Just(n) ->
+      val d = s.demand
+      d := !d + n
+      drain-acks(s)
+    Nothing -> ()
+
+// Suspend this strand until the next grant arrives (the producer's loop keeps
+// running other strands; no OS thread blocks).
+fun await-ack( s : bsender<a> ) : <async,ioc> ()
+  val n = s.acks.xreceive
+  val d = s.demand
+  d := !d + n
+
+// Ship as much backlog as demand allows, oldest first, in batches of at most
+// half a window (so the receiver consumes one batch while the next crosses).
+fun ship( s : bsender<a> ) : <async,ioc> ()
+  val rd = s.demand
+  val rp = s.pending
+  val rn = s.pending-n
+  val d = !rd
+  val n = !rn
+  if d > 0 && n > 0 then
+    val k = min(d, min(n, max(1, s.window / 2)))
+    val items = (!rp).reverse
+    rp := items.drop(k).reverse
+    rn := n - k
+    rd := d - k
+    s.data.xemit(Batch(s.id, s.ack-send, items.take(k)))
+    ship(s)
+
+// Emit from the producer. Ships eagerly while the receiver has granted demand;
+// otherwise buffers loop-locally. Suspends (awaiting grants) once the local
+// backlog reaches `cap` -- this is where backpressure bites.
+pub fun bsender/emit( s : bsender<a>, v : a ) : <async,ioc> ()
+  val rp = s.pending
+  val rn = s.pending-n
+  rp := Cons(v, !rp)
+  rn := !rn + 1
+  drain-acks(s)
+  ship(s)
+  if !rn >= s.cap then emit-wait(s)
+
+fun emit-wait( s : bsender<a> ) : <async,ioc> ()
+  await-ack(s)
+  ship(s)
+  val rn = s.pending-n
+  if !rn >= s.cap then emit-wait(s)
+
+// Ship the entire backlog, awaiting grants as needed, until nothing is pending.
+pub fun bsender/flush( s : bsender<a> ) : <async,ioc> ()
+  drain-acks(s)
+  ship(s)
+  val rn = s.pending-n
+  if !rn > 0 then
+    await-ack(s)
+    flush(s)
+
+// Flush, await the full window back (every shipped item consumed and granted),
+// then close the ack mailbox. After this the receiver holds no live reference
+// into the producer's loop, so both loops can drain and exit.
+pub fun bsender/close( s : bsender<a> ) : <async,ioc> ()
+  s.flush
+  val rd = s.demand
+  fun settle()
+    if !rd < s.window then
+      await-ack(s)
+      settle()
+  settle()
+  s.acks.close
+
+// Pool `k` consumed items for producer `id`, granting (one int crossing) once
+// the pool reaches half a window. Held-back remainders are released by
+// `flush-grants` when the receiver idles or closes.
+fun add-grant( b : bchannel<a>, id : int, ack : xsender<int>, k : int ) : <async,ioc> ()
+  val rg = b.grants
+  val threshold = max(1, b.window / 2)
+  fun bump( gs : list<(int, xsender<int>, int)> ) : ioc list<(int, xsender<int>, int)>
+    match gs
+      Cons((gid, gack, p), rest) ->
+        if gid == id then
+          val p2 = p + k
+          if p2 >= threshold then
+            gack.xemit(p2)
+            Cons((gid, gack, 0), rest)
+          else
+            Cons((gid, gack, p2), rest)
+        else
+          Cons((gid, gack, p), bump(rest))
+      Nil ->
+        if k >= threshold then
+          ack.xemit(k)
+          [(id, ack, 0)]
+        else
+          [(id, ack, k)]
+  rg := bump(!rg)
+
+// Release every pooled grant. Called only at `bchannel/close`: it lets a
+// producer waiting in `bsender/close` settle its sub-threshold remainder. It
+// must NOT run on every receiver wait -- that reintroduces a reverse crossing
+// per item under light load (the measured 50x ping-pong pathology).
+fun flush-grants( b : bchannel<a> ) : <async,ioc> ()
+  val rg = b.grants
+  rg := (!rg).map fn((id, ack, p))
+    if p > 0 then ack.xemit(p)
+    (id, ack, 0)
+
+// Receive on the receiver's loop. Consumed counts are pooled per producer and
+// granted back in half-window chunks, waking suspended producers.
+pub fun bchannel/receive( b : bchannel<a> ) : <async,ioc> a
+  val cursor = b.cursor
+  match !cursor
+    Just(cur) -> match cur.remaining
+      Cons(v, rest) ->
+        match rest
+          Nil ->
+            cursor := Nothing
+            add-grant(b, cur.id, cur.ack, cur.size)
+          _   ->
+            cursor := Just(cur( remaining = rest ))
+        v
+      Nil ->
+        cursor := Nothing               // defensive: producers never ship empty
+        b.receive
+    Nothing ->
+      match b.data.try-xreceive
+        Just(bt) ->
+          cursor := Just(Bcursor(bt.id, bt.ack, bt.items, bt.items.length))
+        Nothing  ->
+          val bt = b.data.xreceive
+          cursor := Just(Bcursor(bt.id, bt.ack, bt.items, bt.items.length))
+      b.receive
+
+// Close the receiver half once every producer has `close`d (or will consume no
+// further grants). Pooled grants are flushed first so a producer suspended in
+// `close`/`flush` can settle; producer ack mailboxes close in `bsender/close`.
+pub fun bchannel/close( b : bchannel<a> ) : <async,ioc> ()
+  flush-grants(b)
+  b.data.close

--- a/lib/std/async/thread.kk
+++ b/lib/std/async/thread.kk
@@ -12,8 +12,9 @@ This module offloads heavy, self-contained computations onto worker threads so
 they do not block the async loop that requested them. On native (`libc`) hosts
 the work runs on a libuv threadpool thread with its own Koka heap; the result is
 marked _thread-shared_ (atomic refcounts) before it crosses back to the
-requesting loop. On hosts without OS threads (web/wasi) `compute` degrades to a
+requesting loop. On hosts without OS threads (web/wasm) `compute` degrades to a
 cooperative strand with the exact same API, so applications stay portable.
+Wasi should support threads, but we don't support wasi threads yet.
 
 # Data offload
 
@@ -36,25 +37,11 @@ import async/async
 // `xsender`, `spawn-thread`, `native-threads` -- through `std/async/thread`.
 pub import async/api/thread
   [host=libc]                          async/api/uv/thread
-  [host=jsnode|jsweb|wasmweb|wasi-web] async/api/coop/thread
+  [host=jsnode|jsweb|wasmweb] async/api/coop/thread
 
-// Offload the pure computation `work` onto a worker thread (native) or a
-// cooperative strand (web/wasi), and await its result on the current async loop
+// Offload the pure computation `work` onto a worker thread (native/wasi) or a
+// cooperative strand (web/wasm), and await its result on the current async loop
 // without blocking it. Other strands (timers, subscriptions, animations) keep
-// running while `work` executes.
-//
-// `work` must be _self-contained_: it may only read thread-shared/immutable
-// values captured in its closure and must not mutate shared state or perform
-// I/O — on native hosts it runs on a separate thread with NO effect handlers in
-// scope (a worker starts with an empty evidence vector). `work` is `pure`
-// (`<exn,div>`), and `exn` is handler-based, so we must INSTALL a fresh `exn`
-// handler on the worker itself: `error/try(work)` does that when the thunk runs
-// there, catching any exception into an `error<a>` that crosses back and is
-// rethrown here. (`unsafe-total(work)` would only cast the effect away and
-// segfault — its own docs warn of this; here `unsafe-total` dismisses just the
-// leftover `div`, which is handler-free and safe.) Its result is marked
-// thread-shared before it crosses back.
-pub fun compute( work : () -> pure a ) : async a
-  match await-compute( fn() unsafe-total{ error/try(work) } )
-    Ok(x)    -> x
-    Error(e) -> impossible("async/compute: `work` must not raise, but it did: " ++ e.show)
+// running while `work` executes.  Its result is marked thread-shared before it crosses back.
+pub fun compute( work : () -> ioc a ) : <async|ioc> a
+  await-compute(work)

--- a/lib/std/async/thread.kk
+++ b/lib/std/async/thread.kk
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------
+  Copyright 2026, Tim Whiting, Microsoft Research, Daan Leijen.
+
+  This is free software; you can redistribute it and/or modify it under the
+  terms of the Apache License, Version 2.0. A copy of the License can be
+  found in the LICENSE file at the root of this distribution.
+---------------------------------------------------------------------------*/
+
+/* Threading for asynchronous programs.
+
+This module offloads heavy, self-contained computations onto worker threads so
+they do not block the async loop that requested them. On native (`libc`) hosts
+the work runs on a libuv threadpool thread with its own Koka heap; the result is
+marked _thread-shared_ (atomic refcounts) before it crosses back to the
+requesting loop. On hosts without OS threads (web/wasi) `compute` degrades to a
+cooperative strand with the exact same API, so applications stay portable.
+
+# Data offload
+
+    fun main()
+      val n = compute fn() heavy-pure-work()   // runs off the async loop
+      println("result: " ++ n.show)
+
+While `compute` runs, the requesting loop keeps servicing other strands (timers,
+subscriptions, animation), so a UI thread stays responsive during heavy work.
+*/
+module async/thread
+
+import std/core/unsafe
+import std/core/exn
+import async/async
+
+// Select the host threading backend. Native uses real OS worker threads (libuv
+// threadpool + uv_thread); every JavaScript/Wasm host degrades to a cooperative
+// strand. `pub import` re-exports the backend's portable surface -- `xchannel`,
+// `xsender`, `spawn-thread`, `native-threads` -- through `std/async/thread`.
+pub import async/api/thread
+  [host=libc]                          async/api/uv/thread
+  [host=jsnode|jsweb|wasmweb|wasi-web] async/api/coop/thread
+
+// Offload the pure computation `work` onto a worker thread (native) or a
+// cooperative strand (web/wasi), and await its result on the current async loop
+// without blocking it. Other strands (timers, subscriptions, animations) keep
+// running while `work` executes.
+//
+// `work` must be _self-contained_: it may only read thread-shared/immutable
+// values captured in its closure and must not mutate shared state or perform
+// I/O — on native hosts it runs on a separate thread with NO effect handlers in
+// scope (a worker starts with an empty evidence vector). `work` is `pure`
+// (`<exn,div>`), and `exn` is handler-based, so we must INSTALL a fresh `exn`
+// handler on the worker itself: `error/try(work)` does that when the thunk runs
+// there, catching any exception into an `error<a>` that crosses back and is
+// rethrown here. (`unsafe-total(work)` would only cast the effect away and
+// segfault — its own docs warn of this; here `unsafe-total` dismisses just the
+// leftover `div`, which is handler-free and safe.) Its result is marked
+// thread-shared before it crosses back.
+pub fun compute( work : () -> pure a ) : async a
+  match await-compute( fn() unsafe-total{ error/try(work) } )
+    Ok(x)    -> x
+    Error(e) -> impossible("async/compute: `work` must not raise, but it did: " ++ e.show)

--- a/src/Backend/C/FromCore.hs
+++ b/src/Backend/C/FromCore.hs
@@ -402,6 +402,26 @@ genTopDefDecl genSig inlineC def@(Def name tp defBody vis sort inl rng comm)
                                 emitToH (text "#define" <+> ppName name <+> parens (text "(double)" <.> parens flt))
                         _ -> do doc <- genStat (ResultAssign (TName name tp) Nothing) (defBody)
                                 emitToInit (block doc)  -- must be scoped to avoid name clashes
+                                -- Mark the heap-allocated part of a toplevel constant as STATIC (stuck
+                                -- refcounts, like a compile-time static): these live in C statics and are
+                                -- dup/dropped by ANY thread that runs this module's code, so plain
+                                -- (non-atomic) refcounts race across threads (lost increment -> premature
+                                -- free -> heap corruption). String literals are made stuck at init already;
+                                -- computed constants are ordinary heap blocks and need this. (Same issue
+                                -- class as the shared kk_evv_empty_singleton.) `dup;box;mark;drop-box`
+                                -- covers both reference types (box is a reinterpret; the trailing drop is a
+                                -- no-op once stuck) and value structs (box allocates a wrapper owning the
+                                -- dup'd fields; the stuck wrapper is a small one-time leak at init).
+                                let needsMark = case cType tp of
+                                                  CFun _ _  -> True
+                                                  CBox      -> True
+                                                  CData _   -> True
+                                                  CPrim val -> val `elem` ["kk_integer_t","kk_bytes_t","kk_string_t","kk_vector_t","kk_evv_t","kk_ref_t","kk_box_t"]
+                                when needsMark $
+                                  emitToInit $ case cType tp of
+                                    CBox -> text "kk_box_mark_static" <.> arguments [ppName name] <.> semi
+                                    _    -> text "{ kk_box_t _kk_c = " <.> genBoxCall tp (genDupCall tp (ppName name))
+                                            <.> text "; kk_box_mark_static(_kk_c, kk_context()); kk_box_drop(_kk_c, kk_context()); }"
                                 case genDupDropCall False {-drop-} tp (ppName name) of
                                   []   -> return ()
                                   docs -> emitToDone (hcat docs <.> semi)

--- a/test/async/bchannel-multi.kk
+++ b/test/async/bchannel-multi.kk
@@ -1,0 +1,28 @@
+// Bounded channel with MULTIPLE producer threads.
+//
+// Each producer opens its own sender (own ack mailbox, own window/backlog) on
+// its own loop; batches carry their producer's ack sender, so grants minted by
+// `receive` wake the right producer. Interleaving across producers is
+// arbitrary, but each producer's items must arrive in FIFO order and nothing
+// may be lost or duplicated.
+import std/async
+import std/async/thread
+import std/async/bchannel
+
+fun producer( c : bconnect<(int,int)>, id : int, n : int ) : <async,ioc> ()
+  val s = c.sender
+  list(1, n).foreach fn(i)
+    s.emit((id, i))
+  s.close
+
+fun main()
+  val b : bchannel<(int,int)> = bchannel(16)
+  val c = b.connect
+  spawn-thread(fn() producer(c, 1, 1000))
+  spawn-thread(fn() producer(c, 2, 1000))
+  val got = list(1, 2000).map(fn(_) b.receive)
+  val one = got.filter(fn(x) x.fst == 1).map(fn(x) x.snd)
+  val two = got.filter(fn(x) x.fst == 2).map(fn(x) x.snd)
+  println("p1 in order: " ++ (one == list(1, 1000)).show ++
+          ", p2 in order: " ++ (two == list(1, 1000)).show)
+  b.close

--- a/test/async/bchannel-multi.kk.out
+++ b/test/async/bchannel-multi.kk.out
@@ -1,0 +1,1 @@
+p1 in order: True, p2 in order: True

--- a/test/async/bchannel.kk
+++ b/test/async/bchannel.kk
@@ -1,0 +1,25 @@
+// Bounded cross-thread channel (backpressure over xchannel).
+//
+// The main loop owns a `bchannel` with a small window; a `spawn-thread` worker
+// opens the producer half on its own loop and emits far more items than the
+// window, so it repeatedly fills its local backlog and suspends awaiting
+// grants. Grants are minted by `receive` on the main loop as batches are
+// consumed, so the window bounds unconsumed items end-to-end. Values arrive in
+// order; `close` on both halves lets each loop drain so the program exits.
+import std/async
+import std/async/thread     // portable: spawn-thread / xchannel underneath
+import std/async/bchannel
+
+fun main()
+  val b : bchannel<int> = bchannel(8)     // tiny window: forces backpressure
+  val c = b.connect                        // the only value that crosses the spawn
+  spawn-thread(fn()
+    val s = c.sender                       // producer half, on the worker's loop
+    list(1, 100).foreach fn(i)
+      s.emit(i)                            // suspends when the backlog fills
+    s.close                                // flush + await the full window back
+  )
+  val got = list(1, 100).map(fn(_) b.receive)
+  println("received: " ++ got.length.show ++ ", in order: " ++ (got == list(1, 100)).show)
+  println("sum: " ++ got.sum.show)
+  b.close

--- a/test/async/bchannel.kk.out
+++ b/test/async/bchannel.kk.out
@@ -1,0 +1,2 @@
+received: 100, in order: True
+sum: 5050

--- a/test/async/xthread-stress.kk
+++ b/test/async/xthread-stress.kk
@@ -1,0 +1,56 @@
+// Regression test for cross-thread heap corruption (thread-shared refcounts).
+//
+// Historically three distinct bugs corrupted the heap once a second OS thread ran
+// Koka code concurrently (spawn-thread / std/async/thread):
+//  1. the empty evidence-vector singleton was a plain-refcounted heap block shared
+//     by every thread (now the static KK_HEADER_STATIC block),
+//  2. `kk_block_make_shared` mapped rc `N` (= N+1 refs) to `-N` (= N refs), losing
+//     one reference for every marked block with rc >= 1 (now `~rc`),
+//  3. string literals and computed module toplevel constants live in C statics but
+//     had PLAIN refcounts, dup/dropped non-atomically from every thread (literals
+//     are now stuck via `kk_string_literal_init`; computed toplevels are marked
+//     thread-shared at module init).
+//
+// Part 1 hammers shared constants/literals from both threads concurrently
+// (`duration.show` churn -- the historical crasher at ~50% of runs); part 2 is the
+// original xchannel repro: a worker allocating concurrently (wait) while streaming
+// boxed structs to main.
+import std/async
+import std/time/duration
+import std/async/thread
+
+struct model( ticks : int, result : maybe<int> )
+
+fun churn( n : int, acc : int ) : ioc int
+  if n <= 0 then acc else
+    val s = (n.milli-seconds).show      // dup/drops shared decimal/duration constants + literals
+    churn(n - 1, acc + s.count)
+
+fun sender-loop( out : xsender<model>, n : int ) : <async,ioc,exn> ()
+  if n >= 200 then () else
+    wait(1.milli-seconds)               // concurrent allocation on the worker heap
+    out.xemit(Model(n, if n > 3 then Just(n) else Nothing))
+    sender-loop(out, n + 1)
+
+fun main()
+  // part 1: both threads churn the same shared constants/literals
+  val c : xchannel<int> = xchannel()
+  val csend = c.sender
+  spawn-thread(fn()
+    with handle/try fn(err) println("worker exn: " ++ err.show)
+    csend.xemit(churn(10000, 0))
+  )
+  val m = churn(10000, 0)
+  val w = c.xreceive
+  println("churn: main=" ++ m.show ++ " worker=" ++ w.show ++ (if m == w then " ok" else " MISMATCH"))
+  c.close
+  // part 2: boxed structs cross while the worker keeps allocating
+  val x : xchannel<model> = xchannel()
+  val out = x.sender
+  spawn-thread(fn()
+    with handle/try fn(err) println("worker exn: " ++ err.show)
+    sender-loop(out, 0)
+  )
+  val got = list(1, 200).map(fn(_) x.xreceive.ticks)
+  println("stream: received " ++ got.length.show ++ ", sum=" ++ got.sum.show)
+  x.close

--- a/test/async/xthread-stress.kk.out
+++ b/test/async/xthread-stress.kk.out
@@ -1,0 +1,6 @@
+async/xthread-stress/model/result: (model : model) -> maybe<int>
+async/xthread-stress/model/ticks: (model : model) -> int
+async/xthread-stress/Model: (ticks : int, result : maybe<int>) -> model
+async/xthread-stress/churn: (n : int, acc : int) -> ioc int
+async/xthread-stress/main: () -> <ioc,std/async/async/async> ()
+async/xthread-stress/sender-loop: (out : std/async/api/uv/thread/xsender<model>, n : int) -> <io,std/async/async/async> ()

--- a/test/async/xthread.kk
+++ b/test/async/xthread.kk
@@ -20,3 +20,4 @@ fun main()
   val got = list(1, 5).map(fn(_) x.xreceive)
   println("received: " ++ got.show)          // [10,20,30,40,50], in order
   println("sum: " ++ got.sum.show)           // 150
+  x.close                                     // close the uv_async handle so the loop drains + the program exits

--- a/test/async/xthread.kk
+++ b/test/async/xthread.kk
@@ -1,0 +1,22 @@
+// Thread-safe channel + persistent worker thread (native libuv).
+//
+// The main loop owns an `xchannel`; a `spawn-thread` worker runs its OWN async
+// loop (init loop + async/exn handlers + uv_run) and `xemit`s values across the
+// thread boundary through the channel's `sender`. Each cross-thread emit marks
+// the value thread-shared and wakes the owner loop via uv_async, which delivers
+// it to the waiting `xreceive`. Native only (real OS threads).
+import std/async
+import std/time/duration
+import std/async/api/uv/thread
+
+fun main()
+  val x : xchannel<int> = xchannel()      // owned by the MAIN loop
+  val s = x.sender                          // the cross-thread SENDER half (no Koka channel)
+  spawn-thread(fn()                         // a worker thread with its OWN async loop
+    list(1, 5).foreach fn(i)
+      s.xemit(i * 10)                        // wake the main loop from another thread
+      wait(10.milli-seconds)
+  )
+  val got = list(1, 5).map(fn(_) x.xreceive)
+  println("received: " ++ got.show)          // [10,20,30,40,50], in order
+  println("sum: " ++ got.sum.show)           // 150

--- a/test/async/xthread.kk
+++ b/test/async/xthread.kk
@@ -7,7 +7,7 @@
 // it to the waiting `xreceive`. Native only (real OS threads).
 import std/async
 import std/time/duration
-import std/async/api/uv/thread
+import std/async/thread     // portable: xchannel / xsender / spawn-thread / native-threads
 
 fun main()
   val x : xchannel<int> = xchannel()      // owned by the MAIN loop

--- a/test/async/xthread.kk.out
+++ b/test/async/xthread.kk.out
@@ -1,0 +1,1 @@
+async/xthread/main: () -> <ioc,std/async/async/async> ()


### PR DESCRIPTION
This adds OS-thread support to `std/async` and fixes the runtime thread-safety issues it uncovered.

## Thread support

- `spawn-thread( body : () -> <async,ioc> () )`: a persistent OS thread running `body` under its own async handler and libuv loop, so `wait`, `spawn`, and channels work on the worker exactly as on main.
- `xchannel<a>` / `xsender<a>`: a thread-safe channel. Any thread may `xemit` through the sender; values are marked thread-shared, enqueued under a mutex, and the owner loop is woken via `uv_async_send` (the only thread-safe libuv call), delivering on the owner's thread. The sender half carries no Koka state, so it is the only part that crosses threads. A regular `channel` cannot be shared across threads: its state transitions are not atomic, and emitting to a waiting receiver would run the receiver's continuation (and drive its uv loop) on the wrong thread.
- `compute( work : () -> pure a ) : async a`: offload pure work to the libuv threadpool.
- Exposed portably via `std/async/thread`; on hosts without OS threads (web/wasi) the same API degrades to cooperative strands and `native-threads()` reports `False`.

## Thread-safety fixes

Running Koka code on two threads concurrently corrupted the heap (~30-50% of runs) because several process-global heap blocks carry plain, non-atomic reference counts:

1. `kk_evv_empty_singleton` was a heap-allocated shared block; it now uses the existing static (stuck refcount).
2. `kk_block_make_shared` mapped rc `N` (= N+1 references) to `-N` (= N references), losing one reference for every marked block with rc >= 1; the correct map is `~rc`.
3. String literals are lazily allocated into C statics shared by all threads, with a first-use initialization that can race. `kk_string_literal_init` now publishes with a CAS and gives literals a stuck refcount (dup/drop become no-ops -- also cheaper than before).
4. Computed module toplevel constants also live in C statics; the C backend now marks their reachable graph static at module init (new `kk_box_mark_static`: every not-yet-shared block in the graph becomes stuck, matching how compile-time statics behave).

`test/async/xthread-stress.kk` reproduces the corruption (two threads churning `duration.show` concurrently, plus boxed values streaming over an `xchannel`); it crashed ~50% of runs before these fixes and is clean over repeated runs under mimalloc's debug checks and the system allocator.

Unrelated to threading: `kk_uint8_box/unbox` are added to kklib -- `lib/std/core/bytes.kk` uses the `uint8` value type so the generated code references them, and a clean stdlib rebuild fails without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)