### PR TITLE
interpreter: make semiRandom inclusive of max

### DIFF
--- a/src/Interpreter/Interpret.hs
+++ b/src/Interpreter/Interpret.hs
@@ -646,7 +646,7 @@ messageHeader st
 semiRandom min max
   = do t <- getCurrentTime
        let i = fileTimeToPicoseconds t `div` 100000000000
-       return (fromInteger (min + (i `mod` (max - min))))
+       return (fromInteger (min + (i `mod` (max - min + 1))))
 
 putQuote ::  State -> IO ()
 putQuote st


### PR DESCRIPTION
To select a quote to print when the interpreter exits, the `putQuote` function passes `length quotes - 1` as the upper bound to `semiRandom`. For the last quote to be printed, `semiRandom` needs to be inclusive of the upper bound `max`, following typical convention in Haskell.