### PR TITLE
infer: show implicit parameter names as written

### DIFF
--- a/src/Type/Infer.hs
+++ b/src/Type/Infer.hs
@@ -2508,7 +2508,8 @@ matchFunTypeArgs context fun tp fresolved fixed named
     matchNamed pars ((i,((name,rng),arg)):named)
       = case extract name [] pars of
           Nothing -> do -- trace ("matchNamed: no parameter with name " ++ show name ++ " in " ++ show pars) $ return ()
-                        typeError context (getRange fun) (text "there is no parameter with name" <+> pretty name) tp []
+                        penv <- getPrettyEnv
+                        typeError context (getRange fun) (text "there is no parameter with name" <+> ppName penv name) tp []
                         matchNamed pars named
           Just (j,tp,pars1)
               -> do newarg  <- if (isOptional tp)


### PR DESCRIPTION
A misspelled or misplaced implicit argument reports the internal encoding of the name rather than the name as written:

```koka
fun g( x : int ) : int
  x

fun main()
  println(g(1, ?cmp = 2))
```

```
type error: there is no parameter with name @implicit/cmp
```

`@implicit/cmp` is how the name is stored; `?cmp` is how it is written and read. `matchNamed` rendered it with the raw `Pretty Name` instance, which shows the stored form.

The diagnostic now goes through the established `Type.Pretty.ppName` path and
the current inference `PrettyEnv`. This is the same user-facing name renderer
used by surrounding inference diagnostics; it prints an implicit as `?name`
while preserving the active qualification, import, and color policy. The
message becomes:

```
type error: there is no parameter with name ?cmp
```

The same leak appears whenever an implicit is passed by name to a function that does not take it, which an ordinary typo reaches.

The adjacent raw `pretty name` in constructor-field matching is intentionally
unchanged: constructor field names do not use the implicit-parameter encoding.
Other active inference diagnostics already use `ppName`; remaining raw name
rendering in this module is confined to debug traces or non-implicit name
classes.

## Testing

- `nix develop /home/siraben/koka-projects/koka --command cabal build exe:koka-plain`
- Focused `--target=js` repro: the expected type error names `?cmp` and does
  not expose `@implicit/cmp`.

The broader example suite previously completed 445 examples with one
environmental `lib/slice` failure because `pcre2-8` was unavailable; the same
failure occurred on an unmodified tree.
