### PR TITLE
implicits: dot-parameters unpack via the type annotation

### DIFF
--- a/src/Kind/Infer.hs
+++ b/src/Kind/Infer.hs
@@ -1087,9 +1087,12 @@ infLamValueBinder (ValueBinder name mbTp mbExpr nameRng rng)
        mbExpr' <- case mbExpr of
                   Nothing   -> return Nothing
                   Just (Parens (Var iname _ nrng) nm pre prng)  | isImplicitParamName name  -- ?? unpack
-                            -> do (qname,ikind,_) <- findInfKind iname rng
-                                  -- kind          <- resolveKind ikind
-                                  -- addRangeInfo r (Id qname (NITypeCon kind) [] False)
+                            -> do -- when the parameter name IS a type, qualify it (`.?order` unpacks
+                                  -- an `order`); otherwise pass the plain name through -- the type
+                                  -- checker unpacks via the parameter's type annotation instead
+                                  -- (`.?key : child` unpacks a `child`).
+                                  mbQname <- lookupInfKindName iname
+                                  let qname = case mbQname of { Just q -> q; Nothing -> iname }
                                   return (Just (Parens (Var qname False nrng) nm "implicit" prng))
                   Just expr -> do expr' <- infExpr expr
                                   return (Just expr')

--- a/src/Kind/InferMonad.hs
+++ b/src/Kind/InferMonad.hs
@@ -15,7 +15,7 @@ module Kind.InferMonad( KInfer
                       , addSynonym
                       , getSynonyms, getAllNewtypes, getPlatform
                       , extendInfGamma, extendKGamma, extendKSub
-                      , findInfKind
+                      , findInfKind, lookupInfKindName
                       , getColorScheme
                       , lookupSynInfo, lookupDataInfo
                       , qualifyDef
@@ -318,6 +318,26 @@ infQualifiedName name range
 
 ppModule cs name
   = color (colorModule cs) (text (nameModule name))
+
+-- Resolve a type name WITHOUT reporting errors: used by implicit-parameter
+-- unpacking (`.?name`), where the parameter name may not be a type at all
+-- (the unpack type then comes from the parameter's type annotation instead).
+lookupInfKindName :: Name -> KInfer (Maybe Name)
+lookupInfKindName name0
+  = do env <- getKindEnv
+       let name  = case importsExpand name0 (imports env) of
+                     Right (name',_) -> name'
+                     _               -> name0
+           qname = if isQualified name then name else qualify (currentModule env) name
+       case M.lookup name (infgamma env) of
+         Just _  -> return (Just name)
+         Nothing ->
+           case M.lookup qname (infgamma env) of
+             Just _  -> return (Just qname)
+             Nothing ->
+               case kgammaLookup (currentModule env) name (kgamma env) of
+                 Found qname' _ -> return (Just qname')
+                 _              -> return Nothing
 
 findInfKind :: Name -> Range -> KInfer (Name,InfKind,String)
 findInfKind name0 range

--- a/src/Type/Infer.hs
+++ b/src/Type/Infer.hs
@@ -1437,16 +1437,17 @@ inferLam topLevel propagated expect bindersL body0 rng
   where
     infBody isNamed =
      do -- traceDoc $ \env -> text "infer lam:" <+> pretty (map binderName bindersL) <+> pretty (show expect) <+> text ", propagated:" <+> ppProp env propagated <+> text (if isNamed then "(named)" else "")
-        (bindersX,unpackImplicitss) <- unzip <$> mapM inferImplicitParam bindersL
-        let body = foldr (\f x -> f x) body0 unpackImplicitss
-
-        (propArgs,propEff,propBody,skolems,expectBody) <- matchFun (length bindersX) propagated
+        (propArgs,propEff,propBody,skolems,expectBody) <- matchFun (length bindersL) propagated
         -- traceDoc $ \env -> text "  prop eff:" <+> ppProp env propEff
 
-        let binders0 = [case binderType binder of
+        -- fill in propagated parameter types FIRST so implicit-parameter unpacking
+        -- (`.?name : tp`) can find the struct via the parameter's type
+        let bindersP = [case binderType binder of
                           Nothing -> binder{ binderType = fmap snd mbProp }
                           Just _  -> binder
-                        | (binder,mbProp) <- zip bindersX propArgs]
+                        | (binder,mbProp) <- zip bindersL propArgs]
+        (binders0,unpackImplicitss) <- unzip <$> mapM inferImplicitParam bindersP
+        let body = foldr (\f x -> f x) body0 unpackImplicitss
         binders1 <- mapM instantiateBinder binders0
         -- traceDoc $ \env -> text "infexExpr.Lam: binder types: " <+> list [ppName env (binderName b) <+> text "=" <+> ppType env (binderType b) | b <- binders1] <+>
         --                    text ", propagated body: " <+> ppProp env propBody
@@ -2001,13 +2002,13 @@ inferBinders scopeDepth infgamma binders
 
 -- infer implicit parameter declaration:
 -- check if the expression is a single identifier and possibly generate unpacking of fields
-inferImplicitParam :: ValueBinder t1 (Maybe (Expr t2)) -> Inf (ValueBinder t1 (Maybe (Expr t2)), Expr Type -> Expr Type)
+inferImplicitParam :: ValueBinder (Maybe Type) (Maybe (Expr t2)) -> Inf (ValueBinder (Maybe Type) (Maybe (Expr t2)), Expr Type -> Expr Type)
 inferImplicitParam par
   = if isImplicitParamName (binderName par)
      then  do -- let pname = plainImplicitParamName (binderName par)
               unpack <- case binderExpr par of
                 Just (Parens (Var qname _ rng) _ _ _) -- encoded in the parser as a default expression
-                           -> inferImplicitUnpack (rangeHide (binderRange par)) (rangeHide rng) (binderName par) qname
+                           -> inferImplicitUnpack (rangeHide (binderRange par)) (rangeHide rng) (binderName par) qname (binderType par)
                 Nothing    -> return id
                 Just expr  -> do contextError (getRange par) (getRange expr) (text "the value of an implicit parameter must be a single identifier") []
                                  return id
@@ -2018,10 +2019,24 @@ inferImplicitParam par
 qualifyUnpacked :: Name -> Name -> Name
 qualifyUnpacked pname fname = (qualifyLocally (nameAsModuleName $ fromImplicitParamName pname) fname)
 
-inferImplicitUnpack :: Range -> Range -> Name -> Name -> Inf (Expr Type -> Expr Type)
-inferImplicitUnpack rng nrng pname qname
+inferImplicitUnpack :: Range -> Range -> Name -> Name -> Maybe Type -> Inf (Expr Type -> Expr Type)
+inferImplicitUnpack rng nrng pname qname mbParTp
   = do nt <- getNewtypes
-       case newtypesLookupAny qname nt of
+       let mbInfo = case newtypesLookupAny qname nt of
+                      Just di -> Just di
+                      Nothing -> -- the parameter name is not a type: unpack via the
+                                 -- parameter's type annotation (`.?key : child`)
+                                 case mbParTp of
+                                   Just tp -> case typeConNameOf tp of
+                                                Just tc -> newtypesLookupAny tc nt
+                                                Nothing -> Nothing
+                                   Nothing -> Nothing
+           typeConNameOf tp = case expandSyn tp of
+                                TCon tcon     -> Just (typeconName tcon)
+                                TApp t _      -> typeConNameOf t
+                                TForall _ t   -> typeConNameOf t
+                                _             -> Nothing
+       case mbInfo of
         Just (DataInfo{dataInfoSort=Inductive,
                         dataInfoConstrs=[conInfo],
                         dataInfoDef=ddef})  | not (dataDefIsOpen ddef)
@@ -2045,11 +2060,22 @@ inferImplicitUnpack rng nrng pname qname
                         TCon tcon              -> [typeConName tcon]
                         _                      -> []
 
-              in do unpackBases <- mapM (\(fname,fqname) -> inferImplicitUnpack rng nrng (qualifyUnpacked pname fname) fqname) bases  -- todo: stop recursion!
+              in do unpackBases <- mapM (\(fname,fqname) -> inferImplicitUnpack rng nrng (qualifyUnpacked pname fname) fqname Nothing) bases  -- todo: stop recursion!
                     return (compose (unpack:unpackBases))
 
-        _  -> do -- traceDefDoc $ \penv -> text "inferImplicitUnpack: cannot resolve" <+> text (show qname)
+        _  -> do penv <- getPrettyEnv
+                 contextError rng nrng
+                   (text "cannot unpack the implicit parameter" <+> ppParam penv (fromImplicitParamName pname))
+                   [(text "because", text "no struct type" <+> ppParam penv qname <+> text "is defined" <.>
+                                     (case mbParTp of
+                                        Just tp -> text ", and its type" <+> ppType penv tp <+> text "is not a (non-open) struct"
+                                        Nothing -> text ", and it has no type annotation")),
+                    (text "hint", text "annotate with a struct type to unpack, e.g." <+>
+                                  text "`.?" <.> ppParam penv (fromImplicitParamName pname) <.> text " : mystruct`" <.>
+                                  text ", or use a plain `?` parameter to pass it through unchanged")]
                  return id
+  where
+    ppParam penv nm = ppName penv nm
 
 
 -- | Infer automatic unwrapping for parameters with default values, and adjust their type from optional<a> to a

--- a/test/overload/implicit-unpack.kk
+++ b/test/overload/implicit-unpack.kk
@@ -1,0 +1,17 @@
+// Dot-implicits (`.?name : tp`) unpack a struct given by the TYPE ANNOTATION,
+// so the parameter name need not be the type name. The unpacked fields become
+// locally-qualified bindings (`name/field`) available for implicit resolution.
+value struct env( indent : int, pre : string )
+
+fun line( s : string, ?indent : int, ?pre : string ) : console ()
+  println(pre ++ "  ".repeat(indent) ++ s)
+
+// `.?fmt : env` unpacks env: fields resolve ?indent / ?pre inside the body
+fun section( title : string, .?fmt : env ) : console ()
+  line(title, ?indent = fmt/indent, ?pre = fmt/pre)
+  line(title ++ " (implicit fields)")   // ?indent/?pre resolve via the unpack
+
+fun main()
+  section("a", ?fmt = Env(1, ">"))
+  val fmt = Env(2, "#")
+  section("b")                          // resolves ?fmt by name

--- a/test/overload/implicit-unpack.kk.out
+++ b/test/overload/implicit-unpack.kk.out
@@ -1,0 +1,4 @@
+>  a
+>  a (implicit fields)
+#    b
+#    b (implicit fields)


### PR DESCRIPTION
A dot-implicit parameter (`.?name`) unpacks a struct so its fields become locally-qualified bindings (`name/field`) available for implicit resolution in the body. Previously the parameter *name* had to be the struct's type name (`.?order` unpacking an `order`); the kind checker errored otherwise.

- **Kind/Infer**: if the parameter name does not resolve as a type, pass the plain name through (new lenient `lookupInfKindName`) instead of erroring.
- **Type/Infer**: fill propagated parameter types before `inferImplicitParam`, and let `inferImplicitUnpack` fall back to the annotated type's constructor — so `.?key : child` unpacks a `child` while the parameter keeps its own name.
- **New error** when a dot-implicit has nothing to unpack (previously silently ignored, leading to confusing downstream resolution failures):

  ```
  cannot unpack the implicit parameter key
    because: no struct type key is defined, and its type int is not a (non-open) struct
    hint   : annotate with a struct type to unpack, e.g. `.?key : mystruct`,
             or use a plain `?` parameter to pass it through unchanged
  ```

Test: `test/overload/implicit-unpack.kk` exercises both an explicitly-passed and a name-resolved unpacked implicit, with the fields resolving further implicits in the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)