### PR TITLE
infer: stop dot-implicit unpack recursing on base fields

### DIFF
--- a/src/Type/Infer.hs
+++ b/src/Type/Infer.hs
@@ -2008,7 +2008,7 @@ inferImplicitParam par
      then  do -- let pname = plainImplicitParamName (binderName par)
               unpack <- case binderExpr par of
                 Just (Parens (Var qname _ rng) _ _ _) -- encoded in the parser as a default expression
-                           -> inferImplicitUnpack (rangeHide (binderRange par)) (rangeHide rng) (binderName par) qname (binderType par)
+                           -> inferImplicitUnpack [] (rangeHide (binderRange par)) (rangeHide rng) (binderName par) qname (binderType par)
                 Nothing    -> return id
                 Just expr  -> do contextError (getRange par) (getRange expr) (text "the value of an implicit parameter must be a single identifier") []
                                  return id
@@ -2019,8 +2019,11 @@ inferImplicitParam par
 qualifyUnpacked :: Name -> Name -> Name
 qualifyUnpacked pname fname = (qualifyLocally (nameAsModuleName $ fromImplicitParamName pname) fname)
 
-inferImplicitUnpack :: Range -> Range -> Name -> Name -> Maybe Type -> Inf (Expr Type -> Expr Type)
-inferImplicitUnpack rng nrng pname qname mbParTp
+-- | Unpack a dot-implicit parameter, as in @.?p : mystruct@, into its fields.
+-- `visited` holds the struct types already being unpacked along this path so
+-- that a `base` field referring back to one of them terminates.
+inferImplicitUnpack :: [Name] -> Range -> Range -> Name -> Name -> Maybe Type -> Inf (Expr Type -> Expr Type)
+inferImplicitUnpack visited rng nrng pname qname mbParTp
   = do nt <- getNewtypes
        let -- the type annotation (`.?key : child`) takes precedence over the
            -- parameter name: it is the declared type of the parameter
@@ -2037,9 +2040,7 @@ inferImplicitUnpack rng nrng pname qname mbParTp
                                 TForall _ t   -> typeConNameOf t
                                 _             -> Nothing
        case mbInfo of
-        Just (DataInfo{dataInfoSort=Inductive,
-                        dataInfoConstrs=[conInfo],
-                        dataInfoDef=ddef})  | not (dataDefIsOpen ddef)
+        Just info@DataInfo{dataInfoConstrs=[conInfo]} | dataInfoIsStruct info
         -- struct: unpack the fields
            -> let pats = [PatVar (ValueBinder (qualifyUnpacked pname fname) Nothing (PatWild nrng) nrng rng)
                             | (fname,ftp) <- conInfoParams conInfo, not (nameIsNil fname)]
@@ -2060,7 +2061,20 @@ inferImplicitUnpack rng nrng pname qname mbParTp
                         TCon tcon              -> [typeConName tcon]
                         _                      -> []
 
-              in do unpackBases <- mapM (\(fname,fqname) -> inferImplicitUnpack rng nrng (qualifyUnpacked pname fname) fqname Nothing) bases  -- todo: stop recursion!
+              in do -- unpacking a base field is implicit, so one that cannot be
+                    -- unpacked is skipped instead of reported (the error would
+                    -- name a parameter the user never wrote); a field whose type
+                    -- is already on this path is skipped to stop the recursion
+                    let unpackable fqname = case newtypesLookupAny fqname nt of
+                                              Just di -> dataInfoIsStruct di
+                                              Nothing -> False
+                        here     = maybe qname id (mbParTp >>= typeConNameOf)
+                        visited' = here : qname : visited
+                        bases'   = [b | b@(_,fqname) <- bases,
+                                        fqname `notElem` visited', unpackable fqname]
+                    unpackBases <- mapM (\(fname,fqname) ->
+                                     inferImplicitUnpack visited' rng nrng
+                                       (qualifyUnpacked pname fname) fqname Nothing) bases'
                     return (compose (unpack:unpackBases))
 
         _  -> do penv <- getPrettyEnv

--- a/src/Type/Type.hs
+++ b/src/Type/Type.hs
@@ -13,7 +13,7 @@ module Type.Type (-- * Types
                     Type(..), Scheme, Sigma, Rho, Tau, Effect, InferType
                   , Flavour(..)
                   , DataInfo(..), DataKind(..), ConInfo(..), SynInfo(..)
-                  , dataInfoIsOpen, dataInfoIsExtend, dataInfoIsLiteral
+                  , dataInfoIsOpen, dataInfoIsExtend, dataInfoIsStruct, dataInfoIsLiteral
                   , conInfoSize, conInfoScanCount
                   , conInfoIsLazy, dataInfoIsLazy, conInfoLazyFip, lazyName
                   , eqType, eqTypes, elemType
@@ -183,6 +183,16 @@ dataInfoIsExtend info
 
 dataInfoIsOpen info
   = dataDefIsOpen (dataInfoDef info)
+
+-- | A closed inductive type with exactly one constructor can be unpacked as a
+-- struct.
+dataInfoIsStruct :: DataInfo -> Bool
+dataInfoIsStruct info
+  = dataInfoSort info == Inductive &&
+    not (dataInfoIsOpen info) &&
+    case dataInfoConstrs info of
+      [_] -> True
+      _   -> False
 
 dataInfoIsLiteral info
   = let name = dataInfoName info


### PR DESCRIPTION
`inferImplicitUnpack` unpacks every field named `base*` recursively, with no visited set — the source says `-- todo: stop recursion!` — and no check that the field can be unpacked at all. Two user-visible failures follow, both reachable from the `.?` syntax added in 1a4f997f.

## 1. The compiler does not terminate

```koka
struct ctx( base : ctx )

fun f( .?c : ctx ) : int
  1

fun main()
  println("ok")
```

Memory grows without bound rather than the compiler reporting anything: 0.7 GB at 2 s, 2.5 GB at 4 s, 4.8 GB at 8 s, 5.3 GB at 12 s. Mutually recursive structs behave the same.

It takes the `base` prefix and `.?` together. The recursive struct alone compiles; `?c : ctx` without the dot compiles; the same struct with the field renamed `parent` compiles.

## 2. An ordinary field name is rejected

Any struct used as a dot-implicit that has a field whose name merely *starts with* `base`, and whose type is not a single-constructor inductive struct, is refused:

```koka
value struct fmt( basename : string, pre : string )

fun line( s : string, ?pre : string ) : console ()
  println(pre ++ s)

fun section( title : string, .?f : fmt ) : console ()
  line(title)

fun main()
  section("hi", ?f = Fmt("x", ">"))
```

```
type error: cannot unpack the implicit parameter f/basename
  because: the parameter has no type annotation, and the type string has more than one constructor
  hint   : annotate with a struct type to unpack, e.g. `.?f/basename : mystruct`, ...
```

`basename` is an ordinary field, `f/basename` is a parameter the user never wrote, and the hint cannot be acted on. `base : int` and `base : maybe<int>` fail the same way; renaming the field to anything not starting with `base` compiles and runs.

## The change

`inferImplicitUnpack` now carries the chain of struct types being unpacked along the current path and skips a `base` field whose type is already on it, which terminates both the self-referential and the mutually recursive case.

Unpacking a `base` field is implicit — the user did not ask for it — so one that cannot be unpacked is skipped rather than reported. An explicitly annotated `.?p : tp` that cannot be unpacked still reports, as before.

The shared shape check is exposed as `dataInfoIsStruct`: a data type is
unpackable when it is closed, inductive, and has exactly one constructor.
Both the top-level unpack and recursive `base*` filtering use that predicate,
so the two paths cannot drift.

## Testing

- `nix develop /home/siraben/koka-projects/koka --command cabal build exe:koka`
- `nix develop /home/siraben/koka-projects/koka --command cabal run koka-test -- --target-js --seq --match /overload/implicit-unpack`
  — 1 example, 0 failures
- Focused JS-target compile repros for a self-recursive struct, mutually
  recursive structs, and the ordinary `basename : string` field all succeed
  within a 15-second timeout.
- An explicitly annotated `.?value : maybe<int>` still fails with
  `cannot unpack the implicit parameter value`, preserving the explicit error.

The earlier full native suite run completed 445 examples with one unrelated
`lib/slice` failure due to the missing `pcre2-8` dependency; it failed
identically on an unmodified tree.
