### PR TITLE
interpreter: handle ModeLanguageServer in `:set`

### DIFF
--- a/src/Interpreter/Interpret.hs
+++ b/src/Interpreter/Interpret.hs
@@ -227,6 +227,10 @@ command st buildc cmd
                                                      nextClear st buildc
                                   ModeCompiler files     -> setFlags files
                                   ModeInteractive files  -> setFlags files
+                                  -- `:set --language-server` can reach here; starting a
+                                  -- language server from the interpreter is not meaningful
+                                  ModeLanguageServer _   -> do messageError st "cannot switch to language server mode"
+                                                               next st buildc
                                   -- ModeDoc files          -> setFlags files
                               }
                     }


### PR DESCRIPTION
`:set --language-server` kills the interpreter:

```
$ koka
> :set --language-server
src/Interpreter/Interpret.hs:(221,33)-(229,74): Non-exhaustive patterns in case
```

`:set` runs `processExtraOptions`, which runs the full option parser and so can return any `Mode`. The case that follows covers `ModeHelp`, `ModeVersion`, `ModeCompiler` and `ModeInteractive` — four of the five constructors — and `ModeLanguageServer` falls through to nothing.

Starting a language server from inside the interpreter is not meaningful, so the new branch reports that and continues rather than ending the session on a Haskell pattern-match failure.

## Testing

`:set --language-server` now prints `cannot switch to language server mode` and the prompt returns. Suite: 445 examples, 1 failure — `lib/slice`, which needs `pcre2-8` and fails identically on an unmodified tree here.
