### PR TITLE
Core: fix type synonyms used only in inline-exposed nested binders

### DIFF
--- a/src/Core/Pretty.hs
+++ b/src/Core/Pretty.hs
@@ -105,7 +105,9 @@ prettyCore env0 eguard inlineDefs core@(Core modName imports fixDefs typeDefGrou
     env  = env1{ expandSynonyms = False }
     envX = env1{ showKinds = True, expandSynonyms = True }
 
-    signatures   = extractSignatures core
+    -- also scan bodies written to .inline-section: a synonym used only on a nested
+    -- binder there (never in the def's own signature) needs mirroring too
+    signatures   = extractSignatures core ++ concatMap (fts . inlineExpr) inlineDefs
     importedSyns = extractImportedSynonyms (coreProgName core) signatures
     extraImports1 = map extractImportsFromSynInfo importedSyns
     extraImports2 = extractImportFromSignatures signatures
@@ -638,6 +640,11 @@ instance HasTypeVar DefGroup where
         DefRec defs   -> ftc defs
         DefNonRec def -> ftc def
 
+  fts defGroup
+    = case defGroup of
+        DefRec defs   -> fts defs
+        DefNonRec def -> fts def
+
 
 instance HasTypeVar Def where
   sub `substitute` (Def name scheme expr vis isVal inl nameRng doc)
@@ -651,6 +658,9 @@ instance HasTypeVar Def where
 
   ftc (Def name scheme expr vis isVal inl nameRng doc)
     = tcsUnion (ftc scheme) (ftc expr)
+
+  fts (Def name scheme expr vis isVal inl nameRng doc)
+    = fts scheme ++ fts expr
 
 instance HasTypeVar Expr where
   sub `substitute` expr
@@ -705,6 +715,18 @@ instance HasTypeVar Expr where
                   Case exprs branches -> ftc exprs `tcsUnion` ftc branches
       in tcs
 
+  fts expr
+    = case expr of
+        Lam tname eff expr -> fts tname ++ fts eff ++ fts expr
+        Var tname info     -> fts tname
+        App a b            -> fts a ++ fts b
+        TypeLam tvs expr   -> fts expr
+        TypeApp expr tp    -> fts expr ++ fts tp
+        Con tname repr     -> fts tname
+        Lit lit            -> []
+        Let defGroups expr -> fts defGroups ++ fts expr
+        Case exprs branches -> fts exprs ++ fts branches
+
 instance HasTypeVar Branch where
   sub `substitute` (Branch patterns guards)
     = let sub' = subRemove (tvsList (btv patterns)) sub
@@ -719,6 +741,9 @@ instance HasTypeVar Branch where
   ftc (Branch patterns guards)
     = tcsUnion (ftc patterns) (ftc guards)
 
+  fts (Branch patterns guards)
+    = fts patterns ++ fts guards
+
 instance HasTypeVar Guard where
   sub `substitute` (Guard test expr)
     = Guard (sub `substitute` test) (sub `substitute` expr)
@@ -731,6 +756,9 @@ instance HasTypeVar Guard where
 
   ftc (Guard test expr)
     = ftc test `tcsUnion` ftc expr
+
+  fts (Guard test expr)
+    = fts test ++ fts expr
 
 instance HasTypeVar Pattern where
   sub `substitute` pat
@@ -768,6 +796,13 @@ instance HasTypeVar Pattern where
       in -- trace ("ftc :" ++ show (tvsList (tvs)) ++ ", in pattern: " ++ show pat) $
          tcs
 
+  fts pat
+    = case pat of
+        PatVar tname pat    -> fts tname ++ fts pat
+        PatCon tname args _ targs exists tres _ _ -> fts tname ++ fts args ++ fts targs ++ fts tres
+        PatWild             -> []
+        PatLit lit          -> []
+
 instance HasTypeVar TName where
   sub `substitute` (TName name tp)
     = TName name (sub `substitute` tp)
@@ -775,5 +810,7 @@ instance HasTypeVar TName where
     = ftv tp
   btv (TName name tp)
     = btv tp
+  fts (TName name tp)
+    = fts tp
   ftc (TName name tp)
     = ftc tp

--- a/src/Type/TypeVar.hs
+++ b/src/Type/TypeVar.hs
@@ -11,7 +11,7 @@
 
 module Type.TypeVar
   ( -- * Type substitutable entities
-    HasTypeVar (substitute, ftv, btv, ftc),
+    HasTypeVar (substitute, ftv, btv, ftc, fts),
     (|->),
     alltv,
     fuv,
@@ -455,6 +455,12 @@ class HasTypeVar a where
   -- | Return used type constructors
   ftc :: a -> TypeCons
 
+  -- | Return every type synonym reference found (unlike 'ftc', which only records the
+  -- synonym's name via its underlying TypeCon, this keeps the full 'Type' -- e.g. so
+  -- callers can inspect its 'SynInfo'). Default: none.
+  fts :: a -> [Type]
+  fts _ = []
+
 -- | Entities that contain type variables that can be put in a particular order
 class HasOrderedTypeVar a where
   -- | Return free type variables in a particular order, may contain duplicates
@@ -494,6 +500,8 @@ instance (HasTypeVar a) => HasTypeVar [a] where
     tvsUnions (map btv xs)
   ftc xs =
     S.unions (map ftc xs)
+  fts xs =
+    concatMap fts xs
 
 instance HasTypeVar Range where
   sub `substitute` r = r
@@ -560,7 +568,17 @@ instance HasTypeVar Type where
       TCon tcon -> S.singleton tcon
       TVar tvar -> S.empty
       TApp tp arg -> S.union (ftc tp) (ftc arg)
-      TSyn syn xs tp -> S.union (ftc xs) (ftc tp)
+      -- also include the synonym's own name, not just its expansion's constructors
+      TSyn syn xs tp -> S.insert (TypeCon (typesynName syn) (typesynKind syn)) (S.union (ftc xs) (ftc tp))
+
+  fts tp0 =
+    case tp0 of
+      TForall vars tp -> fts tp
+      TFun args effect result -> concat (fts effect : fts result : map (fts . snd) args)
+      TCon tcon -> []
+      TVar tvar -> []
+      TApp tp arg -> fts tp ++ fts arg
+      TSyn syn xs tp -> tp0 : (fts xs ++ fts tp)
 
 instance HasTypeVar Name where
   sub `substitute` name = name

--- a/test/parc/syn-nested1.kk
+++ b/test/parc/syn-nested1.kk
@@ -1,0 +1,24 @@
+// Regression test for a type-synonym round-trip bug in module interfaces.
+//
+// `syn-nested1c` uses the `my-alias` synonym (defined in `syn-nested1a`) only on
+// an inferred, nested lambda parameter deep inside `use-cb`'s body -- never in
+// any of its own declared signatures. Core.Core.extractSignatures used to only
+// look at each def's own top-level signature type when deciding which type
+// synonyms to mirror into a module's compiled interface, so this nested use was
+// never mirrored into `syn-nested1c`'s own interface. Reloading that interface
+// (e.g. compiling this file against an unchanged, previously-compiled
+// `syn-nested1c`) then resolved `my-alias` to a bare, unexpandable type
+// constructor instead of the synonym, and the C backend failed with
+// "unknown type name ..._my_alias" (or, before that, Core.Parc crashed outright
+// with "cannot find type: ...").
+//
+// This file relies on `syn-nested1a`/`syn-nested1b`/`syn-nested1c` having
+// already been compiled (and their interfaces cached) as their own tests
+// earlier in this directory, so importing them here exercises the interface
+// *reload* path rather than a fresh from-source check.
+
+module syn-nested1
+import syn-nested1c
+
+pub fun run() : int
+  use-cb()

--- a/test/parc/syn-nested1.kk.out
+++ b/test/parc/syn-nested1.kk.out
@@ -1,0 +1,39 @@
+module parc/syn-nested1
+import std/core/types = std/core/types pub = "";
+import std/core/hnd = std/core/hnd pub = "";
+import std/core/exn = std/core/exn pub = "";
+import std/core/bool = std/core/bool pub = "";
+import std/core/order = std/core/order pub = "";
+import std/core/char = std/core/char pub = "";
+import std/core/int = std/core/int pub = "";
+import std/core/vector = std/core/vector pub = "";
+import std/core/bytes = std/core/bytes pub = "";
+import std/core/bslice = std/core/bslice pub = "";
+import std/core/string = std/core/string pub = "";
+import std/core/sslice = std/core/sslice pub = "";
+import std/core/list = std/core/list pub = "";
+import std/core/maybe = std/core/maybe pub = "";
+import std/core/maybe2 = std/core/maybe2 pub = "";
+import std/core/either = std/core/either pub = "";
+import std/core/result = std/core/result pub = "";
+import std/core/tuple = std/core/tuple pub = "";
+import std/core/lazy = std/core/lazy pub = "";
+import std/core/show = std/core/show pub = "";
+import std/core/debug = std/core/debug pub = "";
+import std/core/delayed = std/core/delayed pub = "";
+import std/core/console = std/core/console pub = "";
+import std/core = std/core = "";
+import parc/syn-nested1c = parc/syn-nested1c = "";
+import parc/syn-nested1a = parc/syn-nested1a inline = "";
+import parc/syn-nested1b = parc/syn-nested1b inline = "";
+pub fun run : () -> int
+  = fn(){
+    parc/syn-nested1b/apply-cb((fn(xs: parc/syn-nested1a/my-alias){
+      (match (xs) {
+        (std/core/types/Nil() : (list<int>) )
+           -> 0;
+        _
+           -> std/core/list/@unroll-lift-length@6470@10000(xs, 0);
+      });
+    }));
+  };

--- a/test/parc/syn-nested1a.kk
+++ b/test/parc/syn-nested1a.kk
@@ -1,0 +1,3 @@
+module syn-nested1a
+
+pub alias my-alias = list<int>

--- a/test/parc/syn-nested1a.kk.out
+++ b/test/parc/syn-nested1a.kk.out
@@ -1,0 +1,26 @@
+module parc/syn-nested1a
+import std/core/types = std/core/types pub = "";
+import std/core/hnd = std/core/hnd pub = "";
+import std/core/exn = std/core/exn pub = "";
+import std/core/bool = std/core/bool pub = "";
+import std/core/order = std/core/order pub = "";
+import std/core/char = std/core/char pub = "";
+import std/core/int = std/core/int pub = "";
+import std/core/vector = std/core/vector pub = "";
+import std/core/bytes = std/core/bytes pub = "";
+import std/core/bslice = std/core/bslice pub = "";
+import std/core/string = std/core/string pub = "";
+import std/core/sslice = std/core/sslice pub = "";
+import std/core/list = std/core/list pub = "";
+import std/core/maybe = std/core/maybe pub = "";
+import std/core/maybe2 = std/core/maybe2 pub = "";
+import std/core/either = std/core/either pub = "";
+import std/core/result = std/core/result pub = "";
+import std/core/tuple = std/core/tuple pub = "";
+import std/core/lazy = std/core/lazy pub = "";
+import std/core/show = std/core/show pub = "";
+import std/core/debug = std/core/debug pub = "";
+import std/core/delayed = std/core/delayed pub = "";
+import std/core/console = std/core/console pub = "";
+import std/core = std/core = "";
+pub alias parc/syn-nested1a/my-alias = (list :: V -> V)<int> = 1;

--- a/test/parc/syn-nested1b.kk
+++ b/test/parc/syn-nested1b.kk
@@ -1,0 +1,5 @@
+module syn-nested1b
+import syn-nested1a
+
+pub noinline fun apply-cb( f : (x : my-alias) -> int ) : int
+  f(Cons(1,Cons(2,Nil)))

--- a/test/parc/syn-nested1b.kk.out
+++ b/test/parc/syn-nested1b.kk.out
@@ -1,0 +1,31 @@
+module parc/syn-nested1b
+import std/core/types = std/core/types pub = "";
+import std/core/hnd = std/core/hnd pub = "";
+import std/core/exn = std/core/exn pub = "";
+import std/core/bool = std/core/bool pub = "";
+import std/core/order = std/core/order pub = "";
+import std/core/char = std/core/char pub = "";
+import std/core/int = std/core/int pub = "";
+import std/core/vector = std/core/vector pub = "";
+import std/core/bytes = std/core/bytes pub = "";
+import std/core/bslice = std/core/bslice pub = "";
+import std/core/string = std/core/string pub = "";
+import std/core/sslice = std/core/sslice pub = "";
+import std/core/list = std/core/list pub = "";
+import std/core/maybe = std/core/maybe pub = "";
+import std/core/maybe2 = std/core/maybe2 pub = "";
+import std/core/either = std/core/either pub = "";
+import std/core/result = std/core/result pub = "";
+import std/core/tuple = std/core/tuple pub = "";
+import std/core/lazy = std/core/lazy pub = "";
+import std/core/show = std/core/show pub = "";
+import std/core/debug = std/core/debug pub = "";
+import std/core/delayed = std/core/delayed pub = "";
+import std/core/console = std/core/console pub = "";
+import std/core = std/core = "";
+import parc/syn-nested1a = parc/syn-nested1a = "";
+local alias parc/syn-nested1a/my-alias = (list :: V -> V)<int> = 1;
+pub fun apply-cb : (f : (x : parc/syn-nested1a/my-alias) -> int) -> int
+  = fn(f: (x : parc/syn-nested1a/my-alias) -> int){
+    f((std/core/types/Cons((std/core/types/@box(1)), (std/core/types/Cons((std/core/types/@box(2)), std/core/types/Nil)))));
+  };

--- a/test/parc/syn-nested1c.kk
+++ b/test/parc/syn-nested1c.kk
@@ -1,0 +1,10 @@
+module syn-nested1c
+import syn-nested1b
+
+// note: `my-alias` never appears in this signature -- the callback lambda's
+// parameter type below is only ever *inferred* (via unification with
+// `apply-cb`'s parameter type), not declared here. A type synonym used only
+// in such a nested position used to fail to round-trip through this module's
+// own compiled interface (see syn-nested1.kk).
+pub fun use-cb() : int
+  apply-cb( fn(xs) xs.length )

--- a/test/parc/syn-nested1c.kk.out
+++ b/test/parc/syn-nested1c.kk.out
@@ -1,0 +1,43 @@
+module parc/syn-nested1c
+import std/core/types = std/core/types pub = "";
+import std/core/hnd = std/core/hnd pub = "";
+import std/core/exn = std/core/exn pub = "";
+import std/core/bool = std/core/bool pub = "";
+import std/core/order = std/core/order pub = "";
+import std/core/char = std/core/char pub = "";
+import std/core/int = std/core/int pub = "";
+import std/core/vector = std/core/vector pub = "";
+import std/core/bytes = std/core/bytes pub = "";
+import std/core/bslice = std/core/bslice pub = "";
+import std/core/string = std/core/string pub = "";
+import std/core/sslice = std/core/sslice pub = "";
+import std/core/list = std/core/list pub = "";
+import std/core/maybe = std/core/maybe pub = "";
+import std/core/maybe2 = std/core/maybe2 pub = "";
+import std/core/either = std/core/either pub = "";
+import std/core/result = std/core/result pub = "";
+import std/core/tuple = std/core/tuple pub = "";
+import std/core/lazy = std/core/lazy pub = "";
+import std/core/show = std/core/show pub = "";
+import std/core/debug = std/core/debug pub = "";
+import std/core/delayed = std/core/delayed pub = "";
+import std/core/console = std/core/console pub = "";
+import std/core = std/core = "";
+import parc/syn-nested1b = parc/syn-nested1b = "";
+import parc/syn-nested1a = parc/syn-nested1a inline = "";
+// note: `my-alias` never appears in this signature -- the callback lambda's
+// parameter type below is only ever *inferred* (via unification with
+// `apply-cb`'s parameter type), not declared here. A type synonym used only
+// in such a nested position used to fail to round-trip through this module's
+// own compiled interface (see syn-nested1.kk).
+pub fun use-cb : () -> int
+  = fn(){
+    parc/syn-nested1b/apply-cb((fn(xs: parc/syn-nested1a/my-alias){
+      (match (xs) {
+        (std/core/types/Nil() : (list<int>) )
+           -> 0;
+        _
+           -> std/core/list/@unroll-lift-length@6470@10000(xs, 0);
+      });
+    }));
+  };


### PR DESCRIPTION
Fixes another missing import due to inline bug.