### PR TITLE
fix: multi-letter type variables binding in some contexts

### DIFF
--- a/src/Kind/Infer.hs
+++ b/src/Kind/Infer.hs
@@ -1729,6 +1729,10 @@ resolveApp idmap partialSyn (TpCon name r,[fixed,ext]) rng  | name == nameEffect
        return (shallowEffectExtend fixed' ext')
 
 resolveApp idmap partialSyn (TpCon name r,args) rng
+  | M.member name idmap
+  = resolveApp idmap partialSyn (TpVar name r,args) rng
+
+resolveApp idmap partialSyn (TpCon name r,args) rng
   =  do (qname,ikind,doc) <- findInfKind name rng
         kind  <- resolveKind ikind
         addRangeInfo r (Id qname (NITypeCon kind doc) [] False)

--- a/test/kind/type11.kk
+++ b/test/kind/type11.kk
@@ -1,0 +1,10 @@
+struct multi-box<element>(value : element)
+struct multi-pair<left,right>(fst : left, snd : right)
+
+alias multi-id<element> = element
+alias multi-apply<constructor :: V -> V, element> = constructor<element>
+alias multi-rank2 = forall<element> element -> element
+alias int-shadow<int> = int
+
+effect multi-cell<element>
+  fun multi-get() : element

--- a/test/kind/type11.kk.out
+++ b/test/kind/type11.kk.out
@@ -1,0 +1,12 @@
+int-shadow : V -> V
+multi-apply : (V -> V, V) -> V
+multi-box : V -> V
+multi-cell : (V, E, V) -> V
+multi-id : V -> V
+multi-pair : (V, V) -> V
+multi-rank2 : V
+ 
+pub alias int-shadow<a> :: V -> V = a = 1
+pub alias multi-apply<a,b> :: (V -> V, V) -> V = a<b> = 1
+pub alias multi-id<a> :: V -> V = a = 1
+pub alias multi-rank2 = forall<a> (a) -> a = 1


### PR DESCRIPTION
## Problem

Type binders accept `varid`, so names such as `element` and `constructor` are valid:

```koka
struct box<element>(value : element)
```

However, occurrences of multi-letter names in type expressions are initially represented as `TpCon`, since `isTypeVar` only recognizes the narrower `letter { digit }` form. Kind inference then tries to resolve a locally bound name as a global type constructor, resulting in errors such as:

```
internal compiler error: Kind.Infer.resolve data def: unknown type: element
```

Related issues #158 and #211

## Fix

Before resolving a `TpCon` as a global constructor, check whether its name is present in the local type-binder environment. If it is locally bound, delegate to the existing `TpVar` resolution path.

This keeps the current classification of unbound type names intact while allowing every name accepted as a type binder to be used consistently. It also covers applied higher-kinded variables and binders that shadow existing type constructor names. The hover tool in the language server is now working correctly as well.

## Tests

I also added kind-inference regression coverage for multi-letter variables in different contexts. 