### PR TITLE
core: exit with a failure status on an uncaught exception

### DIFF
--- a/lib/std/core.kk
+++ b/lib/std/core.kk
@@ -231,12 +231,20 @@ pub extern host() : ndet string
   js inline "$std_core_console._host"
 
 
-// The default exception handler
+// Exit with a failure status
+extern @exit-failure() : ()
+  c  "kk_exit_failure"
+  cs inline "System.Environment.Exit(1)"
+  js inline "((typeof process !== 'undefined' && process.exit) ? process.exit(1) : undefined)"
+
+// The default exception handler; exits with a failure status so an uncaught
+// exception is not reported as success
 pub fun @default-exn(action : () -> <exn,console|e> () ) : <console|e> ()
   handle( action )
     final ctl throw-exn( exn : exception )
       "uncaught exception: ".print
       exn.println
+      @exit-failure()
 
 
 // ----------------------------------------------------------------------------

--- a/lib/std/core/inline/core.c
+++ b/lib/std/core/inline/core.c
@@ -11,3 +11,11 @@ kk_box_t kk_main_console( kk_function_t action, kk_context_t* ctx ) {
   return kk_function_call(kk_box_t,(kk_function_t,kk_unit_t,kk_context_t*),action,(action,kk_Unit,ctx),ctx);
 }
 
+// exit flushes the standard streams and runs kklib's atexit handler,
+// so the message printed just before this is not lost
+kk_unit_t kk_exit_failure( kk_context_t* ctx ) {
+  kk_unused(ctx);
+  exit(1);
+  return kk_Unit;
+}
+

--- a/lib/std/core/inline/core.h
+++ b/lib/std/core/inline/core.h
@@ -14,4 +14,5 @@
 ---------------------------------------------------------------------------*/
 
 kk_box_t kk_main_console( kk_function_t action, kk_context_t* ctx );
+kk_unit_t kk_exit_failure( kk_context_t* ctx );
 


### PR DESCRIPTION
A program that dies on an uncaught exception exits 0.

```
$ cat throws.kk
fun main()
  throw("boom")

$ koka -e throws.kk; echo $?
uncaught exception: boom
0
```

The compiled executable does the same, so this is the program's own status and not an artefact of `-e`. `@default-exn` prints the message and returns, so `main` completes normally and the process reports success.

Every consumer of the exit status is therefore wrong: `koka prog.kk && deploy` deploys, a CI step passes, and a test runner cannot tell a crashed program from a passing one without grepping stdout for the message — which then cannot distinguish a crash from a program that legitimately prints those words.

## The change

`@exit-failure` is added next to `main-console` in `std/core`, with an implementation per backend: `exit(1)` on C, `System.Environment.Exit(1)` on C#, and `process.exit(1)` on JS where `process` exists. On C, `exit` flushes the standard streams and runs the `atexit` handler kklib installs, so the message printed immediately before is not lost.

Only genuinely uncaught exceptions are affected:

| program | before | after |
| --- | --- | --- |
| normal return | 0 | 0 |
| exception caught with `try` | 0 | 0 |
| uncaught exception | 0 | 1 |

## Testing

Eight tests end in an uncaught exception — `algeff/nim`, `algeff/match-error`, `jsgen/exn`, `jsgen/err`, `cgen/vector1`, `finally/finally1a`, `finally/initially2a`, `lib/range1` — and all eight still pass: the harness compares stdout and ignores the exit status, and stdout is unchanged.

Suite: 445 examples, 1 failure — `lib/slice`, which needs `pcre2-8` and fails identically on an unmodified tree here. CI installs it through vcpkg.

What I could not verify: this ran on Linux x86-64 only, so the Windows, macOS and arm64 legs are untested by me, and with no .NET toolchain the `cs` clause is written from the surrounding conventions rather than compiled. The `js` clause is exercised — the JS-backend tests and the `--target=js` link test are among those passing.

## Note

This changes observable behaviour, so it may want discussion rather than review — in particular whether 1 is the status you want.
