### PR TITLE
parse: fix internal error on `with` binding a pattern

### DIFF
--- a/src/Syntax/Parse.hs
+++ b/src/Syntax/Parse.hs
@@ -1641,7 +1641,9 @@ withstat
                                            (keyword "=" <|> keyword "<-")
                                            return x
            e <- basicexpr <|> handlerExprStat krng HandlerInstance
-           pure $ applyToContinuation krng [promoteValueBinder par] $ transform e
+           -- the transform from `parameter` wraps the continuation lambda's
+           -- body in a match, so it applies to that lambda and not to `e`
+           pure $ applyToContinuationWith krng [promoteValueBinder par] transform e
         <|>
         do e <- basicexpr <|> handlerExprStat krng HandlerNormal
            return (applyToContinuation krng [] e)
@@ -1653,7 +1655,12 @@ withstat
            _ -> binder
 
 applyToContinuation wrng params expr body
-  = let lam = Lam params body False (combineRanged wrng body)
+  = applyToContinuationWith wrng params id expr body
+
+-- as applyToContinuation but applies `xform` to the continuation lambda;
+-- this is how a pattern parameter, as in `with (a,b) <- e`, gets its match
+applyToContinuationWith wrng params xform expr body
+  = let lam = xform (Lam params body False (combineRanged wrng body))
         fun = Parens lam (newName "with") "expr" wrng -- Parens makes it last in type inference so types can better propagate (ambients/heap1) (todo: no longer the case right?)
         funarg = [(Nothing,fun)]
         fullrange = combineRanged wrng fun

--- a/test/parse/with-pattern.kk
+++ b/test/parse/with-pattern.kk
@@ -1,0 +1,33 @@
+// A `with` statement may bind a pattern instead of a plain name, so a chain of
+// fallible steps reads as a sequence rather than as nested matches. The pattern
+// is matched in the continuation lambda that `with` builds.
+//
+// No `.kk.out` is committed: record it with `--mode=new`.
+fun and-then( r : either<string,a>, next : (a) -> either<string,b> ) : either<string,b>
+  match r
+    Left(x)  -> Left(x)
+    Right(v) -> next(v)
+
+fun pair() : either<string,int>
+  with (a, b) <- Right((1,2)).and-then
+  Right(a + b)
+
+fun triple() : either<string,int>
+  with (a, b, c) <- Right((1,2,3)).and-then
+  Right(a + b + c)
+
+// nested patterns bind too
+fun nested() : either<string,int>
+  with (a, (b, c)) <- Right((1,(2,3))).and-then
+  Right(a + b + c)
+
+// and the short-circuiting path still skips the continuation
+fun short() : either<string,int>
+  with (a, b) <- Left("no").and-then
+  Right(a + b)
+
+fun main()
+  println(pair().show)
+  println(triple().show)
+  println(nested().show)
+  println(short().show)


### PR DESCRIPTION
A `with` statement that binds a pattern rather than a plain name aborts the compiler on every input, with no source position beyond `(1,1)`:

```
internal error: Syntax.Parse.parameter: unexpected function expression in parameter match transform
```

## Reproducing

```koka
fun and-then( r : either<string,a>, next : (a) -> either<string,b> ) : either<string,b>
  match r
    Left(x)  -> Left(x)
    Right(v) -> next(v)

fun pair() : either<string,int>
  with (a, b) <- Right((1,2)).and-then
  Right(a + b)

fun main()
  println(pair().show)
```

## Cause

`parameter` returns a transform that destructures a pattern parameter by wrapping the *continuation lambda's* body in a `match`. It matches `Lam`, `Ann` and `Parens`, with a catch-all `failure` for anything else. `withstat` applied it to `e`, the expression being called — an `App` — so it went straight to the catch-all. Plain binders were unaffected because they take the `PatVar` fast path and receive `id`.

`applyToContinuationWith` applies the transform to the `Lam` that `applyToContinuation` builds, which is the lambda whose parameter carries the pattern.

## Why the construct is worth having

With a bind on `either`, a chain of fallible steps reads as a sequence instead of a staircase of nested matches one level deeper per step:

```koka
with st1        <- st0.expect(0x22, "a string key").and-then
with (key, st2) <- parse-string-literal(st1).and-then
with st3        <- skip-ws(st2).expect(0x3A, "':'").and-then
```

## Testing

`test/parse/with-pattern.kk` covers two- and three-component tuples, a nested pattern, and the short-circuiting path. No `.kk.out` is committed — record it with `--mode=new`.

Suite: 445 examples, 1 failure — `lib/slice`, which needs `pcre2-8` and fails identically on an unmodified tree here.
